### PR TITLE
`improve`: write modified config values back to the maker `config.toml` file

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -204,7 +204,7 @@ impl Maker {
             config.connection_type = connection_type;
         }
 
-        // TODO: Write the modified config back to the file.
+        config.write_to_file(&data_dir.join("config.toml"))?;
 
         log::info!("Initializing wallet sync");
         wallet.sync()?;

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -3,8 +3,9 @@
 use std::{io, path::PathBuf};
 
 use bitcoin::Amount;
+use std::io::Write;
 
-use crate::utill::{get_maker_dir, parse_field, parse_toml, write_default_config, ConnectionType};
+use crate::utill::{get_maker_dir, parse_field, parse_toml, ConnectionType};
 
 /// Maker Configuration, controlling various maker behavior.
 #[derive(Debug, Clone, PartialEq)]
@@ -90,7 +91,7 @@ impl MakerConfig {
         let config_path = config_path.unwrap_or(&default_config_path);
 
         if !config_path.exists() {
-            write_default_maker_config(config_path)?;
+            write_default_maker_config(config_path);
             log::warn!(
                 "Maker config file not found, creating default config file at path: {}",
                 config_path.display()
@@ -193,35 +194,61 @@ impl MakerConfig {
             .unwrap_or(default_config.connection_type),
         })
     }
+
+    // Method to serialize the MakerConfig into a TOML string and write it to a file
+    pub fn write_to_file(&self, path: &PathBuf) -> std::io::Result<()> {
+        let toml_data = format!(
+            r#"
+            port = {}
+            rpc_port = {}
+            heart_beat_interval_secs = {}
+            rpc_ping_interval_secs = {}
+            directory_servers_refresh_interval_secs = {}
+            idle_connection_timeout = {}
+            absolute_fee_sats = {}
+            amount_relative_fee_ppb = {}
+            time_relative_fee_ppb = {}
+            required_confirms = {}
+            min_contract_reaction_time = {}
+            min_size = {}
+            socks_port = {}
+            directory_server_onion_address = "{}"
+            directory_server_clearnet_address = "{}"
+            fidelity_value = {}
+            fidelity_timelock = {}
+            connection_type = "{:?}"
+            "#,
+            self.port,
+            self.rpc_port,
+            self.heart_beat_interval_secs,
+            self.rpc_ping_interval_secs,
+            self.directory_servers_refresh_interval_secs,
+            self.idle_connection_timeout,
+            self.absolute_fee_sats,
+            self.amount_relative_fee_ppb,
+            self.time_relative_fee_ppb,
+            self.required_confirms,
+            self.min_contract_reaction_time,
+            self.min_size,
+            self.socks_port,
+            self.directory_server_onion_address,
+            self.directory_server_clearnet_address,
+            self.fidelity_value,
+            self.fidelity_timelock,
+            self.connection_type,
+        );
+
+        std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(toml_data.as_bytes())?;
+        file.flush()?;
+        Ok(())
+    }
 }
 
-fn write_default_maker_config(config_path: &PathBuf) -> io::Result<()> {
-    let config_string = String::from(
-        "\
-            [maker_config]\n\
-            port = 6102\n\
-            rpc_port = 6103\n\
-            heart_beat_interval_secs = 3\n\
-            rpc_ping_interval_secs = 60\n\
-            directory_servers_refresh_interval_secs = 43200\n\
-            idle_connection_timeout = 300\n\
-            onion_addrs = myhiddenserviceaddress.onion\n\
-            absolute_fee_sats = 1000\n\
-            amount_relative_fee_ppb = 10000000\n\
-            time_relative_fee_ppb = 100000\n\
-            required_confirms = 1\n\
-            min_contract_reaction_time = 48\n\
-            min_size = 10000\n\
-            socks_port = 19050\n\
-            directory_server_onion_address = directoryhiddenserviceaddress.onion:8080\n\
-            directory_server_clearnet_address = 127.0.0.1:8080\n\
-            connection_type = tor
-            ",
-    );
-
-    write_default_config(config_path, config_string)?;
-
-    Ok(())
+fn write_default_maker_config(config_path: &PathBuf) {
+    let config = MakerConfig::default();
+    config.write_to_file(config_path).unwrap();
 }
 
 #[cfg(test)]

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -7,7 +7,7 @@ use crate::{
     market::rpc::start_rpc_server_thread,
     utill::{
         get_dns_dir, get_tor_addrs, monitor_log_for_completion, parse_field, parse_toml,
-        write_default_config, ConnectionType,
+        ConnectionType,
     },
 };
 
@@ -166,11 +166,14 @@ fn write_default_directory_config(config_path: &PathBuf) -> Result<(), Directory
             port = 8080\n\
             socks_port = 19060\n\
             connection_type = tor\n\
-            rpc_port= 4321\n\
+            rpc_port = 4321\n\
             ",
     );
