### PR TITLE
Handle Errors in Apps and DNS Server

### DIFF
--- a/src/bin/directoryd.rs
+++ b/src/bin/directoryd.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use coinswap::{
-    market::directory::{start_directory_server, DirectoryServer},
+    market::directory::{start_directory_server, DirectoryServer, DirectoryServerError},
     utill::{read_connection_network_string, setup_logger},
 };
 use std::{path::PathBuf, sync::Arc};
@@ -17,14 +17,16 @@ struct Cli {
     data_directory: Option<PathBuf>,
 }
 
-fn main() {
+fn main() -> Result<(), DirectoryServerError> {
     setup_logger(log::LevelFilter::Info);
 
     let args = Cli::parse();
 
-    let conn_type = read_connection_network_string(&args.network).unwrap();
+    let conn_type = read_connection_network_string(&args.network)?;
 
-    let directory = Arc::new(DirectoryServer::new(args.data_directory, Some(conn_type)).unwrap());
+    let directory = Arc::new(DirectoryServer::new(args.data_directory, Some(conn_type))?);
 
-    start_directory_server(directory).expect("");
+    start_directory_server(directory)?;
+
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! High-level network and protocol errors.
 
+use std::error::Error;
+
 use bitcoin::Amount;
 
 use crate::protocol::error::ContractError;
@@ -12,6 +14,19 @@ pub enum NetError {
     ConnectionTimedOut,
     InvalidNetworkAddress,
     Cbor(serde_cbor::Error),
+    InvalidAppNetwork,
+}
+
+impl std::fmt::Display for NetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Error for NetError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
 }
 
 impl From<std::io::Error> for NetError {

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -90,7 +90,7 @@ impl MakerConfig {
         let config_path = config_path.unwrap_or(&default_config_path);
 
         if !config_path.exists() {
-            write_default_maker_config(config_path);
+            write_default_maker_config(config_path)?;
             log::warn!(
                 "Maker config file not found, creating default config file at path: {}",
                 config_path.display()
@@ -195,7 +195,7 @@ impl MakerConfig {
     }
 }
 
-fn write_default_maker_config(config_path: &PathBuf) {
+fn write_default_maker_config(config_path: &PathBuf) -> io::Result<()> {
     let config_string = String::from(
         "\
             [maker_config]\n\
@@ -219,7 +219,9 @@ fn write_default_maker_config(config_path: &PathBuf) {
             ",
     );
 
-    write_default_config(config_path, config_string).unwrap();
+    write_default_config(config_path, config_string)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -20,10 +20,8 @@ pub enum MakerError {
     General(&'static str),
     MutexPossion,
     Secp(secp256k1::Error),
-    ContractError(ContractError),
     Wallet(WalletError),
     Net(NetError),
-    Deserialize(serde_cbor::Error),
     SpecialBehaviour(MakerBehavior),
     Protocol(ProtocolError),
 }
@@ -36,7 +34,7 @@ impl From<std::io::Error> for MakerError {
 
 impl From<serde_cbor::Error> for MakerError {
     fn from(value: serde_cbor::Error) -> Self {
-        Self::Deserialize(value)
+        Self::Net(NetError::Cbor(value))
     }
 }
 
@@ -66,7 +64,7 @@ impl From<secp256k1::Error> for MakerError {
 
 impl From<ContractError> for MakerError {
     fn from(value: ContractError) -> Self {
-        Self::ContractError(value)
+        Self::Protocol(ProtocolError::from(value))
     }
 }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -408,7 +408,7 @@ impl Maker {
             Amount::from_sat(incoming_amount),
             read_contract_locktime(
                 &message.confirmed_funding_txes[0].contract_redeemscript
-            ).unwrap(),
+            )?,
             Amount::from_sat(outgoing_amount),
             message.next_locktime
         );
@@ -661,18 +661,13 @@ fn unexpected_recovery(maker: Arc<Maker>) -> Result<(), MakerError> {
         {
             let contract_timelock = og_sc.get_timelock()?;
             let contract = og_sc.get_fully_signed_contract_tx()?;
-            let next_internal_address = &maker
-                .wallet
-                .read()
-                .unwrap()
-                .get_next_internal_addresses(1)
-                .unwrap()[0];
+            let next_internal_address = &maker.wallet.read()?.get_next_internal_addresses(1)?[0];
             let time_lock_spend = og_sc.create_timelock_spend(next_internal_address)?;
             outgoings.push((
                 (og_sc.get_multisig_redeemscript(), contract),
                 (contract_timelock, time_lock_spend),
             ));
-            let incoming_contract = ic_sc.get_fully_signed_contract_tx().unwrap();
+            let incoming_contract = ic_sc.get_fully_signed_contract_tx()?;
             incomings.push((ic_sc.get_multisig_redeemscript(), incoming_contract));
         }
         // Spawn a separate thread to wait for contract maturity and broadcasting timelocked.

--- a/src/market/rpc/server.rs
+++ b/src/market/rpc/server.rs
@@ -8,50 +8,54 @@ use std::{
 };
 
 use crate::{
-    market::directory::DirectoryServer,
+    error::NetError,
+    market::directory::{DirectoryServer, DirectoryServerError},
     utill::{read_message, send_message},
 };
 
 use super::{RpcMsgReq, RpcMsgResp};
 
-fn handle_request(socket: &mut TcpStream, address: Arc<RwLock<HashSet<String>>>) {
-    let req_bytes = read_message(socket).unwrap();
-    let rpc_request: RpcMsgReq = serde_cbor::from_slice(&req_bytes).unwrap();
+fn handle_request(
+    socket: &mut TcpStream,
+    address: Arc<RwLock<HashSet<String>>>,
+) -> Result<(), DirectoryServerError> {
+    let req_bytes = read_message(socket)?;
+    let rpc_request: RpcMsgReq = serde_cbor::from_slice(&req_bytes).map_err(NetError::Cbor)?;
 
     match rpc_request {
         RpcMsgReq::ListAddresses => {
             log::info!("RPC request received: {:?}", rpc_request);
-            let resp = RpcMsgResp::ListAddressesResp(address.read().unwrap().clone());
+            let resp = RpcMsgResp::ListAddressesResp(address.read()?.clone());
             if let Err(e) = send_message(socket, &resp) {
                 log::info!("Error sending RPC response {:?}", e);
             };
         }
     }
+
+    Ok(())
 }
 
-pub fn start_rpc_server_thread(directory: Arc<DirectoryServer>) {
+pub fn start_rpc_server_thread(
+    directory: Arc<DirectoryServer>,
+) -> Result<(), DirectoryServerError> {
     let rpc_port = directory.rpc_port;
     let rpc_socket = format!("127.0.0.1:{}", rpc_port);
-    let listener = Arc::new(TcpListener::bind(&rpc_socket).unwrap());
+    let listener = Arc::new(TcpListener::bind(&rpc_socket)?);
     log::info!(
         "[{}] RPC socket binding successful at {}",
         directory.rpc_port,
         rpc_socket
     );
 
-    listener.set_nonblocking(true).unwrap();
+    listener.set_nonblocking(true)?;
 
     while !directory.shutdown.load(Relaxed) {
         match listener.accept() {
             Ok((mut stream, addr)) => {
                 log::info!("Got RPC request from: {}", addr);
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(20)))
-                    .unwrap();
-                stream
-                    .set_write_timeout(Some(Duration::from_secs(20)))
-                    .unwrap();
-                handle_request(&mut stream, directory.addresses.clone());
+                stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+                stream.set_write_timeout(Some(Duration::from_secs(20)))?;
+                handle_request(&mut stream, directory.addresses.clone())?;
             }
             Err(e) => {
                 if e.kind() == ErrorKind::WouldBlock {
@@ -65,4 +69,6 @@ pub fn start_rpc_server_thread(directory: Arc<DirectoryServer>) {
         }
         sleep(Duration::from_secs(3));
     }
+
+    Ok(())
 }

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -15,7 +15,7 @@ use bitcoin::{
         rand::{rngs::OsRng, RngCore},
         Secp256k1, SecretKey,
     },
-    Network, PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
+    PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
 };
 use log::LevelFilter;
 use log4rs::{
@@ -165,7 +165,7 @@ pub fn send_message(
     socket_writer: &mut TcpStream,
     message: &impl serde::Serialize,
 ) -> Result<(), NetError> {
-    let msg_bytes = serde_cbor::ser::to_vec(message).map_err(NetError::Cbor)?;
+    let msg_bytes = serde_cbor::ser::to_vec(message)?;
     let msg_len = (msg_bytes.len() as u32).to_be_bytes();
     let mut to_send = Vec::with_capacity(msg_bytes.len() + msg_len.len());
     to_send.extend(msg_len);
@@ -294,21 +294,6 @@ pub fn redeemscript_to_scriptpubkey(redeemscript: &ScriptBuf) -> ScriptBuf {
     .unwrap();
     //p2wsh address
     ScriptBuf::new_witness_program(&witness_program)
-}
-
-/// Converts a byte vector to a hexadecimal string representation.
-pub fn to_hex(bytes: &[u8]) -> String {
-    let hex_chars: Vec<char> = "0123456789abcdef".chars().collect();
-    let mut hex_string = String::new();
-
-    for &byte in bytes {
-        let high_nibble = (byte >> 4) & 0xf;
-        let low_nibble = byte & 0xf;
-        hex_string.push(hex_chars[high_nibble as usize]);
-        hex_string.push(hex_chars[low_nibble as usize]);
-    }
-
-    hex_string
 }
 
 /// Parse TOML file into key-value pair.
@@ -458,10 +443,10 @@ pub fn compute_checksum(descriptor: &str) -> Result<String, WalletError> {
 }
 
 /// Parse the proxy (Socket:Port) argument from the cli input.
-pub fn parse_proxy_auth(s: &str) -> Result<(String, String), String> {
+pub fn parse_proxy_auth(s: &str) -> Result<(String, String), NetError> {
     let parts: Vec<_> = s.split(':').collect();
     if parts.len() != 2 {
-        return Err("Invalid format".to_string());
+        return Err(NetError::InvalidNetworkAddress);
     }
 
     let user = parts[0].to_string();
@@ -470,22 +455,12 @@ pub fn parse_proxy_auth(s: &str) -> Result<(String, String), String> {
     Ok((user, passwd))
 }
 
-/// Parse the network string for Bitcoin Backend. Used in CLI apps.
-pub fn read_bitcoin_network_string(network: &str) -> Result<Network, String> {
-    match network {
-        "regtest" => Ok(Network::Regtest),
-        "mainnet" => Ok(Network::Bitcoin),
-        "signet" => Ok(Network::Signet),
-        _ => Err("Invalid Bitcoin Network".to_string()),
-    }
-}
-
 /// Parse the network string for Connection Type. Used in CLI apps.
-pub fn read_connection_network_string(network: &str) -> Result<ConnectionType, String> {
+pub fn read_connection_network_string(network: &str) -> Result<ConnectionType, NetError> {
     match network {
         "clearnet" => Ok(ConnectionType::CLEARNET),
         "tor" => Ok(ConnectionType::TOR),
-        _ => Err("Invalid Connection Network".to_string()),
+        _ => Err(NetError::InvalidAppNetwork),
     }
 }
 
@@ -496,7 +471,7 @@ mod tests {
     use bitcoin::{
         blockdata::{opcodes::all, script::Builder},
         secp256k1::Scalar,
-        PubkeyHash, Txid,
+        PubkeyHash,
     };
 
     use serde_json::json;
@@ -554,27 +529,6 @@ mod tests {
             convert_json_rpc_bitcoin_to_satoshis(&amount),
             1_234_567_812_345_678
         );
-    }
-    #[test]
-    fn test_to_hex() {
-        let mut txid_test_vector = [
-            vec![
-                0x5a, 0x4e, 0xbf, 0x66, 0x82, 0x2b, 0x0b, 0x2d, 0x56, 0xbd, 0x9d, 0xc6, 0x4e, 0xce,
-                0x0b, 0xc3, 0x8e, 0xe7, 0x84, 0x4a, 0x23, 0xff, 0x1d, 0x73, 0x20, 0xa8, 0x8c, 0x5f,
-                0xdb, 0x2a, 0xd3, 0xe2,
-            ],
-            vec![
-                0x6d, 0x69, 0x37, 0x2e, 0x3e, 0x59, 0x28, 0xa7, 0x3c, 0x98, 0x38, 0x18, 0xbd, 0x19,
-                0x27, 0xe1, 0x90, 0x8f, 0x51, 0xa6, 0xc2, 0xcd, 0x32, 0x58, 0x98, 0xb3, 0xb4, 0x16,
-                0x90, 0xd4, 0xfa, 0x7b,
-            ],
-        ];
-        for i in txid_test_vector.iter_mut() {
-            let txid1 = Txid::from_str(to_hex(i).as_str()).unwrap();
-            i.reverse();
-            let txid2 = Txid::from_slice(i).unwrap();
-            assert_eq!(txid1, txid2);
-        }
     }
     #[test]
     fn test_redeemscript_to_scriptpubkey_custom() {

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -6,7 +6,7 @@ use crate::protocol::error::ContractError;
 /// Enum for handling wallet-related errors.
 #[derive(Debug)]
 pub enum WalletError {
-    File(std::io::Error),
+    IO(std::io::Error),
     Cbor(serde_cbor::Error),
     Rpc(bitcoind::bitcoincore_rpc::Error),
     Protocol(String),
@@ -22,7 +22,7 @@ pub enum WalletError {
 
 impl From<std::io::Error> for WalletError {
     fn from(e: std::io::Error) -> Self {
-        Self::File(e)
+        Self::IO(e)
     }
 }
 

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -145,7 +145,7 @@ impl TestFramework {
         );
         let directory_server_instance_clone = directory_server_instance.clone();
         thread::spawn(move || {
-            start_directory_server(directory_server_instance_clone).expect("TODO: panic message");
+            start_directory_server(directory_server_instance_clone).unwrap();
         });
 
         // Translate a RpcConfig from the test framework.


### PR DESCRIPTION
Fixes #238 #239

Overrides #241 and #247.

AppError is removed as its redundant wrapper. Instead, each app is returning their module-specific error types.

DNS Error has more variants now to cover all the necessary errors. 