### PR TITLE
Improving error handling in the market app

### DIFF
--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -100,7 +100,7 @@ fn network_bootstrap(
                 let maker_hs_path_str =
                     format!("/tmp/tor-rust-maker{}/hs-dir/hostname", maker.config.port);
                 let maker_hs_path = PathBuf::from(maker_hs_path_str);
-                let mut maker_file = fs::File::open(&maker_hs_path).unwrap();
+                let mut maker_file = fs::File::open(maker_hs_path).unwrap();
                 let mut maker_onion_addr: String = String::new();
                 maker_file.read_to_string(&mut maker_onion_addr).unwrap();
                 maker_onion_addr.pop();

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -25,7 +25,9 @@ use crate::utill::{
 /// Represents errors that can occur during directory server operations.
 #[derive(Debug)]
 pub enum DirectoryServerError {
-    Other(&'static str),
+    PoissonError(&'static str),
+    Socks5ConnectionError(String),
+    IO(std::io::Error),
 }
 
 /// Directory Configuration,
@@ -118,9 +120,15 @@ impl DirectoryServer {
         let mut flag = self
             .shutdown
             .write()
-            .map_err(|_| DirectoryServerError::Other("Rwlock write error!"))?;
+            .map_err(|_| DirectoryServerError::PoissonError("Rwlock write error!"))?;
         *flag = true;
         Ok(())
+    }
+}
+
+impl From<std::io::Error> for DirectoryServerError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IO(value)
     }
 }
 

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -177,43 +177,41 @@ pub fn fetch_addresses_from_dns(
     // TODO: Make the communication in serde_encoded bytes.
 
     loop {
-        let result: Result<Vec<MakerAddress>, DirectoryServerError> = (async {
-            let mut stream = match connection_type {
-                ConnectionType::CLEARNET => TcpStream::connect(directory_server_address.as_str())
-                    .await
-                    .unwrap(),
-                ConnectionType::TOR => Socks5Stream::connect(
-                    format!("127.0.0.1:{}", socks_port.unwrap_or(19050)).as_str(),
-                    directory_server_address.as_str(),
-                )
-                .await
-                .map_err(|e| {
-                    DirectoryServerError::Socks5ConnectionError(format!(
-                        "Issue with fetching maker address from directory server: {}",
-                        e
-                    ))
-                })?
-                .into_inner(),
-            };
+        let mut stream = match connection_type {
+            ConnectionType::CLEARNET => TcpStream::connect(directory_server_address.as_str())?,
+            ConnectionType::TOR => {
+                let socket_addrs = format!("127.0.0.1:{}", socks_port.expect("Tor port expected"));
+                Socks5Stream::connect(socket_addrs, directory_server_address.as_str())?.into_inner()
+            }
+        };
 
-            let request_line = "GET\n";
-            stream.write_all(request_line.as_bytes()).await?; // Are custom messages required here ?
+        stream.set_read_timeout(Some(NET_TIMEOUT))?;
+        stream.set_write_timeout(Some(NET_TIMEOUT))?;
+        stream.flush()?;
 
-            let mut response = String::new();
-            stream.read_to_string(&mut response).await?;
+        // TODO: Handle timeout cases like the Taker/Maker comms, with attempt count and variable delays.
+        if let Err(e) = stream
+            .write_all("GET\n".as_bytes())
+            .and_then(|_| stream.flush())
+        {
+            log::error!("Error sending GET request to DNS {}.\nRe-attempting...", e);
+            thread::sleep(GLOBAL_PAUSE);
+            continue;
+        }
 
-            let addresses: Vec<MakerAddress> = response
-                .lines()
-                .map(|addr| MakerAddress::new(addr.to_string()).expect("Malformed maker address"))
-                .collect();
+        let mut response = String::new();
 
-            log::info!("Maker addresses received from DNS: {:?}", addresses);
+        if let Err(e) = stream.read_to_string(&mut response) {
+            log::error!("Error reading DNS response: {}. \nRe-attempting...", e);
+            thread::sleep(GLOBAL_PAUSE);
+            continue;
+        }
 
-            Ok(addresses)
-        })
-        .await;
-
-        match result {
+        match response
+            .lines()
+            .map(MakerAddress::new)
+            .collect::<Result<Vec<MakerAddress>, _>>()
+        {
             Ok(addresses) => {
                 if addresses.len() < number_of_makers {
                     log::info!(


### PR DESCRIPTION
The PR aims to improve error handling inside the market app. Currently, errors are handled by a generic 'other' inside the DirectoryServerError enum. Function call specific error types that marker app has to handle will be added. Addresses Issue #238 