### PR TITLE
update Fidelity test and make related changes

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -16,10 +16,9 @@ use std::{
 
 use bip39::Mnemonic;
 use bitcoin::{
-    absolute::LockTime,
     ecdsa::Signature,
     secp256k1::{self, Secp256k1},
-    Amount, OutPoint, PublicKey, ScriptBuf, Transaction,
+    OutPoint, PublicKey, ScriptBuf, Transaction,
 };
 use bitcoind::bitcoincore_rpc::RpcApi;
 use std::time::Duration;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -239,25 +239,6 @@ impl Maker {
         &self.wallet
     }
 
-    /// Generates Fidelity bond from existing utxos
-    /// Errors if not enough balance
-    pub fn create_fidelity_bond(&self) -> Result<(), MakerError> {
-        let mut wallet = self.wallet.write()?;
-        log::info!("Creating Fidelity Bond.");
-        let fidelity_index = wallet.create_fidelity(
-            Amount::from_sat(self.config.fidelity_value),
-            LockTime::from_height(self.config.fidelity_timelock).unwrap(),
-        )?;
-
-        log::info!("Created new fidelity bond at index: {} ", fidelity_index);
-        let bond = wallet
-            .get_fidelity_bonds()
-            .get(&fidelity_index)
-            .expect("bond expected");
-        log::info!("Bond: {:?}", bond);
-        Ok(())
-    }
-
     /// Checks consistency of the [ProofOfFunding] message and return the Hashvalue
     /// used in hashlock transaction.
     pub fn verify_proof_of_funding(&self, message: &ProofOfFunding) -> Result<Hash160, MakerError> {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     protocol::messages::TakerToMakerMessage,
     utill::{monitor_log_for_completion, read_message, send_message, ConnectionType},
-    wallet::{FidelityError, WalletError},
+    wallet::WalletError,
 };
 
 use crate::maker::error::MakerError;
@@ -228,10 +228,10 @@ fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), Ma
                 // Wait for sufficient fund to create fidelity bond.
                 // Hard error if fidelity still can't be created.
                 Err(e) => {
-                    if let WalletError::Fidelity(FidelityError::InsufficientFund {
+                    if let WalletError::InsufficientFund {
                         available,
                         required,
-                    }) = e
+                    } = e
                     {
                         log::warn!("Insufficient fund to create fidelity bond.");
                         let amount = required - available;

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -952,12 +952,9 @@ impl Wallet {
 
     /// Refreshes the offer maximum size cache based on the current wallet's unspent transaction outputs (UTXOs).
     pub fn refresh_offer_maxsize_cache(&mut self) -> Result<(), WalletError> {
-        let all_utxos = self.get_all_utxo()?;
-        let mut utxos = self.list_descriptor_utxo_spend_info(Some(&all_utxos))?;
-        let mut swap_coin_utxo = self.list_swap_coin_utxo_spend_info(Some(&all_utxos))?;
-        utxos.append(&mut swap_coin_utxo);
-        let balance: Amount = utxos.iter().fold(Amount::ZERO, |acc, u| acc + u.0.amount);
-        self.store.offer_maxsize = balance.to_sat();
+        let swap_balance = self.balance_swap_coins(None)?;
+        let seed_balance = self.balance_descriptor_utxo(None)?;
+        self.store.offer_maxsize = (seed_balance + swap_balance).to_sat();
         Ok(())
     }
 

--- a/src/wallet/direct_send.rs
+++ b/src/wallet/direct_send.rs
@@ -117,13 +117,10 @@ impl Wallet {
 
         if let SendAmount::Amount(a) = send_amount {
             if a + fee > total_input_value {
-                return Err(WalletError::Protocol(format!(
-
-                    "Insufficient funds: Required (send_amount + fee): {} sats | Available: {} sats | Deficit: {} sats.",
-                    (a + fee).to_sat(),
-                    total_input_value.to_sat(),
-                    (a + fee - total_input_value).to_sat(),
-                )));
+                return Err(WalletError::InsufficientFund {
+                    available: total_input_value.to_sat(),
+                    required: (a + fee).to_sat(),
+                });
             }
         }
 

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -17,6 +17,7 @@ pub enum WalletError {
     Locktime(bitcoin::blockdata::locktime::absolute::ConversionError),
     Secp(bitcoin::secp256k1::Error),
     Consensus(String),
+    InsufficientFund { available: u64, required: u64 },
 }
 
 impl From<std::io::Error> for WalletError {

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -46,10 +46,12 @@ const FIDELITY_DERIVATION_PATH: &str = "m/84'/0'/0'/2";
 #[derive(Debug)]
 pub enum FidelityError {
     WrongScriptType,
+    // TODO: Do we require this unused error variant?
     BondAlreadyExists(u32),
     BondDoesNotExist,
     BondAlreadySpent,
     CertExpired,
+    // TODO: Include this variant in WalletError instead.
     InsufficientFund { available: u64, required: u64 },
     General(String),
 }

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -5,6 +5,11 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use crate::{
+    protocol::messages::FidelityProof,
+    utill::redeemscript_to_scriptpubkey,
+    wallet::{UTXOSpendInfo, Wallet},
+};
 use bitcoin::{
     absolute::LockTime,
     bip32::{ChildNumber, DerivationPath},
@@ -18,12 +23,6 @@ use bitcoin::{
 };
 use bitcoind::bitcoincore_rpc::RpcApi;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    protocol::messages::FidelityProof,
-    utill::redeemscript_to_scriptpubkey,
-    wallet::{UTXOSpendInfo, Wallet},
-};
 
 use super::WalletError;
 
@@ -46,13 +45,9 @@ const FIDELITY_DERIVATION_PATH: &str = "m/84'/0'/0'/2";
 #[derive(Debug)]
 pub enum FidelityError {
     WrongScriptType,
-    // TODO: Do we require this unused error variant?
-    BondAlreadyExists(u32),
     BondDoesNotExist,
     BondAlreadySpent,
     CertExpired,
-    // TODO: Include this variant in WalletError instead.
-    InsufficientFund { available: u64, required: u64 },
     General(String),
 }
 
@@ -325,11 +320,10 @@ impl Wallet {
         });
 
         if total_input_amount < amount {
-            return Err((FidelityError::InsufficientFund {
+            return Err(WalletError::InsufficientFund {
                 available: total_input_amount.to_sat(),
                 required: amount.to_sat(),
-            })
-            .into());
+            });
         }
 
         let change_amount = total_input_amount.checked_sub(amount + fee);


### PR DESCRIPTION
## Description
* This pr aims to update fidelity test to check `get_highest_fidelity_index` and  `calculate_bond_value` api. ( solves  part of #97)
* It also do some refactorings and enhancement in `maker_server_code ` which are related to `fidelity`  .
* Though [da9bc93](https://github.com/citadel-tech/coinswap/pull/271/commits/da9bc938575f3accdc92fc609116620fe567c1d9) is unrelated to this pr , but still I have included here itself as it's a small change.


## Note to the Reviewers: 
- I have not tested any fidelity api which are related to `certificate` concept as it requires a more thoughts and research whether we indeed requires it or not.