-
-    Ok(write_default_config(config_path, config_string)?)
+    std::fs::create_dir_all(config_path.parent().expect("Path should NOT be root!"))?;
+    let mut file = File::create(config_path)?;
+    file.write_all(config_string.as_bytes())?;
+    file.flush()?;
+    Ok(())
 }
 
 pub fn start_address_writer_thread(

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -223,6 +223,8 @@ impl Taker {
             config.connection_type = connection_type;
         }
 
+        config.write_to_file(&data_dir.join("config.toml"))?;
+
         log::info!("Initializing wallet sync");
         wallet.sync()?;
         log::info!("Completed wallet sync");

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -3,9 +3,8 @@
 //!  Represents the configuration options for the Taker module, controlling behaviors
 //! such as refund locktime, connection attempts, sleep delays, and timeouts.
 
-use std::{io, path::PathBuf};
-
-use crate::utill::{get_taker_dir, parse_field, parse_toml, write_default_config, ConnectionType};
+use crate::utill::{get_taker_dir, parse_field, parse_toml, ConnectionType};
+use std::{io, io::Write, path::PathBuf};
 /// Taker configuration with refund, connection, and sleep settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TakerConfig {
@@ -73,7 +72,8 @@ impl TakerConfig {
         let config_path = config_path.unwrap_or(&default_config_path);
 
         if !config_path.exists() {
-            write_default_taker_config(config_path);
+            let config = TakerConfig::default();
+            config.write_to_file(config_path).unwrap();
             log::warn!(
                 "Taker config file not found, creating default config file at path: {}",
                 config_path.display()
@@ -88,7 +88,7 @@ impl TakerConfig {
 
         let taker_config_section = section.get("taker_config").cloned().unwrap_or_default();
 
-        Ok(Self {
+        Ok(TakerConfig {
             refund_locktime: parse_field(
                 taker_config_section.get("refund_locktime"),
                 default_config.refund_locktime,
@@ -166,31 +166,52 @@ impl TakerConfig {
             .unwrap_or(default_config.rpc_port),
         })
     }
-}
 
-fn write_default_taker_config(config_path: &PathBuf) {
-    let config_string = String::from(
-        "\
-                        [taker_config]\n\
-                        refund_locktime = 48\n\
-                        refund_locktime_step = 48\n\
-                        first_connect_attempts = 5\n\
-                        first_connect_sleep_delay_sec = 1\n\
-                        first_connect_attempt_timeout_sec = 60\n\
-                        reconnect_attempts = 3200\n\
-                        reconnect_short_sleep_delay = 10\n\
-                        reconnect_long_sleep_delay = 60\n\
-                        short_long_sleep_delay_transition = 60\n\
-                        reconnect_attempt_timeout_sec = 300\n\
-                        port = 8000\n\
-                        socks_port = 19050\n\
-                        directory_server_onion_address = directoryhiddenserviceaddress.onion:8080\n\
-                        directory_server_clearnet_address = 127.0.0.1:8080\n\
-                        connection_type = tor\n\
-                        rpc_port = 8081\n
-                        ",
-    );
-    write_default_config(config_path, config_string).unwrap();
+    // Method to manually serialize the Taker Config into a TOML string
+    pub fn write_to_file(&self, path: &PathBuf) -> std::io::Result<()> {
+        let toml_data = format!(
+            r#"
+            [taker_config]
+            refund_locktime = {}
+            refund_locktime_step = {}
+            first_connect_attempts = {}
+            first_connect_sleep_delay_sec = {}
+            first_connect_attempt_timeout_sec = {}
+            reconnect_attempts = {}
+            reconnect_short_sleep_delay = {}
+            reconnect_long_sleep_delay = {}
+            short_long_sleep_delay_transition = {}
+            reconnect_attempt_timeout_sec = {}
+            port = {}
+            socks_port = {}
+            directory_server_onion_address = {}
+            directory_server_clearnet_address = {}
+            connection_type = "{:?}"
+            rpc_port = {}
+            "#,
+            self.refund_locktime,
+            self.refund_locktime_step,
+            self.first_connect_attempts,
+            self.first_connect_sleep_delay_sec,
+            self.first_connect_attempt_timeout_sec,
+            self.reconnect_attempts,
+            self.reconnect_short_sleep_delay,
+            self.reconnect_long_sleep_delay,
+            self.short_long_sleep_delay_transition,
+            self.reconnect_attempt_timeout_sec,
+            self.port,
+            self.socks_port,
+            self.directory_server_onion_address,
+            self.directory_server_clearnet_address,
+            self.connection_type,
+            self.rpc_port
+        );
+        std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(toml_data.as_bytes())?;
+        file.flush()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -335,17 +335,6 @@ pub fn parse_field<T: std::str::FromStr>(value: Option<&String>, default: T) -> 
     }
 }
 
-/// Function to write data to default toml files
-pub fn write_default_config(path: &PathBuf, toml_data: String) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut file = File::create(path)?;
-    file.write_all(toml_data.as_bytes())?;
-    file.flush()?;
-    Ok(())
-}
-
 /// Function to check if tor log contains a pattern
 pub fn monitor_log_for_completion(log_file: &PathBuf, pattern: &str) -> io::Result<()> {
     let mut last_size = 0;


### PR DESCRIPTION
```rs
        let mut config = MakerConfig::new(Some(&data_dir.join("config.toml")))?;

        if let Some(port) = port {
            config.port = port;
        }

        if let Some(rpc_port) = rpc_port {
            config.rpc_port = rpc_port;
        }

        if let Some(socks_port) = socks_port {
            config.socks_port = socks_port;
        }

        if let Some(connection_type) = connection_type {
            config.connection_type = connection_type;
        }
```

Maker config parameters like `port`, `rpc_port`, `socks_port`, `connection_type` when updated with new values, does NOT reflect in the `config.toml` file.
This PR aims to fix that.