### PR TITLE
add `directoryd` and `directory-cli` binary apps

### DIFF
--- a/src/bin/directory-cli.rs
+++ b/src/bin/directory-cli.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+
+
+use coinswap::{
+    market::rpc::{read_rpc_message, RpcMsgReq}, utill::{send_message, setup_logger}, maker::error::MakerError,
+};
+
+
+use serde::{Deserialize, Serialize};
+use tokio::{io::BufReader, net::TcpStream};
+
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Message {
+    Hello,
+}
+
+/// directory-cli is a command line app to send RPC messages to directory server.
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct App {
+    /// The command to execute
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Parser, Debug)]
+enum Commands {
+    /// Sends a Ping
+    Ping
+}
+
+#[tokio::main]
+async fn main() -> Result<(), MakerError> {
+    setup_logger();
+    let cli = App::parse();
+
+    match cli.command {
+        Commands::Ping => {
+            log::info!("Sending Ping");
+            send_rpc_req(&RpcMsgReq::Ping).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async  fn send_rpc_req(req : &RpcMsgReq) -> Result<(), MakerError> {
+    log::info!("Connecting to 127.0.0.1:4321");
+    let mut stream = TcpStream::connect("127.0.0.1:4321").await?;
+    println!("{:?}", stream);
+    log::info!("Connected to 127.0.0.1:4321");
+
+    let (read_half, mut write_half) = stream.split();
+
+    if let Err(e) = send_message(&mut write_half, &req).await {
+        log::error!("Error Sending RPC message : {:?}", e);
+    };
+
+
+    if let Some(rpc_resp) = read_rpc_message(&mut BufReader::new(read_half)).await? {
+        log::info!("RPC response received: {:?}", rpc_resp);
+    } else {
+        log::error!("RPC response received: None");
+    }
+
+    Ok(())
+}

--- a/src/bin/directory.rs
+++ b/src/bin/directory.rs
@@ -46,11 +46,9 @@ fn main() {
             };
 
             let data_directory = data_directory.unwrap_or(get_dns_dir());
-            let directory_server = DirectoryServer::new(
-                Some(data_directory.join("config.toml")),
-                Some(network_type),
-            )
-            .unwrap();
+            let directory_server =
+                DirectoryServer::new(Some(data_directory.join("config.toml")), Some(network_type))
+                    .unwrap();
             let arc_directory_server = Arc::new(directory_server);
 
             start_directory_server(arc_directory_server);

--- a/src/bin/directory.rs
+++ b/src/bin/directory.rs
@@ -47,7 +47,7 @@ fn main() {
 
             let data_directory = data_directory.unwrap_or(get_dns_dir());
             let directory_server = DirectoryServer::new(
-                Some(&data_directory.join("config.toml")),
+                Some(data_directory.join("config.toml")),
                 Some(network_type),
             )
             .unwrap();

--- a/src/bin/directoryd.rs
+++ b/src/bin/directoryd.rs
@@ -5,10 +5,6 @@ use coinswap::{
 };
 use std::{path::PathBuf, sync::Arc};
 
-/// The DNS Server.
-///
-/// This app starts the DNS server to serve Maker addresses to the Taker clients.
-
 #[derive(Parser)]
 #[clap(version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
@@ -24,7 +20,6 @@ struct Cli {
 
 fn main() {
     setup_logger();
-    log::info!("Starting Directory Server");
 
     let args = Cli::parse();
 

--- a/src/bin/directoryd.rs
+++ b/src/bin/directoryd.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use coinswap::{
     market::directory::{start_directory_server, DirectoryServer},
-    utill::{setup_logger, read_connection_network_string},
+    utill::{read_connection_network_string, setup_logger},
 };
 use std::{path::PathBuf, sync::Arc};
 
@@ -25,13 +25,7 @@ fn main() {
 
     let conn_type = read_connection_network_string(&args.network).unwrap();
 
-    let directory = Arc::new(
-        DirectoryServer::new(
-            args.data_directory,
-            Some(conn_type), 
-        ). unwrap(),
-    );
+    let directory = Arc::new(DirectoryServer::new(args.data_directory, Some(conn_type)).unwrap());
 
     start_directory_server(directory);
-
 }

--- a/src/bin/directoryd.rs
+++ b/src/bin/directoryd.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+use coinswap::{
+    market::directory::{start_directory_server, DirectoryServer},
+    utill::{setup_logger, read_connection_network_string},
+};
+use std::{path::PathBuf, sync::Arc};
+
+/// The DNS Server.
+///
+/// This app starts the DNS server to serve Maker addresses to the Taker clients.
+
+#[derive(Parser)]
+#[clap(version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
+author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
+
+struct Cli {
+    /// Optional network type.
+    #[clap(long, short = 'n', default_value = "clearnet", possible_values = &["tor", "clearnet"])]
+    network: String,
+    /// Optional DNS data directory. Default value : "~/.coinswap/directory"
+    #[clap(long, short = 'd')]
+    data_directory: Option<PathBuf>,
+}
+
+fn main() {
+    setup_logger();
+    log::info!("Starting Directory Server");
+
+    let args = Cli::parse();
+
+    let conn_type = read_connection_network_string(&args.network).unwrap();
+
+    let directory = Arc::new(
+        DirectoryServer::new(
+            args.data_directory,
+            Some(conn_type), 
+        ). unwrap(),
+    );
+
+    start_directory_server(directory);
+
+}

--- a/src/market/mod.rs
+++ b/src/market/mod.rs
@@ -1,3 +1,4 @@
 //! (dummy) Current toy implementation of a directory-server.
 
 pub mod directory;
+pub  mod rpc;

--- a/src/market/mod.rs
+++ b/src/market/mod.rs
@@ -1,4 +1,4 @@
 //! (dummy) Current toy implementation of a directory-server.
 
 pub mod directory;
-pub  mod rpc;
+pub mod rpc;

--- a/src/market/rpc/messages.rs
+++ b/src/market/rpc/messages.rs
@@ -1,0 +1,14 @@
+use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum RpcMsgReq {
+   Ping,
+   ListAddresses,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum RpcMsgResp {
+   Pong,
+   ListAddressesResp { addresses: Vec<String> },
+}

--- a/src/market/rpc/messages.rs
+++ b/src/market/rpc/messages.rs
@@ -1,14 +1,13 @@
-use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgReq {
    Ping,
-   ListAddresses,
+   // ListAddresses,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgResp {
    Pong,
-   ListAddressesResp { addresses: Vec<String> },
+   // ListAddressesResp { addresses: Vec<String> },
 }

--- a/src/market/rpc/messages.rs
+++ b/src/market/rpc/messages.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+// use std::collections::HashSet;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgReq {
@@ -9,5 +10,5 @@ pub enum RpcMsgReq {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgResp {
    Pong,
-   // ListAddressesResp { addresses: Vec<String> },
+   // ListAddressesResp(HashSet<String>),
 }

--- a/src/market/rpc/messages.rs
+++ b/src/market/rpc/messages.rs
@@ -1,14 +1,12 @@
 use serde::{Deserialize, Serialize};
-// use std::collections::HashSet;
+use std::collections::HashSet;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgReq {
-   Ping,
-   // ListAddresses,
+    ListAddresses,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RpcMsgResp {
-   Pong,
-   // ListAddressesResp(HashSet<String>),
+    ListAddressesResp(HashSet<String>),
 }

--- a/src/market/rpc/mod.rs
+++ b/src/market/rpc/mod.rs
@@ -1,0 +1,5 @@
+mod messages;
+mod server;
+
+pub use messages::RpcMsgReq;
+pub use server::{read_rpc_message, start_rpc_server_thread};

--- a/src/market/rpc/mod.rs
+++ b/src/market/rpc/mod.rs
@@ -2,4 +2,4 @@ mod messages;
 mod server;
 
 pub use messages::{RpcMsgReq, RpcMsgResp};
-pub use server::{read_rpc_message, start_rpc_server_thread};
+pub use server::{read_rpc_message, start_rpc_server_thread, read_resp_message};

--- a/src/market/rpc/mod.rs
+++ b/src/market/rpc/mod.rs
@@ -1,5 +1,5 @@
 mod messages;
 mod server;
 
-pub use messages::RpcMsgReq;
+pub use messages::{RpcMsgReq, RpcMsgResp};
 pub use server::{read_rpc_message, start_rpc_server_thread};

--- a/src/market/rpc/mod.rs
+++ b/src/market/rpc/mod.rs
@@ -2,4 +2,4 @@ mod messages;
 mod server;
 
 pub use messages::{RpcMsgReq, RpcMsgResp};
-pub use server::{read_rpc_message, start_rpc_server_thread, read_resp_message};
+pub use server::{read_resp_message, read_rpc_message, start_rpc_server_thread};

--- a/src/market/rpc/server.rs
+++ b/src/market/rpc/server.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+use tokio::{
+    io::{AsyncReadExt, BufReader},
+    net::{tcp::ReadHalf, TcpStream}, //TcpListener
+};
+
+use crate::{
+    maker::error::MakerError, market::directory::DirectoryServer, utill::send_message
+};
+
+use super::RpcMsgReq;
+use super::RpcMsgResp;
+
+pub async fn read_rpc_message(
+    reader: &mut BufReader<ReadHalf<'_>>,
+) -> Result<Option<RpcMsgReq>, MakerError> {
+    let read_result = reader.read_u32().await;
+    // If its EOF, return None
+    if read_result
+        .as_ref()
+        .is_err_and(|e| e.kind() == std::io::ErrorKind::UnexpectedEof)
+    {
+        return Ok(None);
+    }
+    let length = read_result?;
+    if length == 0 {
+        return Ok(None);
+    }
+    let mut buffer = vec![0; length as usize];
+    reader.read_exact(&mut buffer).await?;
+    let message: RpcMsgReq = serde_cbor::from_slice(&buffer)?;
+    Ok(Some(message))
+}
+
+async fn handle_request(mut socker: TcpStream) -> Result<(), MakerError> {
+    let (socket_reader, mut socket_writer) = socker.split();
+    let mut reader = BufReader::new(socket_reader);
+    if let Some(rpc_request) = read_rpc_message(&mut reader).await? {
+        match rpc_request {
+            RpcMsgReq::Ping => {
+                log::info!("RPC request received: {:?}", rpc_request);
+                if let Err(e) = send_message(&mut socket_writer, &RpcMsgResp::Pong).await {
+                    log::info!("Error sending RPC response {:?}", e);
+                };
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn start_rpc_server_thread(directory: Arc<DirectoryServer>) {
+    let rpc_port = directory.rpc_port;
+    let rpc_socket = format!("127.0.0.1:{}", rpc_port);
+    let listener = TcpListener::bind(&rpc_socket).await.unwrap();
+    log::info!(
+        "[{}] RPC socket binding successful at {}",
+        directory.rpc_port,
+        rpc_socket
+    );
+    // read this
+    tokio::spawn(async move {
+        loop {
+            let (socket, addrs) = listener.accept().await.unwrap();
+            log::info!("Got RPC request from: {}", addrs);
+            handle_request(socket).await.unwrap();
+        }
+    });
+}
+
+

--- a/src/market/rpc/server.rs
+++ b/src/market/rpc/server.rs
@@ -7,7 +7,7 @@ use tokio::{
 };
 
 use crate::{
-    maker::error::MakerError, market::directory::DirectoryServer, utill::send_message
+    maker::error::MakerError, market::directory::DirectoryServer, utill::send_message, 
 };
 
 use super::RpcMsgReq;
@@ -16,6 +16,31 @@ use super::RpcMsgResp;
 pub async fn read_rpc_message(
     reader: &mut BufReader<ReadHalf<'_>>,
 ) -> Result<Option<RpcMsgReq>, MakerError> {
+    let read_result = reader.read_u32().await;
+    // If its EOF, return None
+    log::info!("read_result: {:?}", read_result);
+    if read_result
+        .as_ref()
+        .is_err_and(|e| e.kind() == std::io::ErrorKind::UnexpectedEof)
+    {
+        return Ok(None);
+    }
+    let length = read_result?;
+    log::info!("length: {:?}", length);
+    if length == 0 {
+        return Ok(None);
+    }
+    let mut buffer = vec![0; length as usize];
+    reader.read_exact(&mut buffer).await?;
+    log::info!("buffer: {:?}", buffer);
+    let message: RpcMsgReq = serde_cbor::from_slice(&buffer)?;
+    log::info!("message: {:?}", message);
+    Ok(Some(message))
+}
+
+pub async fn read_resp_message(
+    reader: &mut BufReader<ReadHalf<'_>>,
+) -> Result<Option<RpcMsgResp>, MakerError> {
     let read_result = reader.read_u32().await;
     // If its EOF, return None
     if read_result
@@ -30,18 +55,21 @@ pub async fn read_rpc_message(
     }
     let mut buffer = vec![0; length as usize];
     reader.read_exact(&mut buffer).await?;
-    let message: RpcMsgReq = serde_cbor::from_slice(&buffer)?;
+    let message: RpcMsgResp = serde_cbor::from_slice(&buffer)?;
     Ok(Some(message))
 }
 
 async fn handle_request(mut socker: TcpStream) -> Result<(), MakerError> {
     let (socket_reader, mut socket_writer) = socker.split();
     let mut reader = BufReader::new(socket_reader);
+   
+
     if let Some(rpc_request) = read_rpc_message(&mut reader).await? {
         match rpc_request {
             RpcMsgReq::Ping => {
                 log::info!("RPC request received: {:?}", rpc_request);
-                if let Err(e) = send_message(&mut socket_writer, &RpcMsgResp::Pong).await {
+                let resp = RpcMsgResp::Pong;
+                if let Err(e) = send_message(&mut socket_writer, &resp).await {
                     log::info!("Error sending RPC response {:?}", e);
                 };
             }


### PR DESCRIPTION
This PR aims to add `directoryd` and `directory-cli` binary apps, and resolve the help text bug that was occurring on running directory server app 