### PR TITLE
Use the existing OnionAddress struct

### DIFF
--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -6,13 +6,7 @@ use coinswap::{
     },
     utill::{send_message, setup_logger},
 };
-use serde::{Deserialize, Serialize};
 use tokio::{io::BufReader, net::TcpStream};
-
-#[derive(Serialize, Deserialize, Debug)]
-enum Message {
-    Hello,
-}
 
 /// maker-cli is a command line app to send RPC messages to maker server.
 #[derive(Parser, Debug)]

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -22,7 +22,6 @@ use std::{
 use bitcoin::{absolute::LockTime, Amount};
 use bitcoind::bitcoincore_rpc::RpcApi;
 
-use serde::{Deserialize, Serialize};
 use tokio::{
     io::{AsyncReadExt, BufReader},
     net::{tcp::ReadHalf, TcpListener, TcpStream},
@@ -36,12 +35,6 @@ pub use api::{Maker, MakerBehavior};
 use std::io::Read;
 use tokio::io::AsyncWriteExt;
 use tokio_socks::tcp::Socks5Stream;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct OnionAddress {
-    port: String,
-    onion_addr: String,
-}
 
 use crate::{
     maker::{

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -876,7 +876,7 @@ impl Taker {
         let previous_maker = self.ongoing_swap_state.peer_infos.iter().rev().nth(1);
 
         log::info!("Connecting to {}", this_maker.address);
-        let address = this_maker.address.as_str();
+        let address = this_maker.address.to_string();
         let mut socket = match self.config.connection_type {
             ConnectionType::CLEARNET => TcpStream::connect(address).await?,
             ConnectionType::TOR => Socks5Stream::connect(
@@ -1617,7 +1617,7 @@ impl Taker {
         receivers_multisig_redeemscripts: &[ScriptBuf],
     ) -> Result<(), TakerError> {
         log::info!("Connecting to {}", maker_address);
-        let address = maker_address.as_str();
+        let address = maker_address.to_string();
         let mut socket = match self.config.connection_type {
             ConnectionType::CLEARNET => TcpStream::connect(address).await?,
             ConnectionType::TOR => Socks5Stream::connect(

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -102,7 +102,7 @@ pub(crate) async fn req_sigs_for_sender_once<S: SwapCoin>(
     locktime: u16,
 ) -> Result<ContractSigsForSender, TakerError> {
     log::info!("Connecting to {}", maker_address);
-    let address = maker_address.as_str();
+    let address = maker_address.to_string();
 
     let mut socket = match connection_type {
         ConnectionType::CLEARNET => TcpStream::connect(address).await?,
@@ -184,7 +184,7 @@ pub(crate) async fn req_sigs_for_recvr_once<S: SwapCoin>(
     receivers_contract_txes: &[Transaction],
 ) -> Result<ContractSigsForRecvr, TakerError> {
     log::info!("Connecting to {}", maker_address);
-    let address = maker_address.as_str();
+    let address = maker_address.to_string();
     let mut socket = match connection_type {
         ConnectionType::CLEARNET => TcpStream::connect(address).await?,
         ConnectionType::TOR => Socks5Stream::connect("127.0.0.1:19050", address)
@@ -460,7 +460,7 @@ async fn download_maker_offer_attempt_once(
     addr: &MakerAddress,
     connection_type: ConnectionType,
 ) -> Result<Offer, TakerError> {
-    let address = addr.as_str();
+    let address = addr.to_string();
 
     let mut socket = match connection_type {
         ConnectionType::CLEARNET => TcpStream::connect(address).await?,


### PR DESCRIPTION
The existing OnionAddress struct is unused. We make that used in this PR.

Remove the previous String and use the OnionAddress struct for all Maker Addresses.