### PR TITLE
`feat:` add Mac-OS in our CI/CD

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,29 +1,27 @@
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 
 name: build
 
 jobs:
-
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust:
-          - stable
-          - nightly 
-        features:
-          - default
-          - integration-test
+        os: [ubuntu-latest, macos-latest]
+        rust: [stable, nightly]
+        features: [default, integration-test]
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
       - name: Generate cache key
-        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+        run: echo "${{ matrix.os }}-${{ matrix.rust }}-${{ matrix.features }}" | tee .cache_key
+
       - name: cache
         uses: actions/cache@v2
         with:
@@ -32,11 +30,24 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
       - name: Set default toolchain
         run: rustup default ${{ matrix.rust }}
+
       - name: Set profile
         run: rustup set profile minimal
+
       - name: Update toolchain
         run: rustup update
-      - name: Build
+
+      - name: Install dependencies on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install automake libtool
+
+      - name: Build on macOS with specific target and features
+        if: matrix.os == 'macos-latest'
+        run: cargo build --target=aarch64-apple-darwin --features=build-macos-aarch
+
+      - name: Build on other OSes
+        if: matrix.os != 'macos-latest'
         run: cargo build --features ${{ matrix.features }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,30 +1,43 @@
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 
 name: lint
 
 jobs:
-
   fmt:
     name: rust fmt
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        
       - name: Set default toolchain
         run: rustup default nightly
+
       - name: Set profile
         run: rustup set profile minimal
+
       - name: Add rustfmt
         run: rustup component add rustfmt
+
       - name: Add clippy
         run: rustup component add clippy
+
+      - name: Install dependencies on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install automake libtool
+
       - name: Update toolchain
         run: rustup update
+
       - name: Check fmt
         run: cargo fmt --all -- --check
+
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 
 name: test
@@ -9,32 +9,38 @@ name: test
 jobs:
   test_with_codecov:
     name: Run tests with coverage reporting
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set default toolchain
         run: rustup default nightly
+
       - name: Set profile
         run: rustup set profile minimal
 
-      # Pin grcov to v0.8.2 because of build failure at 0.8.3
       - name: Install grcov
         run: cargo install grcov --force --version 0.8.2
 
-      # Tests are run with code coverage support
+      - name: Install dependencies on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install automake libtool
+
       - name: Run cargo test
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
         run: cargo test --features=integration-test -- --nocapture
+
       - id: coverage
         name: Generate coverage
         uses: actions-rs/grcov@v0.1.5
-      
-      # Upload coverage report
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Changes in the PR:

1.  In the light of issues like https://github.com/citadel-tech/coinswap/issues/127, it would be good to have `macos` jobs in our CI/CD since we are slowly scaling up and it is better to have noticed any build or testing failures for Mac in CI/CD itself rather than waiting for some Mac users to report it to us. This way we have more time window for fixing the error.
2. The integration tests currently fail on MacOS and this has been the case for everyone using MacOS in our team.