### PR TITLE
`cleanup`: `compute_checksum` & `polynomial_modulus` exists in BDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bitcoind = "0.32"
 libtor = {version = "47.13.0", optional = true}
 mitosis = {version = "0.1.1", optional = true}
 log4rs = "1.3.0"
+bdk = "0.29.0"
 
 
 #Empty default feature set, (helpful to generalise in github actions)

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -41,14 +41,6 @@ use crate::{
     wallet::{SwapCoin, WalletError},
 };
 
-const INPUT_CHARSET: &str =
-    "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
-const CHECKSUM_CHARSET: &str = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
-
-const MASK_LOW_35_BITS: u64 = 0x7ffffffff;
-const SHIFT_FOR_C0: u64 = 35;
-const CHECKSUM_FINAL_XOR_VALUE: u64 = 1;
-
 /// Converts a string representation of a network to a `Network` enum variant.
 pub fn str_to_bitcoin_network(net_str: &str) -> Network {
     match net_str {
@@ -372,72 +364,6 @@ pub fn monitor_log_for_completion(log_dir: PathBuf, pattern: &str) -> io::Result
         }
         thread::sleep(Duration::from_secs(3));
     }
-}
-
-fn polynomial_modulus(mut checksum: u64, value: u64) -> u64 {
-    let upper_bits = checksum >> SHIFT_FOR_C0;
-    checksum = ((checksum & MASK_LOW_35_BITS) << 5) ^ value;
-
-    static FEEDBACK_TERMS: [(u64, u64); 5] = [
-        (0x1, 0xf5dee51989),
-        (0x2, 0xa9fdca3312),
-        (0x4, 0x1bab10e32d),
-        (0x8, 0x3706b1677a),
-        (0x10, 0x644d626ffd),
-    ];
-
-    for &(bit, term) in FEEDBACK_TERMS.iter() {
-        if (upper_bits & bit) != 0 {
-            checksum ^= term;
-        }
-    }
-
-    checksum
-}
-
-/// Compute the checksum of a descriptor
-pub fn compute_checksum(descriptor: &str) -> Result<String, WalletError> {
-    let mut checksum = CHECKSUM_FINAL_XOR_VALUE;
-    let mut accumulated_value = 0;
-    let mut group_count = 0;
-
-    for character in descriptor.chars() {
-        let position = INPUT_CHARSET
-            .find(character)
-            .ok_or(WalletError::Protocol("Descriptor invalid".to_string()))?
-            as u64;
-        checksum = polynomial_modulus(checksum, position & 31);
-        accumulated_value = accumulated_value * 3 + (position >> 5);
-        group_count += 1;
-
-        if group_count == 3 {
-            checksum = polynomial_modulus(checksum, accumulated_value);
-            accumulated_value = 0;
-            group_count = 0;
-        }
-    }
-
-    if group_count > 0 {
-        checksum = polynomial_modulus(checksum, accumulated_value);
-    }
-
-    // Finalize checksum by feeding zeros.
-    (0..8).for_each(|_| {
-        checksum = polynomial_modulus(checksum, 0);
-    });
-    checksum ^= CHECKSUM_FINAL_XOR_VALUE;
-
-    // Convert the checksum into a character string.
-    let checksum_chars = (0..8)
-        .map(|i| {
-            CHECKSUM_CHARSET
-                .chars()
-                .nth(((checksum >> (5 * (7 - i))) & 31) as usize)
-                .unwrap()
-        })
-        .collect::<String>();
-
-    Ok(checksum_chars)
 }
 
 #[cfg(test)]

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -7,6 +7,7 @@ use std::{convert::TryFrom, fs, path::PathBuf, str::FromStr};
 
 use std::collections::{HashMap, HashSet};
 
+use bdk::descriptor::calc_checksum;
 use bitcoin::{
     bip32::{ChildNumber, DerivationPath, ExtendedPubKey},
     hashes::{hash160::Hash as Hash160, hex::FromHex},
@@ -20,10 +21,7 @@ use bitcoind::bitcoincore_rpc::{core_rpc_json::ListUnspentResultEntry, Client, R
 
 use crate::{
     protocol::contract,
-    utill::{
-        compute_checksum, generate_keypair, get_hd_path_from_descriptor,
-        redeemscript_to_scriptpubkey,
-    },
+    utill::{generate_keypair, get_hd_path_from_descriptor, redeemscript_to_scriptpubkey},
 };
 
 use super::{
@@ -566,7 +564,7 @@ impl Wallet {
                 let decriptor = format!(
                     "{}#{}",
                     descriptor_without_checksum,
-                    compute_checksum(&descriptor_without_checksum).unwrap()
+                    calc_checksum(&descriptor_without_checksum).unwrap()
                 );
                 (*keychain, decriptor)
             })
@@ -1381,7 +1379,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<String>>(),
@@ -1400,7 +1398,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<String>>(),
@@ -1416,7 +1414,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -1431,7 +1429,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -1442,7 +1440,7 @@ impl Wallet {
             format!(
                 "{}#{}",
                 descriptor_without_checksum,
-                compute_checksum(&descriptor_without_checksum).unwrap()
+                calc_checksum(&descriptor_without_checksum).unwrap()
             )
         }));
 

--- a/src/wallet/bdk.rs
+++ b/src/wallet/bdk.rs
@@ -20,6 +20,7 @@ use std::{
     num::ParseIntError,
 };
 
+use bdk::descriptor::calc_checksum;
 use bitcoin::{
     absolute::LockTime,
     bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey},
@@ -55,8 +56,8 @@ use crate::{
         messages::Preimage,
     },
     utill::{
-        compute_checksum, generate_keypair, get_hd_path_from_descriptor,
-        redeemscript_to_scriptpubkey, str_to_bitcoin_network,
+        generate_keypair, get_hd_path_from_descriptor, redeemscript_to_scriptpubkey,
+        str_to_bitcoin_network,
     },
 };
 
@@ -598,7 +599,7 @@ impl Wallet {
                 let decriptor = format!(
                     "{}#{}",
                     descriptor_without_checksum,
-                    compute_checksum(&descriptor_without_checksum).unwrap()
+                    calc_checksum(&descriptor_without_checksum).unwrap()
                 );
                 (*keychain, decriptor)
             })
@@ -1413,7 +1414,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<String>>(),
@@ -1432,7 +1433,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<String>>(),
@@ -1448,7 +1449,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -1463,7 +1464,7 @@ impl Wallet {
                     format!(
                         "{}#{}",
                         descriptor_without_checksum,
-                        compute_checksum(&descriptor_without_checksum).unwrap()
+                        calc_checksum(&descriptor_without_checksum).unwrap()
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -1474,7 +1475,7 @@ impl Wallet {
             format!(
                 "{}#{}",
                 descriptor_without_checksum,
-                compute_checksum(&descriptor_without_checksum).unwrap()
+                calc_checksum(&descriptor_without_checksum).unwrap()
             )
         }));
 


### PR DESCRIPTION
Aims to fix #174