### PR TITLE
Add CLI integration tests for makerd/cli, directoryd/cli, and taker-cli apps

### DIFF
--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "integration-test")]
+use std::process::Command;
+use std::str;
+
+#[tokio::test]
+async fn test_cli_integration() {
+    // Start the directory server
+    let output = Command::new("cargo")
+        .args(&["run", "--bin", "directoryd"])
+        .output()
+        .expect("Failed to start directory server");
+    assert!(output.status.success());
+
+    // Start the maker servers
+    let maker_ports = vec![6102, 16102];
+    for port in &maker_ports {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "makerd", "--", "--port", &port.to_string()])
+            .output()
+            .expect("Failed to start maker server");
+        assert!(output.status.success());
+    }
+
+    // Start the taker client
+    let output = Command::new("cargo")
+        .args(&["run", "--bin", "taker-cli", "--", "--amount", "500000", "--makers", "2"])
+        .output()
+        .expect("Failed to start taker client");
+    assert!(output.status.success());
+
+    // Check the output of the taker client
+    let stdout = str::from_utf8(&output.stdout).expect("Failed to read stdout");
+    assert!(stdout.contains("Coinswap completed successfully"));
+
+    // Stop the maker servers
+    for port in &maker_ports {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "makerd", "--", "--port", &port.to_string(), "--stop"])
+            .output()
+            .expect("Failed to stop maker server");
+        assert!(output.status.success());
+    }
+
+    // Stop the directory server
+    let output = Command::new("cargo")
+        .args(&["run", "--bin", "directoryd", "--", "--stop"])
+        .output()
+        .expect("Failed to stop directory server");
+    assert!(output.status.success());
+}

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -11,6 +11,7 @@
 //! The test data also includes the backend bitcoind data-directory, which is useful for observing the blockchain states after a swap.
 //!
 //! Checkout `tests/standard_swap.rs` for example of simple coinswap simulation test between 1 Taker and 2 Makers.
+use std::process::Command;
 use bitcoin::secp256k1::rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{
     collections::HashMap,
@@ -227,6 +228,51 @@ impl TestFramework {
 
     pub fn get_block_count(&self) -> u64 {
         self.bitcoind.client.get_block_count().unwrap()
+    }
+
+    /// Helper function to start the directory server using std::process::Command.
+    pub fn start_directory_server(&self) {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "directoryd"])
+            .output()
+            .expect("Failed to start directory server");
+        assert!(output.status.success());
+    }
+
+    /// Helper function to stop the directory server using std::process::Command.
+    pub fn stop_directory_server(&self) {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "directoryd", "--", "--stop"])
+            .output()
+            .expect("Failed to stop directory server");
+        assert!(output.status.success());
+    }
+
+    /// Helper function to start a maker server using std::process::Command.
+    pub fn start_maker_server(&self, port: u16) {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "makerd", "--", "--port", &port.to_string()])
+            .output()
+            .expect("Failed to start maker server");
+        assert!(output.status.success());
+    }
+
+    /// Helper function to stop a maker server using std::process::Command.
+    pub fn stop_maker_server(&self, port: u16) {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "makerd", "--", "--port", &port.to_string(), "--stop"])
+            .output()
+            .expect("Failed to stop maker server");
+        assert!(output.status.success());
+    }
+
+    /// Helper function to start the taker client using std::process::Command.
+    pub fn start_taker_client(&self, amount: u64, makers: u16) {
+        let output = Command::new("cargo")
+            .args(&["run", "--bin", "taker-cli", "--", "--amount", &amount.to_string(), "--makers", &makers.to_string()])
+            .output()
+            .expect("Failed to start taker client");
+        assert!(output.status.success());
     }
 }
 


### PR DESCRIPTION
Related to #194

Add integration tests for `makerd/cli`, `directoryd/cli`, and `taker-cli` apps using `std::process::Command`.

* **New Integration Tests**
  - Add `tests/cli_integration_tests.rs` to include integration tests for `makerd/cli`, `directoryd/cli`, and `taker-cli` apps.
  - Use `std::process::Command` to call the CLI apps with various commands and arguments.
  - Assert the returned results to ensure the CLI apps work as expected.

* **Helper Functions**
  - Add helper functions in `tests/test_framework/mod.rs` for starting and stopping the directory server, maker server, and taker client using `std::process::Command`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/citadel-tech/coinswap/issues/194?shareId=f6ea693a-7eb8-4016-81e6-9e4027ef1ef7).