### PR TITLE
Take `TakerConfig` from struct instead of having parameter for it.

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -169,16 +169,7 @@ fn main() {
             println!("{:?}", address);
         }
         Commands::SyncOfferBook => {
-            let taker2 = Taker::init(
-                args.data_directory,
-                Some(args.wallet_name),
-                Some(rpc_config),
-                TakerBehavior::Normal,
-                Some(connection_type),
-            )
-            .unwrap();
-            let config = taker2.config.clone();
-            taker.sync_offerbook(&config, args.maker_count).unwrap();
+            taker.sync_offerbook(args.maker_count).unwrap();
         }
         Commands::DoCoinswap => {
             taker.do_coinswap(swap_params).unwrap();


### PR DESCRIPTION
https://github.com/citadel-tech/coinswap/blob/39c9d6548a692d3e1178b809ca24e86c98723bd6/src/taker/api.rs#L1912

* Here , we are seperately taking `TakerConfig` in the function body which is also present in `Taker` struct.
*  And this api is a method of `Taker` -> so we can just take `config` from `self`. 
