### PR TITLE
Modify `KeychainKind` enum & create related functions

### DIFF
--- a/src/wallet/bdk.rs
+++ b/src/wallet/bdk.rs
@@ -84,29 +84,42 @@ pub struct Wallet {
 
 /// Types of keychains
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-pub enum KeychainKind {
+pub enum Keychain {
     /// External: Derives recipient addresses.
     External,
     /// Internal: Derives change addresses.
     Internal,
     /// Fidelity: Generates keypair for fidelity bonds.
-    Fidelity,
+    Fidelity { count: u32 },
     /// SwapCoin: Generates keypair of 2-of-2 multisig in funding transations.
-    SwapCoin,
+    SwapCoin { count: u32 },
     /// Contract: Generates Keypair for hashlock and timelock transactions.
-    Contract,
+    Contract { count: u32 },
 }
 
-impl KeychainKind {
+impl Keychain {
     /// Specify the keychain derivation path from [`HARDENDED_DERIVATION`]
     fn index_num(&self) -> u32 {
         match self {
             Self::External => 0,
             Self::Internal => 1,
-            Self::Fidelity => 2,
-            Self::SwapCoin => 3,
-            Self::Contract => 4,
+            Self::Fidelity { .. } => 2,
+            Self::SwapCoin { .. } => 3,
+            Self::Contract { .. } => 4,
         }
+    }
+
+    // returns path of given keychain.
+    fn path(keychain: Keychain) -> String {
+        let keychain_type = match keychain {
+            Keychain::External => String::from("0"),
+            Keychain::Internal => String::from("1"),
+            Keychain::Fidelity { count } => format!("2/{}", count),
+            Keychain::SwapCoin { count } => format!("3/{}", count),
+            Keychain::Contract { count } => format!("4/{}", count),
+        };
+
+        format!("{}/{}", HARDENDED_DERIVATION, keychain_type)
     }
 }
 
@@ -455,8 +468,8 @@ impl Wallet {
 
     //pub fn get_recovery_phrase_from_file()
 
-    /// Wallet descriptors are derivable. Currently only supports two KeychainKind. Internal and External.
-    fn get_wallet_descriptors(&self) -> Result<HashMap<KeychainKind, String>, WalletError> {
+    /// Wallet descriptors are derivable. Currently only supports two Keychain. Internal and External.
+    fn get_wallet_descriptors(&self) -> Result<HashMap<Keychain, String>, WalletError> {
         let secp = Secp256k1::new();
         let wallet_xpub = Xpub::from_priv(
             &secp,
@@ -471,7 +484,7 @@ impl Wallet {
         );
 
         // Get descriptors for external and internal keychain. Other chains are not supported yet.
-        let x = [KeychainKind::External, KeychainKind::Internal]
+        let x = [Keychain::External, Keychain::Internal]
             .iter()
             .map(|keychain| {
                 let descriptor_without_checksum =
@@ -483,7 +496,7 @@ impl Wallet {
                 );
                 (*keychain, decriptor)
             })
-            .collect::<HashMap<KeychainKind, String>>();
+            .collect::<HashMap<Keychain, String>>();
 
         Ok(x)
         //descriptors.map_err(|e| TeleportError::Rpc(e))
@@ -922,7 +935,7 @@ impl Wallet {
     }
 
     /// Finds the next unused index in the HD keychain.
-    pub(super) fn find_hd_next_index(&self, keychain: KeychainKind) -> Result<u32, WalletError> {
+    pub(super) fn find_hd_next_index(&self, keychain: Keychain) -> Result<u32, WalletError> {
         let mut max_index: i32 = -1;
         let all_utxos = self.get_all_utxo()?;
         let mut utxos = self.list_descriptor_utxo_spend_info(Some(&all_utxos))?;
@@ -951,7 +964,7 @@ impl Wallet {
     pub fn get_next_external_address(&mut self) -> Result<Address, WalletError> {
         let descriptors = self.get_wallet_descriptors()?;
         let receive_branch_descriptor = descriptors
-            .get(&KeychainKind::External)
+            .get(&Keychain::External)
             .expect("external keychain expected");
         let receive_address = self.rpc.derive_addresses(
             receive_branch_descriptor,
@@ -964,10 +977,10 @@ impl Wallet {
 
     /// Gets the next internal addresses from the HD keychain.
     pub fn get_next_internal_addresses(&self, count: u32) -> Result<Vec<Address>, WalletError> {
-        let next_change_addr_index = self.find_hd_next_index(KeychainKind::Internal)?;
+        let next_change_addr_index = self.find_hd_next_index(Keychain::Internal)?;
         let descriptors = self.get_wallet_descriptors()?;
         let change_branch_descriptor = descriptors
-            .get(&KeychainKind::Internal)
+            .get(&Keychain::Internal)
             .expect("Internal Keychain expected");
         let addresses = self.rpc.derive_addresses(
             change_branch_descriptor,
@@ -2040,7 +2053,7 @@ impl Wallet {
         let derivation_path = DerivationPath::from_str(&format!(
             "{}/{}",
             HARDENDED_DERIVATION,
-            KeychainKind::Fidelity.index_num()
+            Keychain::Fidelity { count: 0 }.index_num()
         ))?;
 
         let child_derivation_path = derivation_path.child(ChildNumber::Normal { index });
@@ -3284,7 +3297,7 @@ impl Wallet {
             }
         }
 
-        let max_external_index = self.find_hd_next_index(KeychainKind::External)?;
+        let max_external_index = self.find_hd_next_index(Keychain::External)?;
         self.update_external_index(max_external_index)?;
         Ok(())
     }


### PR DESCRIPTION
* Rename `KeychainKind` to `Keychain` for simplicity.
* Modify `Keychain` to define unique keychainkind to each descriptor related to those keychains (`Swapcoin`, `Contract`, `Fedility`)

* build `path` api which return  the given keychain path -> thus includes `index_num` functionality , hence removed it.