### PR TITLE
moved `wallet_file_path` from `Wallet` to `WalletStore` and import BDK store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ libtor = {version = "47.13.0", optional = true}
 mitosis = {version = "0.1.1", optional = true}
 log4rs = "1.3.0"
 reqwest = { version = "0.11", features = ["socks"] }
-bdk_wallet= { git = "https://github.com/bitcoindevkit/bdk", subdir="crates/wallet", rev = "3b040a7ee69c7fefac6c3ab57c17b220e0beb9fb" }
-bdk_persist= { git = "https://github.com/bitcoindevkit/bdk", subdir="crates/bdk_persist", rev = "3b040a7ee69c7fefac6c3ab57c17b220e0beb9fb" }
-bdk_chain= { git = "https://github.com/bitcoindevkit/bdk", subdir="crates/bdk_chain", rev = "3b040a7ee69c7fefac6c3ab57c17b220e0beb9fb" }
+bdk_wallet = { git = "https://github.com/bitcoindevkit/bdk", subdir = "crates/wallet", rev = "05438017876c3338d091ca85e52242b455e2193a" }
+bdk_chain = { git = "https://github.com/bitcoindevkit/bdk", subdir = "crates/bdk_chain", rev = "05438017876c3338d091ca85e52242b455e2193a" }
+bdk_file_store = { git = "https://github.com/bitcoindevkit/bdk", subdir = "crates/file_store", rev = "05438017876c3338d091ca85e52242b455e2193a" }
 
 
 #Empty default feature set, (helpful to generalise in github actions)


### PR DESCRIPTION
Aims to fix #154 
- [x] Move `wallet_file_path` field to `WalletStore` from `Wallet`
- [x] Moved relevant methods involving path from `Wallet` to `WalletStore` 
- [x] Implement `PersistentBackend` (We can use `FileStore` wherever we need `PersistentBackend` implementation)
```rs
use bdk_file_store::Store as FileStore;
```
- [x] Removed `DisplayAddressType` enum
- [x] Renamed `store` to `wallet_store` to avoid confusion with `bdk_file_store` which is now called `FileStore`
- [x] Updated `bdk` dependencies to use `v1.0.0-alpha.13` 