### PR TITLE
nit: fix doc lint too long paragraph

### DIFF
--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -264,7 +264,9 @@ pub struct SenderContractTxInfo {
     pub funding_amount: Amount,
 }
 
-/// This message is sent by a Maker to a Taker, which is a request to the Taker for gathering signatures for the Maker as both Sender and Receiver of Coinswaps.
+/// This message is sent by a Maker to a Taker, which is a request to the Taker for gathering signatures
+/// for the Maker as both Sender and Receiver of Coinswaps.
+///
 /// This message is sent by a Maker after a [`ProofOfFunding`] has been received.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractSigsAsRecvrAndSender {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -57,6 +57,7 @@ use crate::{
 
 /// Swap specific parameters. These are user's policy and can differ among swaps.
 /// SwapParams govern the criteria to find suitable set of makers from the offerbook.
+///
 /// If no maker matches with a given SwapParam, that coinswap round will fail.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SwapParams {
@@ -135,6 +136,7 @@ pub enum TakerBehavior {
 
 /// The Taker structure that performs bulk of the coinswap protocol. Taker connects
 /// to multiple Makers and send protocol messages sequentially to them. The communication
+///
 /// sequence and corresponding SwapCoin infos are stored in `ongoing_swap_state`.
 pub struct Taker {
     wallet: Wallet,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -193,8 +193,9 @@ pub fn check_and_apply_maker_private_keys<S: SwapCoin>(
 }
 
 /// Generate The Maker's Multisig and HashLock keys and respective nonce values.
-/// Nonce values are random integers and resulting Pubkeys are derived by tweaking the
-/// Maker's advertised Pubkey with these two nonces.
+/// Nonce values are random integers and resulting Pubkeys are derived by tweaking
+///
+/// the Maker's advertised Pubkey with these two nonces.
 pub fn generate_maker_keys(
     tweakable_point: &PublicKey,
     count: u32,


### PR DESCRIPTION
Fixes the newly introduced clippy lint: [too_long_first_doc_paragraph](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph)