### PR TITLE
`ContractTxInfo` construction into helper functions in Signature Request Methods

### DIFF
--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -92,6 +92,30 @@ pub fn handshake_maker(socket: &mut TcpStream) -> Result<(), TakerError> {
     }
 }
 
+fn build_contract_tx_info_for_sender<S: SwapCoin>(
+    maker_multisig_nonces: &[SecretKey],
+    maker_hashlock_nonces: &[SecretKey],
+    outgoing_swapcoins: &[S],
+) -> Vec<ContractTxInfoForSender> {
+    maker_multisig_nonces
+        .iter()
+        .zip(maker_hashlock_nonces.iter())
+        .zip(outgoing_swapcoins.iter())
+        .map(
+            |((&multisig_key_nonce, &hashlock_key_nonce), outgoing_swapcoin)| {
+                ContractTxInfoForSender {
+                    multisig_nonce: multisig_key_nonce,
+                    hashlock_nonce: hashlock_key_nonce,
+                    timelock_pubkey: outgoing_swapcoin.get_timelock_pubkey(),
+                    senders_contract_tx: outgoing_swapcoin.get_contract_tx(),
+                    multisig_redeemscript: outgoing_swapcoin.get_multisig_redeemscript(),
+                    funding_input_value: outgoing_swapcoin.get_funding_amount(),
+                }
+            },
+        )
+        .collect()
+}
+
 /// Request signatures for sender side of the hop. Attempt once.
 pub(crate) fn req_sigs_for_sender_once<S: SwapCoin>(
     socket: &mut TcpStream,
@@ -108,23 +132,11 @@ pub(crate) fn req_sigs_for_sender_once<S: SwapCoin>(
     );
 
     // TODO: Take this construction out of function body.
-    let txs_info = maker_multisig_nonces
-        .iter()
-        .zip(maker_hashlock_nonces.iter())
-        .zip(outgoing_swapcoins.iter())
-        .map(
-            |((&multisig_key_nonce, &hashlock_key_nonce), outgoing_swapcoin)| {
-                ContractTxInfoForSender {
-                    multisig_nonce: multisig_key_nonce,
-                    hashlock_nonce: hashlock_key_nonce,
-                    timelock_pubkey: outgoing_swapcoin.get_timelock_pubkey(),
-                    senders_contract_tx: outgoing_swapcoin.get_contract_tx(),
-                    multisig_redeemscript: outgoing_swapcoin.get_multisig_redeemscript(),
-                    funding_input_value: outgoing_swapcoin.get_funding_amount(),
-                }
-            },
-        )
-        .collect::<Vec<ContractTxInfoForSender>>();
+    let txs_info = build_contract_tx_info_for_sender(
+        maker_multisig_nonces,
+        maker_hashlock_nonces,
+        outgoing_swapcoins,
+    );
 
     send_message(
         socket,
@@ -172,6 +184,20 @@ pub(crate) fn req_sigs_for_sender_once<S: SwapCoin>(
     Ok(contract_sigs_for_sender)
 }
 
+fn build_contract_tx_info_for_recvr<S: SwapCoin>(
+    incoming_swapcoins: &[S],
+    receivers_contract_txes: &[Transaction],
+) -> Vec<ContractTxInfoForRecvr> {
+    incoming_swapcoins
+        .iter()
+        .zip(receivers_contract_txes.iter())
+        .map(|(swapcoin, receivers_contract_tx)| ContractTxInfoForRecvr {
+            multisig_redeemscript: swapcoin.get_multisig_redeemscript(),
+            contract_tx: receivers_contract_tx.clone(),
+        })
+        .collect()
+}
+
 /// Request signatures for receiver side of the hop. Attempt once.
 pub(crate) fn req_sigs_for_recvr_once<S: SwapCoin>(
     socket: &mut TcpStream,
@@ -181,19 +207,11 @@ pub(crate) fn req_sigs_for_recvr_once<S: SwapCoin>(
     log::info!("Connecting to {}", socket.peer_addr()?);
     handshake_maker(socket)?;
 
+    let txs = build_contract_tx_info_for_recvr(incoming_swapcoins, receivers_contract_txes);
     // TODO: Take the message construction out of function body.
     send_message(
         socket,
-        &TakerToMakerMessage::ReqContractSigsForRecvr(ReqContractSigsForRecvr {
-            txs: incoming_swapcoins
-                .iter()
-                .zip(receivers_contract_txes.iter())
-                .map(|(swapcoin, receivers_contract_tx)| ContractTxInfoForRecvr {
-                    multisig_redeemscript: swapcoin.get_multisig_redeemscript(),
-                    contract_tx: receivers_contract_tx.clone(),
-                })
-                .collect::<Vec<ContractTxInfoForRecvr>>(),
-        }),
+        &TakerToMakerMessage::ReqContractSigsForRecvr(ReqContractSigsForRecvr { txs }),
     )?;
 
     let msg_bytes = read_message(socket)?;


### PR DESCRIPTION
This PR refactors the construction of `ContractTxInfoForSender` and `ContractTxInfoForRecvr` into separate helper functions:

- [x] `build_contract_tx_info_for_sender`: Handles the construction of the `txs_info` vector in the `req_sigs_for_sender_once` function. This encapsulates the logic for preparing the sender's contract transaction information, reducing clutter in the main function.

- [x] `build_contract_tx_info_for_recvr`: Constructs the `txs` vector in the `req_sigs_for_recvr_once` function. Simplifies the code in the receiver's signature request method, making it easier to understand and maintain.

TLDR:

Solves 2 TODOs:
1. Take this construction out of function body.
2. Take the message construction out of the function body.