### PR TITLE
update bitcoin to v0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bip39 = {version = "1.0.1", features = ["rand"] }
-bitcoin = {version = "0.30", features = ["rand"] }
+bitcoin = {version = "0.32", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_cbor = "0.11.2"
@@ -18,7 +18,7 @@ futures = "0.3"
 dirs = "3.0.1"
 tokio-socks = "0.5"
 clap = { version = "3.2.22", features = ["derive"] }
-bitcoind = "0.32"
+bitcoind = "0.36"
 libtor = {version = "47.13.0", optional = true}
 mitosis = {version = "0.1.1", optional = true}
 log4rs = "1.3.0"

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -282,12 +282,16 @@ impl Maker {
 
             let funding_output_index = find_funding_output_index(funding_info)?;
 
-            //check the funding_tx is confirmed confirmed to required depth
+            //check the funding_tx is confirmed to required depth
             if let Some(txout) = self
                 .wallet
                 .read()?
                 .rpc
-                .get_tx_out(&funding_info.funding_tx.txid(), funding_output_index, None)
+                .get_tx_out(
+                    &funding_info.funding_tx.compute_txid(),
+                    funding_output_index,
+                    None,
+                )
                 .map_err(WalletError::Rpc)?
             {
                 if txout.confirmations < (self.config.required_confirms as u32) {
@@ -321,7 +325,7 @@ impl Maker {
 
             if !self.wallet.read()?.does_prevout_match_cached_contract(
                 &(OutPoint {
-                    txid: funding_info.funding_tx.txid(),
+                    txid: funding_info.funding_tx.compute_txid(),
                     vout: funding_output_index,
                 }),
                 &contract_spk,
@@ -421,12 +425,12 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
                 let txids_to_watch = connection_state
                     .incoming_swapcoins
                     .iter()
-                    .map(|is| is.contract_tx.txid())
+                    .map(|is| is.contract_tx.compute_txid())
                     .chain(
                         connection_state
                             .outgoing_swapcoins
                             .iter()
-                            .map(|oc| oc.contract_tx.txid()),
+                            .map(|oc| oc.contract_tx.compute_txid()),
                     )
                     .collect::<Vec<_>>();
 
@@ -611,7 +615,7 @@ pub fn recover_from_swap(
             .wallet
             .read()?
             .rpc
-            .get_raw_transaction_info(&tx.txid(), None)
+            .get_raw_transaction_info(&tx.compute_txid(), None)
             .is_ok()
         {
             log::info!(
@@ -628,7 +632,7 @@ pub fn recover_from_swap(
             log::info!(
                 "[{}] Broadcasted Incoming Contract : {}",
                 maker.config.port,
-                tx.txid()
+                tx.compute_txid()
             );
         }
 
@@ -640,7 +644,7 @@ pub fn recover_from_swap(
         log::info!(
             "[{}] Removed Incoming Swapcoin From Wallet, Contract Txid : {}",
             maker.config.port,
-            removed_incoming.contract_tx.txid()
+            removed_incoming.contract_tx.compute_txid()
         );
     }
 
@@ -652,7 +656,7 @@ pub fn recover_from_swap(
             .wallet
             .read()?
             .rpc
-            .get_raw_transaction_info(&tx.txid(), None)
+            .get_raw_transaction_info(&tx.compute_txid(), None)
             .is_ok()
         {
             log::info!(
@@ -669,7 +673,7 @@ pub fn recover_from_swap(
             log::info!(
                 "[{}] Broadcasted Outgoing Contract : {}",
                 maker.config.port,
-                tx.txid()
+                tx.compute_txid()
             );
         }
     }
@@ -688,12 +692,12 @@ pub fn recover_from_swap(
                 .wallet
                 .read()?
                 .rpc
-                .get_raw_transaction_info(&contract.txid(), None)
+                .get_raw_transaction_info(&contract.compute_txid(), None)
             {
                 log::info!(
                     "[{}] Contract Tx : {}, reached confirmation : {:?}, Required Confirmation : {}",
                     maker.config.port,
-                    contract.txid(),
+                    contract.compute_txid(),
                     result.confirmations,
                     timelock
                 );
@@ -704,12 +708,12 @@ pub fn recover_from_swap(
                             "[{}] Timelock maturity of {} blocks for Contract Tx is reached : {}",
                             maker.config.port,
                             timelock,
-                            contract.txid()
+                            contract.compute_txid()
                         );
                         log::info!(
                             "[{}] Broadcasting timelocked tx: {}",
                             maker.config.port,
-                            timelocked_tx.txid()
+                            timelocked_tx.compute_txid()
                         );
                         maker
                             .wallet
@@ -734,7 +738,7 @@ pub fn recover_from_swap(
                 log::info!(
                     "[{}] Removed Outgoing Swapcoin from Wallet, Contract Txid: {}",
                     maker.config.port,
-                    outgoing_removed.contract_tx.txid()
+                    outgoing_removed.contract_tx.compute_txid()
                 );
             }
             log::info!("initializing Wallet Sync.");

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -282,10 +282,10 @@ impl Maker {
 
             let receiver_contract_tx = create_receivers_contract_tx(
                 OutPoint {
-                    txid: funding_info.funding_tx.txid(),
+                    txid: funding_info.funding_tx.compute_txid(),
                     vout: funding_output_index,
                 },
-                funding_output.value,
+                funding_output.value.to_sat(),
                 &funding_info.contract_redeemscript,
             );
 
@@ -315,7 +315,7 @@ impl Maker {
                 receiver_contract_tx.clone(),
                 funding_info.contract_redeemscript.clone(),
                 hashlock_privkey,
-                funding_output.value,
+                funding_output.value.to_sat(),
             );
             if !connection_state
                 .incoming_swapcoins
@@ -338,7 +338,7 @@ impl Maker {
                 .output
                 .get(index as usize)
                 .expect("output at index expected");
-            acc + txout.value
+            acc + txout.value.to_sat()
         });
 
         let calc_coinswap_fees = calculate_coinswap_fee(
@@ -383,7 +383,7 @@ impl Maker {
             self.config.port,
             my_funding_txes
                 .iter()
-                .map(|tx| tx.txid())
+                .map(|tx| tx.compute_txid())
                 .collect::<Vec<_>>()
         );
         log::debug!(
@@ -506,7 +506,7 @@ impl Maker {
                 .rpc
                 .send_raw_transaction(my_funding_tx)
                 .map_err(|e| MakerError::Wallet(e.into()))?;
-            assert_eq!(txid, my_funding_tx.txid());
+            assert_eq!(txid, my_funding_tx.compute_txid());
             my_funding_txids.push(txid);
         }
         log::info!(

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -8,10 +8,9 @@ pub enum ContractError {
     Secp(secp256k1::Error),
     Protocol(&'static str),
     Script(bitcoin::blockdata::script::Error),
-    Hash(bitcoin::hashes::Error),
-    Key(bitcoin::key::Error),
-    Sighash(bitcoin::sighash::Error),
-    Addrs(bitcoin::address::Error),
+    Hash(bitcoin::hashes::FromSliceError),
+    Key(bitcoin::key::FromSliceError),
+    Sighash(bitcoin::transaction::InputsIndexError),
 }
 
 impl From<secp256k1::Error> for ContractError {
@@ -26,26 +25,20 @@ impl From<bitcoin::blockdata::script::Error> for ContractError {
     }
 }
 
-impl From<bitcoin::hashes::Error> for ContractError {
-    fn from(value: bitcoin::hashes::Error) -> Self {
+impl From<bitcoin::hashes::FromSliceError> for ContractError {
+    fn from(value: bitcoin::hashes::FromSliceError) -> Self {
         Self::Hash(value)
     }
 }
 
-impl From<bitcoin::key::Error> for ContractError {
-    fn from(value: bitcoin::key::Error) -> Self {
+impl From<bitcoin::key::FromSliceError> for ContractError {
+    fn from(value: bitcoin::key::FromSliceError) -> Self {
         Self::Key(value)
     }
 }
 
-impl From<bitcoin::sighash::Error> for ContractError {
-    fn from(value: bitcoin::sighash::Error) -> Self {
+impl From<bitcoin::transaction::InputsIndexError> for ContractError {
+    fn from(value: bitcoin::transaction::InputsIndexError) -> Self {
         Self::Sighash(value)
-    }
-}
-
-impl From<bitcoin::address::Error> for ContractError {
-    fn from(value: bitcoin::address::Error) -> Self {
-        Self::Addrs(value)
     }
 }

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -333,7 +333,8 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
                 .output
                 .get(funding_output_index as usize)
                 .expect("funding output expected")
-                .value)
+                .value
+                .to_sat())
         })
         .collect::<Result<Vec<u64>, TakerError>>()?;
 

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -9,14 +9,12 @@ use std::{
 };
 
 use bitcoin::{
-    address::{WitnessProgram, WitnessVersion},
     hashes::{sha256, Hash},
-    script::PushBytesBuf,
     secp256k1::{
         rand::{rngs::OsRng, RngCore},
         Secp256k1, SecretKey,
     },
-    Network, PublicKey, ScriptBuf,
+    Network, PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
 };
 use log4rs::{
     append::{console::ConsoleAppender, file::FileAppender},
@@ -54,17 +52,6 @@ const CHECKSUM_CHARSET: &str = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 const MASK_LOW_35_BITS: u64 = 0x7ffffffff;
 const SHIFT_FOR_C0: u64 = 35;
 const CHECKSUM_FINAL_XOR_VALUE: u64 = 1;
-
-/// Converts a string representation of a network to a `Network` enum variant.
-pub fn str_to_bitcoin_network(net_str: &str) -> Network {
-    match net_str {
-        "main" => Network::Bitcoin,
-        "test" => Network::Testnet,
-        "signet" => Network::Signet,
-        "regtest" => Network::Regtest,
-        _ => panic!("unknown network: {}", net_str),
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConnectionType {
@@ -293,7 +280,7 @@ pub fn generate_keypair() -> (PublicKey, SecretKey) {
 pub fn redeemscript_to_scriptpubkey(redeemscript: &ScriptBuf) -> ScriptBuf {
     let witness_program = WitnessProgram::new(
         WitnessVersion::V0,
-        PushBytesBuf::from(&redeemscript.wscript_hash().to_byte_array()),
+        &redeemscript.wscript_hash().to_byte_array(),
     )
     .unwrap();
     //p2wsh address
@@ -515,26 +502,6 @@ mod tests {
 
     fn remove_temp_config(path: &PathBuf) {
         fs::remove_file(path).unwrap();
-    }
-
-    #[test]
-    fn test_str_to_bitcoin_network() {
-        let net_strs = vec![
-            ("main", Network::Bitcoin),
-            ("test", Network::Testnet),
-            ("signet", Network::Signet),
-            ("regtest", Network::Regtest),
-            ("unknown_network", Network::Bitcoin),
-        ];
-        for (net_str, expected_network) in net_strs {
-            let network = std::panic::catch_unwind(|| str_to_bitcoin_network(net_str));
-            match network {
-                Ok(net) => assert_eq!(net, expected_network),
-                Err(_) => {
-                    assert_eq!(Network::Bitcoin, expected_network);
-                }
-            }
-        }
     }
 
     #[allow(clippy::read_zero_byte_vec)]

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1003,7 +1003,7 @@ impl Wallet {
                         compressed: true,
                         inner: privkey.public_key(&secp),
                     };
-                    let scriptcode = ScriptBuf::new_p2pkh(&pubkey.pubkey_hash());
+                    let scriptcode = ScriptBuf::new_p2wpkh(&pubkey.wpubkey_hash().unwrap());
                     let sighash = SighashCache::new(&tx_clone)
                         .p2wpkh_signature_hash(
                             ix,

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -14,9 +14,8 @@ pub enum WalletError {
     BIP39(bip39::Error),
     Contract(ContractError),
     Fidelity(FidelityError),
-    Locktime(bitcoin::blockdata::locktime::absolute::Error),
+    Locktime(bitcoin::blockdata::locktime::absolute::ConversionError),
     Secp(bitcoin::secp256k1::Error),
-    Address(bitcoin::address::Error),
 }
 
 impl From<std::io::Error> for WalletError {
@@ -61,8 +60,8 @@ impl From<FidelityError> for WalletError {
     }
 }
 
-impl From<bitcoin::blockdata::locktime::absolute::Error> for WalletError {
-    fn from(value: bitcoin::blockdata::locktime::absolute::Error) -> Self {
+impl From<bitcoin::blockdata::locktime::absolute::ConversionError> for WalletError {
+    fn from(value: bitcoin::blockdata::locktime::absolute::ConversionError) -> Self {
         Self::Locktime(value)
     }
 }
@@ -70,11 +69,5 @@ impl From<bitcoin::blockdata::locktime::absolute::Error> for WalletError {
 impl From<bitcoin::secp256k1::Error> for WalletError {
     fn from(value: bitcoin::secp256k1::Error) -> Self {
         Self::Secp(value)
-    }
-}
-
-impl From<bitcoin::address::Error> for WalletError {
-    fn from(value: bitcoin::address::Error) -> Self {
-        Self::Address(value)
     }
 }

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -6,7 +6,7 @@ use bitcoin::Network;
 use bitcoind::bitcoincore_rpc::{Auth, Client, RpcApi};
 use serde_json::{json, Value};
 
-use crate::{utill::str_to_bitcoin_network, wallet::api::KeychainKind};
+use crate::wallet::api::KeychainKind;
 
 use serde::Deserialize;
 
@@ -50,7 +50,7 @@ impl TryFrom<&RPCConfig> for Client {
             .as_str(),
             config.auth.clone(),
         )?;
-        if config.network != str_to_bitcoin_network(rpc.get_blockchain_info()?.chain.as_str()) {
+        if config.network != rpc.get_blockchain_info()?.chain {
             return Err(WalletError::Protocol(
                 "RPC Network not mathcing with RPCConfig".to_string(),
             ));

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use bip39::Mnemonic;
-use bitcoin::{bip32::ExtendedPrivKey, Network, OutPoint, ScriptBuf};
+use bitcoin::{bip32::Xpriv, Network, OutPoint, ScriptBuf};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::OpenOptions,
@@ -24,7 +24,7 @@ pub struct WalletStore {
     /// Network the wallet operates on.
     pub(crate) network: Network,
     /// The master key for the wallet.
-    pub(super) master_key: ExtendedPrivKey,
+    pub(super) master_key: Xpriv,
     /// The external index for the wallet.
     pub(super) external_index: u32,
     /// The maximum size for an offer in the wallet.
@@ -55,7 +55,7 @@ impl WalletStore {
     ) -> Result<Self, WalletError> {
         let mnemonic = Mnemonic::parse(seedphrase)?;
         let seed = mnemonic.to_seed(passphrase);
-        let master_key = ExtendedPrivKey::new_master(network, &seed)?;
+        let master_key = Xpriv::new_master(network, &seed)?;
 
         let store = Self {
             file_name,

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -31,7 +31,7 @@ use coinswap::{
     maker::{Maker, MakerBehavior},
     market::directory::{start_directory_server, DirectoryServer},
     taker::{Taker, TakerBehavior},
-    utill::{setup_logger, str_to_bitcoin_network, ConnectionType},
+    utill::{setup_logger, ConnectionType},
     wallet::RPCConfig,
 };
 
@@ -235,15 +235,7 @@ impl From<&TestFramework> for RPCConfig {
     fn from(value: &TestFramework) -> Self {
         let url = value.bitcoind.rpc_url().split_at(7).1.to_string();
         let auth = Auth::CookieFile(value.bitcoind.params.cookie_file.clone());
-        let network = str_to_bitcoin_network(
-            value
-                .bitcoind
-                .client
-                .get_blockchain_info()
-                .unwrap()
-                .chain
-                .as_str(),
-        );
+        let network = value.bitcoind.client.get_blockchain_info().unwrap().chain;
         Self {
             url,
             auth,


### PR DESCRIPTION
Miscellaneous changes to for rust-bitcoin update.

Removed one utility function `str_to_bitcoin_network` as its not needed anymore.