### PR TITLE
use `Amount` instead of `u64`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! High-level network and protocol errors.
 
+use bitcoin::Amount;
+
 use crate::protocol::error::ContractError;
 
 /// Includes all network-related errors.
@@ -30,7 +32,7 @@ pub enum ProtocolError {
     WrongNumOfSigs { expected: usize, received: usize },
     WrongNumOfContractTxs { expected: usize, received: usize },
     WrongNumOfPrivkeys { expected: usize, received: usize },
-    IncorrectFundingAmount { expected: u64, found: u64 },
+    IncorrectFundingAmount { expected: Amount, found: Amount },
     Contract(ContractError),
 }
 

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -24,9 +24,9 @@ pub struct MakerConfig {
     /// Absolute coinswap fee
     pub absolute_fee_sats: Amount,
     /// Fee rate per swap amount in ppb.
-    pub amount_relative_fee_ppb: u64,
+    pub amount_relative_fee_ppb: Amount,
     /// Fee rate for timelocked contract in ppb
-    pub time_relative_fee_ppb: u64,
+    pub time_relative_fee_ppb: Amount,
     /// No of confirmation required for funding transaction
     pub required_confirms: u64,
     // Minimum timelock difference between contract transaction of two hops
@@ -57,8 +57,8 @@ impl Default for MakerConfig {
             directory_servers_refresh_interval_secs: 60 * 60 * 12, //12 Hours
             idle_connection_timeout: 300,
             absolute_fee_sats: Amount::from_sat(1000),
-            amount_relative_fee_ppb: 10_000_000,
-            time_relative_fee_ppb: 100_000,
+            amount_relative_fee_ppb: Amount::from_sat(10_000_000),
+            time_relative_fee_ppb: Amount::from_sat(100_000),
             required_confirms: 1,
             min_contract_reaction_time: 48,
             min_size: 10_000,

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -2,6 +2,8 @@
 
 use std::{io, path::PathBuf};
 
+use bitcoin::Amount;
+
 use crate::utill::{get_maker_dir, parse_field, parse_toml, write_default_config, ConnectionType};
 
 /// Maker Configuration, controlling various maker behavior.
@@ -20,7 +22,7 @@ pub struct MakerConfig {
     /// Time interval to close a connection if no response is received
     pub idle_connection_timeout: u64,
     /// Absolute coinswap fee
-    pub absolute_fee_sats: u64,
+    pub absolute_fee_sats: Amount,
     /// Fee rate per swap amount in ppb.
     pub amount_relative_fee_ppb: u64,
     /// Fee rate for timelocked contract in ppb
@@ -54,7 +56,7 @@ impl Default for MakerConfig {
             rpc_ping_interval_secs: 60,
             directory_servers_refresh_interval_secs: 60 * 60 * 12, //12 Hours
             idle_connection_timeout: 300,
-            absolute_fee_sats: 1000,
+            absolute_fee_sats: Amount::from_sat(1000),
             amount_relative_fee_ppb: 10_000_000,
             time_relative_fee_ppb: 100_000,
             required_confirms: 1,

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -345,7 +345,7 @@ impl Maker {
             self.config.absolute_fee_sats,
             self.config.amount_relative_fee_ppb,
             self.config.time_relative_fee_ppb,
-            incoming_amount,
+            Amount::from_sat(incoming_amount),
             self.config.required_confirms, //time_in_blocks just 1 for now
         );
 
@@ -359,7 +359,7 @@ impl Maker {
         // Create outgoing coinswap of the next hop
         let (my_funding_txes, outgoing_swapcoins, act_funding_txs_fees) = {
             self.wallet.write()?.initalize_coinswap(
-                outgoing_amount,
+                Amount::from_sat(outgoing_amount),
                 &message
                     .next_coinswap_info
                     .iter()
@@ -372,7 +372,7 @@ impl Maker {
                     .collect::<Vec<PublicKey>>(),
                 hashvalue,
                 message.next_locktime,
-                message.next_fee_rate,
+                Amount::from_sat(message.next_fee_rate),
             )?
         };
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -221,10 +221,9 @@ impl Maker {
             .map(|txinfo| txinfo.senders_contract_tx.input[0].previous_output.txid)
             .collect::<Vec<_>>();
 
-        let total_funding_amount = message
-            .txs_info
-            .iter()
-            .fold(0u64, |acc, txinfo| acc + txinfo.funding_input_value);
+        let total_funding_amount = message.txs_info.iter().fold(0u64, |acc, txinfo| {
+            acc + txinfo.funding_input_value.to_sat()
+        });
 
         if total_funding_amount >= self.config.min_size
             && total_funding_amount < self.wallet.read()?.store.offer_maxsize
@@ -285,7 +284,7 @@ impl Maker {
                     txid: funding_info.funding_tx.compute_txid(),
                     vout: funding_output_index,
                 },
-                funding_output.value.to_sat(),
+                funding_output.value,
                 &funding_info.contract_redeemscript,
             );
 
@@ -315,7 +314,7 @@ impl Maker {
                 receiver_contract_tx.clone(),
                 funding_info.contract_redeemscript.clone(),
                 hashlock_privkey,
-                funding_output.value.to_sat(),
+                funding_output.value,
             );
             if !connection_state
                 .incoming_swapcoins
@@ -376,7 +375,7 @@ impl Maker {
             )?
         };
 
-        let act_coinswap_fees = incoming_amount - outgoing_amount - act_funding_txs_fees;
+        let act_coinswap_fees = incoming_amount - outgoing_amount - act_funding_txs_fees.to_sat();
 
         log::info!(
             "[{}] Outgoing Funding Txids: {:?}.",
@@ -404,7 +403,7 @@ impl Maker {
         log::info!(
             "Calculated Funding Txs Fees = {} | Actual Funding Txs Fees = {} | Calculated Swap Revenue = {} | Actual Swap Revenue = {}",
             Amount::from_sat(calc_funding_tx_fees),
-            Amount::from_sat(act_funding_txs_fees),
+            act_funding_txs_fees,
             Amount::from_sat(calc_coinswap_fees),
             Amount::from_sat(act_coinswap_fees)
         );

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -56,14 +56,14 @@ const PUBKEY2_OFFSET: usize = PUBKEY1_OFFSET + PUBKEY_LENGTH + 1;
 /// Calculate the coin swap fee based on various parameters.
 pub fn calculate_coinswap_fee(
     absolute_fee_sat: Amount,
-    amount_relative_fee_ppb: u64,
-    time_relative_fee_ppb: u64,
+    amount_relative_fee_ppb: Amount,
+    time_relative_fee_ppb: Amount,
     total_funding_amount: Amount,
     time_in_blocks: u64,
 ) -> u64 {
     absolute_fee_sat.to_sat()
-        + (total_funding_amount.to_sat() * amount_relative_fee_ppb) / 1_000_000_000
-        + (time_in_blocks * time_relative_fee_ppb) / 1_000_000_000
+        + (total_funding_amount.to_sat() * amount_relative_fee_ppb.to_sat()) / 1_000_000_000
+        + (time_in_blocks * time_relative_fee_ppb.to_sat()) / 1_000_000_000
 }
 
 /// Apply two signatures to a 2-of-2 multisig spend.
@@ -379,7 +379,7 @@ pub fn read_pubkeys_from_multisig_redeemscript(
 /// Receiver gets the coins via hashlock.
 pub fn create_senders_contract_tx(
     input: OutPoint,
-    input_value: u64,
+    input_value: Amount,
     contract_redeemscript: &ScriptBuf,
 ) -> Transaction {
     Transaction {
@@ -392,7 +392,7 @@ pub fn create_senders_contract_tx(
         output: vec![TxOut {
             script_pubkey: redeemscript_to_scriptpubkey(contract_redeemscript),
             // TODO: Mining fee for contract tx is hard coded here. Make it configurable.
-            value: Amount::from_sat(input_value - 1000),
+            value: input_value - Amount::from_sat(1000),
         }],
         lock_time: LockTime::ZERO,
         version: Version::TWO,
@@ -402,7 +402,7 @@ pub fn create_senders_contract_tx(
 /// Create the receiver's contract transaction.
 pub fn create_receivers_contract_tx(
     input: OutPoint,
-    input_value: u64,
+    input_value: Amount,
     contract_redeemscript: &ScriptBuf,
 ) -> Transaction {
     //exactly the same thing as senders contract for now, until collateral
@@ -462,7 +462,7 @@ pub fn validate_contract_tx(
 pub fn sign_contract_tx(
     contract_tx: &Transaction,
     multisig_redeemscript: &Script,
-    funding_amount: u64,
+    funding_amount: Amount,
     privkey: &SecretKey,
 ) -> Result<Signature, ContractError> {
     let input_index = 0;
@@ -470,7 +470,7 @@ pub fn sign_contract_tx(
         &SighashCache::new(contract_tx).p2wsh_signature_hash(
             input_index,
             multisig_redeemscript,
-            Amount::from_sat(funding_amount),
+            funding_amount,
             EcdsaSighashType::All,
         )?[..],
     )?;
@@ -486,7 +486,7 @@ pub fn sign_contract_tx(
 pub fn verify_contract_tx_sig(
     contract_tx: &Transaction,
     multisig_redeemscript: &Script,
-    funding_amount: u64,
+    funding_amount: Amount,
     pubkey: &PublicKey,
     sig: &bitcoin::secp256k1::ecdsa::Signature,
 ) -> Result<(), ContractError> {
@@ -495,7 +495,7 @@ pub fn verify_contract_tx_sig(
         &SighashCache::new(contract_tx).p2wsh_signature_hash(
             input_index,
             multisig_redeemscript,
-            Amount::from_sat(funding_amount),
+            funding_amount,
             EcdsaSighashType::All,
         )?[..],
     )?;
@@ -710,7 +710,8 @@ mod test {
         .unwrap();
 
         // Create a contract transaction spending the above utxo
-        let contract_tx = create_receivers_contract_tx(spending_utxo, 30000, &contract_script);
+        let contract_tx =
+            create_receivers_contract_tx(spending_utxo, Amount::from_sat(30000), &contract_script);
 
         // Check creation matches expectation
         let expected_tx_hex = String::from(
@@ -850,7 +851,7 @@ mod test {
 
         let contract_tx = create_receivers_contract_tx(
             funding_outpoint,
-            funding_tx.output[0].value.to_sat(),
+            funding_tx.output[0].value,
             &contract_script,
         );
 
@@ -858,7 +859,7 @@ mod test {
         let sig1 = sign_contract_tx(
             &contract_tx,
             &funding_outpoint_script,
-            funding_tx.output[0].value.to_sat(),
+            funding_tx.output[0].value,
             &priv_1.inner,
         )
         .unwrap();
@@ -866,7 +867,7 @@ mod test {
         assert!(verify_contract_tx_sig(
             &contract_tx,
             &funding_outpoint_script,
-            funding_tx.output[0].value.to_sat(),
+            funding_tx.output[0].value,
             &pub1,
             &sig1.signature
         )
@@ -876,7 +877,7 @@ mod test {
         let sig2 = sign_contract_tx(
             &contract_tx,
             &funding_outpoint_script,
-            funding_tx.output[0].value.to_sat(),
+            funding_tx.output[0].value,
             &priv_2.inner,
         )
         .unwrap();
@@ -884,7 +885,7 @@ mod test {
         assert!(verify_contract_tx_sig(
             &contract_tx,
             &funding_outpoint_script,
-            funding_tx.output[0].value.to_sat(),
+            funding_tx.output[0].value,
             &pub2,
             &sig2.signature
         )
@@ -1080,10 +1081,10 @@ mod test {
     #[test]
     fn calculate_coinswap_fee_normal() {
         // Test with typical values
-        let absolute_fee_sat = 1000;
-        let amount_relative_fee_ppb = 500_000_000;
-        let time_relative_fee_ppb = 200_000_000;
-        let total_funding_amount = 1_000_000_000;
+        let absolute_fee_sat = Amount::from_sat(1000);
+        let amount_relative_fee_ppb = Amount::from_sat(500_000_000);
+        let time_relative_fee_ppb = Amount::from_sat(200_000_000);
+        let total_funding_amount = Amount::from_sat(1_000_000_000);
         let time_in_blocks = 100;
 
         let expected_fee = 1000
@@ -1091,10 +1092,10 @@ mod test {
             + (100 * 200_000_000) / 1_000_000_000;
 
         let calculated_fee = calculate_coinswap_fee(
-            Amount::from_sat(absolute_fee_sat),
+            absolute_fee_sat,
             amount_relative_fee_ppb,
             time_relative_fee_ppb,
-            Amount::from_sat(total_funding_amount),
+            total_funding_amount,
             time_in_blocks,
         );
 
@@ -1102,13 +1103,19 @@ mod test {
 
         // Test with zero values
         assert_eq!(
-            calculate_coinswap_fee(Amount::ZERO, 0, 0, Amount::ZERO, 0),
+            calculate_coinswap_fee(Amount::ZERO, Amount::ZERO, Amount::ZERO, Amount::ZERO, 0),
             0
         );
 
         // Test with only the absolute fee being non-zero
         assert_eq!(
-            calculate_coinswap_fee(Amount::from_sat(1000), 0, 0, Amount::ZERO, 0),
+            calculate_coinswap_fee(
+                Amount::from_sat(1000),
+                Amount::ZERO,
+                Amount::ZERO,
+                Amount::ZERO,
+                0
+            ),
             1000
         );
 
@@ -1116,8 +1123,8 @@ mod test {
         assert_eq!(
             calculate_coinswap_fee(
                 Amount::ZERO,
-                1_000_000_000,
-                1_000_000_000,
+                Amount::from_sat(1_000_000_000),
+                Amount::from_sat(1_000_000_000),
                 Amount::from_sat(1000),
                 10
             ),

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -93,7 +93,7 @@ pub struct ContractTxInfoForSender {
     pub timelock_pubkey: PublicKey,
     pub senders_contract_tx: Transaction,
     pub multisig_redeemscript: ScriptBuf,
-    pub funding_input_value: u64,
+    pub funding_input_value: Amount,
 }
 
 /// Request for Contract Sigs **for** the Sender side of the hop.
@@ -239,8 +239,8 @@ pub struct FidelityProof {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct Offer {
     pub absolute_fee_sat: Amount,
-    pub amount_relative_fee_ppb: u64,
-    pub time_relative_fee_ppb: u64,
+    pub amount_relative_fee_ppb: Amount,
+    pub time_relative_fee_ppb: Amount,
     pub required_confirms: u64,
     pub minimum_locktime: u16,
     pub max_size: u64,
@@ -261,7 +261,7 @@ pub struct SenderContractTxInfo {
     pub contract_tx: Transaction,
     pub timelock_pubkey: PublicKey,
     pub multisig_redeemscript: ScriptBuf,
-    pub funding_amount: u64,
+    pub funding_amount: Amount,
 }
 
 /// This message is sent by a Maker to a Taker, which is a request to the Taker for gathering signatures for the Maker as both Sender and Receiver of Coinswaps.

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -58,7 +58,7 @@
 use std::fmt::Display;
 
 use bitcoin::{
-    ecdsa::Signature, hashes::sha256d::Hash, secp256k1::SecretKey, PublicKey, ScriptBuf,
+    ecdsa::Signature, hashes::sha256d::Hash, secp256k1::SecretKey, Amount, PublicKey, ScriptBuf,
     Transaction,
 };
 
@@ -238,7 +238,7 @@ pub struct FidelityProof {
 /// Represents an offer in the context of the Coinswap protocol.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct Offer {
-    pub absolute_fee_sat: u64,
+    pub absolute_fee_sat: Amount,
     pub amount_relative_fee_ppb: u64,
     pub time_relative_fee_ppb: u64,
     pub required_confirms: u64,

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -28,7 +28,7 @@ use bitcoin::{
         rand::{rngs::OsRng, RngCore},
         SecretKey,
     },
-    BlockHash, Network, OutPoint, PublicKey, ScriptBuf, Transaction, Txid,
+    Amount, BlockHash, Network, OutPoint, PublicKey, ScriptBuf, Transaction, Txid,
 };
 use tokio_socks::tcp::Socks5Stream;
 
@@ -466,15 +466,14 @@ impl Taker {
                     &maker.offer.tweakable_point,
                     self.ongoing_swap_state.swap_params.tx_count,
                 );
-
             let (funding_txs, mut outgoing_swapcoins, funding_fee) =
                 self.wallet.initalize_coinswap(
-                    self.ongoing_swap_state.swap_params.send_amount,
+                    Amount::from_sat(self.ongoing_swap_state.swap_params.send_amount),
                     &multisig_pubkeys,
                     &hashlock_pubkeys,
                     self.get_preimage_hash(),
                     swap_locktime,
-                    self.ongoing_swap_state.swap_params.fee_rate,
+                    Amount::from_sat(self.ongoing_swap_state.swap_params.fee_rate),
                 )?;
 
             let contract_reedemscripts = outgoing_swapcoins

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -185,7 +185,6 @@ fn write_default_taker_config(config_path: &PathBuf) {
 
 #[cfg(test)]
 mod tests {
-    use crate::utill::get_taker_dir;
 
     use super::*;
     use std::{

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -260,7 +260,7 @@ pub struct NextPeerInfoArgs {
     pub next_peer_multisig_pubkeys: Vec<PublicKey>,
     pub next_peer_hashlock_pubkeys: Vec<PublicKey>,
     pub next_maker_refund_locktime: u16,
-    pub next_maker_fee_rate: u64,
+    pub next_maker_fee_rate: Amount,
 }
 
 /// [Internal] Send a Proof funding to the maker and init next hop.
@@ -287,7 +287,7 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
                 )
                 .collect::<Vec<NextHopInfo>>(),
             next_locktime: npi.next_maker_refund_locktime,
-            next_fee_rate: npi.next_maker_fee_rate,
+            next_fee_rate: npi.next_maker_fee_rate.to_sat(),
         }),
     )
     .await?;
@@ -343,7 +343,7 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         .senders_contract_txs_info
         .iter()
         .map(|i| i.funding_amount)
-        .sum::<u64>();
+        .sum::<Amount>();
     let coinswap_fees = calculate_coinswap_fee(
         tmi.this_maker.offer.absolute_fee_sat,
         tmi.this_maker.offer.amount_relative_fee_ppb,
@@ -352,13 +352,13 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         1, //time_in_blocks just 1 for now
     );
     let miner_fees_paid_by_taker = (FUNDING_TX_VBYTE_SIZE
-        * npi.next_maker_fee_rate
+        * npi.next_maker_fee_rate.to_sat()
         * (npi.next_peer_multisig_pubkeys.len() as u64))
         / 1000;
     let calculated_next_amount = this_amount - coinswap_fees - miner_fees_paid_by_taker;
-    if calculated_next_amount != next_amount {
+    if Amount::from_sat(calculated_next_amount) != next_amount {
         return Err((ProtocolError::IncorrectFundingAmount {
-            expected: calculated_next_amount,
+            expected: Amount::from_sat(calculated_next_amount),
             found: next_amount,
         })
         .into());

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -9,18 +9,6 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use bitcoin::{secp256k1::SecretKey, PublicKey, ScriptBuf, Transaction};
-use tokio::{
-    io::BufReader,
-    net::{
-        tcp::{ReadHalf, WriteHalf},
-        TcpStream,
-    },
-    select,
-    time::sleep,
-};
-use tokio_socks::tcp::Socks5Stream;
-
 use crate::{
     error::ProtocolError,
     protocol::{
@@ -39,6 +27,17 @@ use crate::{
     },
     utill::{read_maker_message, send_message, ConnectionType},
 };
+use bitcoin::{secp256k1::SecretKey, Amount, PublicKey, ScriptBuf, Transaction};
+use tokio::{
+    io::BufReader,
+    net::{
+        tcp::{ReadHalf, WriteHalf},
+        TcpStream,
+    },
+    select,
+    time::sleep,
+};
+use tokio_socks::tcp::Socks5Stream;
 
 use super::{
     config::TakerConfig,
@@ -349,7 +348,7 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         tmi.this_maker.offer.absolute_fee_sat,
         tmi.this_maker.offer.amount_relative_fee_ppb,
         tmi.this_maker.offer.time_relative_fee_ppb,
-        this_amount,
+        Amount::from_sat(this_amount),
         1, //time_in_blocks just 1 for now
     );
     let miner_fees_paid_by_taker = (FUNDING_TX_VBYTE_SIZE

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1151,12 +1151,12 @@ impl Wallet {
     /// Returns, the Funding Transactions, [`OutgoingSwapCoin`]s and the Total Miner fees.
     pub fn initalize_coinswap(
         &mut self,
-        total_coinswap_amount: u64,
+        total_coinswap_amount: Amount,
         other_multisig_pubkeys: &[PublicKey],
         hashlock_pubkeys: &[PublicKey],
         hashvalue: Hash160,
         locktime: u16,
-        fee_rate: u64,
+        fee_rate: Amount,
     ) -> Result<(Vec<Transaction>, Vec<OutgoingSwapCoin>, u64), WalletError> {
         let (coinswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = other_multisig_pubkeys
             .iter()

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -117,22 +117,22 @@ impl FromStr for DisplayAddressType {
 pub enum UTXOSpendInfo {
     SeedCoin {
         path: String,
-        input_value: u64,
+        input_value: Amount,
     },
     SwapCoin {
         multisig_redeemscript: ScriptBuf,
     },
     TimelockContract {
         swapcoin_multisig_redeemscript: ScriptBuf,
-        input_value: u64,
+        input_value: Amount,
     },
     HashlockContract {
         swapcoin_multisig_redeemscript: ScriptBuf,
-        input_value: u64,
+        input_value: Amount,
     },
     FidelityBondCoin {
         index: u32,
-        input_value: u64,
+        input_value: Amount,
     },
 }
 
@@ -545,9 +545,7 @@ impl Wallet {
             .fidelity_bond
             .iter()
             .find_map(|(i, (bond, _, _))| {
-                if bond.script_pub_key() == utxo.script_pub_key
-                    && bond.amount == utxo.amount.to_sat()
-                {
+                if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
                     Some(UTXOSpendInfo::FidelityBondCoin {
                         index: *i,
                         input_value: bond.amount,
@@ -569,7 +567,7 @@ impl Wallet {
             if utxo.confirmations >= outgoing_swapcoin.get_timelock().into() {
                 return Some(UTXOSpendInfo::TimelockContract {
                     swapcoin_multisig_redeemscript: outgoing_swapcoin.get_multisig_redeemscript(),
-                    input_value: utxo.amount.to_sat(),
+                    input_value: utxo.amount,
                 });
             }
         } else if let Some(incoming_swapcoin) =
@@ -578,7 +576,7 @@ impl Wallet {
             if incoming_swapcoin.is_hash_preimage_known() && utxo.confirmations >= 1 {
                 return Some(UTXOSpendInfo::HashlockContract {
                     swapcoin_multisig_redeemscript: incoming_swapcoin.get_multisig_redeemscript(),
-                    input_value: utxo.amount.to_sat(),
+                    input_value: utxo.amount,
                 });
             }
         }
@@ -608,7 +606,7 @@ impl Wallet {
                 if fingerprint == master_private_key.fingerprint(&secp).to_string() {
                     return Some(UTXOSpendInfo::SeedCoin {
                         path: format!("m/{}/{}", addr_type, index),
-                        input_value: utxo.amount.to_sat(),
+                        input_value: utxo.amount,
                     });
                 }
             } else {
@@ -1005,12 +1003,7 @@ impl Wallet {
                     };
                     let scriptcode = ScriptBuf::new_p2wpkh(&pubkey.wpubkey_hash().unwrap());
                     let sighash = SighashCache::new(&tx_clone)
-                        .p2wpkh_signature_hash(
-                            ix,
-                            &scriptcode,
-                            Amount::from_sat(input_value),
-                            EcdsaSighashType::All,
-                        )
+                        .p2wpkh_signature_hash(ix, &scriptcode, input_value, EcdsaSighashType::All)
                         .unwrap();
                     //use low-R value signatures for privacy
                     //https://en.bitcoin.it/wiki/Privacy#Wallet_fingerprinting
@@ -1043,12 +1036,7 @@ impl Wallet {
                     let privkey = self.get_fidelity_keypair(index)?.secret_key();
                     let redeemscript = self.get_fidelity_reedemscript(index)?;
                     let sighash = SighashCache::new(&tx_clone)
-                        .p2wsh_signature_hash(
-                            ix,
-                            &redeemscript,
-                            Amount::from_sat(input_value),
-                            EcdsaSighashType::All,
-                        )
+                        .p2wsh_signature_hash(ix, &redeemscript, input_value, EcdsaSighashType::All)
                         .unwrap();
                     let sig = secp.sign_ecdsa(
                         &secp256k1::Message::from_digest_slice(&sighash[..]).unwrap(),
@@ -1157,7 +1145,7 @@ impl Wallet {
         hashvalue: Hash160,
         locktime: u16,
         fee_rate: Amount,
-    ) -> Result<(Vec<Transaction>, Vec<OutgoingSwapCoin>, u64), WalletError> {
+    ) -> Result<(Vec<Transaction>, Vec<OutgoingSwapCoin>, Amount), WalletError> {
         let (coinswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = other_multisig_pubkeys
             .iter()
             .map(|other_key| self.create_and_import_coinswap_address(other_key))
@@ -1199,7 +1187,7 @@ impl Wallet {
                     txid: my_funding_tx.compute_txid(),
                     vout: utxo_index,
                 },
-                funding_amount.to_sat(),
+                funding_amount,
                 &contract_redeemscript,
             );
 
@@ -1210,14 +1198,14 @@ impl Wallet {
                 my_senders_contract_tx,
                 contract_redeemscript,
                 timelock_privkey,
-                funding_amount.to_sat(),
+                funding_amount,
             ));
         }
 
         Ok((
             create_funding_txes_result.funding_txes,
             outgoing_swapcoins,
-            create_funding_txes_result.total_miner_fee,
+            Amount::from_sat(create_funding_txes_result.total_miner_fee),
         ))
     }
 

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -132,11 +132,11 @@ async fn test_stop_taker_after_setup() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     info!("Initiating coinswap protocol");

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -106,11 +106,11 @@ async fn test_abort_case_2_move_on_with_other_makers() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     info!("Initiating coinswap protocol");

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -124,11 +124,11 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Calculate Original balance excluding fidelity bonds.

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -105,11 +105,11 @@ async fn maker_drops_after_sending_senders_sigs() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     info!("Initiating coinswap protocol");

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -107,11 +107,11 @@ async fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Spawn a Taker coinswap thread.

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -104,11 +104,11 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Spawn a Taker coinswap thread.

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -104,11 +104,11 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Spawn a Taker coinswap thread.

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -92,7 +92,7 @@ async fn test_fidelity() {
             .next()
             .unwrap();
         assert_eq!(*index, 0);
-        assert_eq!(bond.amount, 5000000);
+        assert_eq!(bond.amount, Amount::from_sat(5000000));
         assert!(!is_spent);
         bond.conf_height
     };
@@ -111,7 +111,7 @@ async fn test_fidelity() {
             .get_fidelity_bonds()
             .get(&index)
             .expect("bond expected");
-        assert_eq!(bond.amount, 1000000);
+        assert_eq!(bond.amount, Amount::from_sat(1000000));
         assert!(!is_spent);
         bond.conf_height
     };

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -130,11 +130,11 @@ async fn malice1_taker_broadcast_contract_prematurely() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Calculate Original balance excluding fidelity bonds.

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -126,11 +126,11 @@ async fn malice2_maker_broadcast_contract_prematurely() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     // Calculate Original balance excluding fidelity bonds.

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -207,11 +207,11 @@ async fn test_standard_coinswap() {
     });
 
     let swap_params = SwapParams {
-        send_amount: 500000,
+        send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
         required_confirms: 1,
-        fee_rate: 1000,
+        fee_rate: Amount::from_sat(1000),
     };
 
     info!("Initiating coinswap protocol");


### PR DESCRIPTION
Aims to fix #183 
(Recently cherry-picked https://github.com/citadel-tech/coinswap/commit/27634156bce9e8c7ad7db4e234eb0873a55000c4 in `bdk-wallet` (commit https://github.com/citadel-tech/coinswap/pull/189/commits/7389880b8004eac15e6ac35d52079dd098acaada) branch so was aware of the conversions so a quick PR)