### PR TITLE
Use `/tmp` directory for unit tests too. 

### DIFF
--- a/src/utill.rs
+++ b/src/utill.rs
@@ -83,7 +83,7 @@ pub fn get_tor_addrs(hs_dir: &Path) -> String {
 /// Get the system specific home directory.
 /// Uses "/tmp" directory for integration tests
 fn get_home_dir() -> PathBuf {
-    if cfg!(feature = "integration-test") {
+    if cfg!(test) {
         "/tmp".into()
     } else {
         dirs::home_dir().expect("home directory expected")


### PR DESCRIPTION
This allows the datadir location to also switch for unit tests along with integration tests.