### PR TITLE
[improve] Use custom fee rate for contract transaction

### DIFF
--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -286,6 +286,7 @@ impl Maker {
                 },
                 funding_output.value,
                 &funding_info.contract_redeemscript,
+                Amount::from_sat(message.next_fee_rate),
             );
 
             let (tweakable_privkey, _) = self.wallet.read()?.get_tweakable_keypair();

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1209,6 +1209,7 @@ impl Taker {
                         previous_funding_output,
                         maker_funding_tx_value,
                         next_contract_redeemscript,
+                        self.ongoing_swap_state.swap_params.fee_rate,
                     )
                 },
             )

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1189,6 +1189,7 @@ impl Wallet {
                 },
                 funding_amount,
                 &contract_redeemscript,
+                fee_rate,
             );
 
             // self.import_wallet_contract_redeemscript(&contract_redeemscript)?;


### PR DESCRIPTION
This PR replaces a hardcoded fee rate by using a parameter of the function `create_senders_contract_tx`  