### PR TITLE
Clean `config` parameters

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -51,7 +51,7 @@ use crate::{
 use super::{config::MakerConfig, error::MakerError};
 
 use crate::maker::server::{
-    DEFAULT_HEART_BEAT_INTERVAL_SECS, DEFAULT_MIN_CONTRACT_REACTION_TIME, DEFAULT_REQUIRED_CONFIRMS,
+    HEART_BEAT_INTERVAL_SECS, MIN_CONTRACT_REACTION_TIME, REQUIRED_CONFIRMS,
 };
 
 /// Used to configure the maker for testing purposes.
@@ -254,7 +254,7 @@ impl Maker {
             // check that the new locktime is sufficently short enough compared to the
             // locktime in the provided funding tx
             let locktime = read_contract_locktime(&funding_info.contract_redeemscript)?;
-            if locktime - message.next_locktime < DEFAULT_MIN_CONTRACT_REACTION_TIME {
+            if locktime - message.next_locktime < MIN_CONTRACT_REACTION_TIME {
                 return Err(MakerError::General(
                     "Next hop locktime too close to current hop locktime",
                 ));
@@ -274,7 +274,7 @@ impl Maker {
                 )
                 .map_err(WalletError::Rpc)?
             {
-                if txout.confirmations < (DEFAULT_REQUIRED_CONFIRMS as u32) {
+                if txout.confirmations < (REQUIRED_CONFIRMS as u32) {
                     return Err(MakerError::General(
                         "funding tx not confirmed to required depth",
                     ));
@@ -367,7 +367,7 @@ impl Maker {
                 &txinfo.timelock_pubkey,
                 &message.hashvalue,
                 &message.locktime,
-                &DEFAULT_MIN_CONTRACT_REACTION_TIME,
+                &MIN_CONTRACT_REACTION_TIME,
             )?;
 
             self.wallet.write()?.cache_prevout_to_contract(
@@ -495,7 +495,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
             }
         } // All locks are cleared here.
 
-        std::thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+        std::thread::sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
     }
 
     Ok(())
@@ -575,7 +575,7 @@ pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
             }
         } // All locks are cleared here
 
-        std::thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+        std::thread::sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
     }
 
     Ok(())

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -50,6 +50,8 @@ use crate::{
 
 use super::{config::MakerConfig, error::MakerError};
 
+use crate::maker::server::{DEFAULT_HEART_BEAT_INTERVAL_SECS, DEFAULT_REQUIRED_CONFIRMS};
+
 /// Used to configure the maker for testing purposes.
 #[derive(Debug, Clone, Copy)]
 pub enum MakerBehavior {
@@ -270,7 +272,7 @@ impl Maker {
                 )
                 .map_err(WalletError::Rpc)?
             {
-                if txout.confirmations < (self.config.required_confirms as u32) {
+                if txout.confirmations < (DEFAULT_REQUIRED_CONFIRMS as u32) {
                     return Err(MakerError::General(
                         "funding tx not confirmed to required depth",
                     ));
@@ -491,7 +493,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
             }
         } // All locks are cleared here.
 
-        std::thread::sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+        std::thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
     }
 
     Ok(())
@@ -571,7 +573,7 @@ pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
             }
         } // All locks are cleared here
 
-        std::thread::sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+        std::thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
     }
 
     Ok(())

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -50,7 +50,9 @@ use crate::{
 
 use super::{config::MakerConfig, error::MakerError};
 
-use crate::maker::server::{DEFAULT_HEART_BEAT_INTERVAL_SECS, DEFAULT_REQUIRED_CONFIRMS};
+use crate::maker::server::{
+    DEFAULT_HEART_BEAT_INTERVAL_SECS, DEFAULT_MIN_CONTRACT_REACTION_TIME, DEFAULT_REQUIRED_CONFIRMS,
+};
 
 /// Used to configure the maker for testing purposes.
 #[derive(Debug, Clone, Copy)]
@@ -252,7 +254,7 @@ impl Maker {
             // check that the new locktime is sufficently short enough compared to the
             // locktime in the provided funding tx
             let locktime = read_contract_locktime(&funding_info.contract_redeemscript)?;
-            if locktime - message.next_locktime < self.config.min_contract_reaction_time {
+            if locktime - message.next_locktime < DEFAULT_MIN_CONTRACT_REACTION_TIME {
                 return Err(MakerError::General(
                     "Next hop locktime too close to current hop locktime",
                 ));
@@ -365,7 +367,7 @@ impl Maker {
                 &txinfo.timelock_pubkey,
                 &message.hashvalue,
                 &message.locktime,
-                &self.config.min_contract_reaction_time,
+                &DEFAULT_MIN_CONTRACT_REACTION_TIME,
             )?;
 
             self.wallet.write()?.cache_prevout_to_contract(

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -16,13 +16,10 @@ pub struct MakerConfig {
     pub rpc_port: u16,
     /// Absolute coinswap fee
     pub absolute_fee_sats: Amount,
-    /// Fee rate per swap amount in ppb.
-    pub amount_relative_fee_ppb: Amount,
-    /// Fee rate for timelocked contract in ppb
+    /// Fee rate for timelocked contract in parts per billion (PPB).
+    /// Similar to `DEFAULT_AMOUNT_RELATIVE_FEE_PPB`, calculated as (amount * fee_ppb) / 1_000_000_000.
     pub time_relative_fee_ppb: Amount,
     /// Minimum timelock difference between contract transaction of two hops
-    pub min_contract_reaction_time: u16,
-    /// Minimum coinswap amount size in sats
     pub min_size: u64,
     /// Socks port
     pub socks_port: u16,
@@ -42,9 +39,7 @@ impl Default for MakerConfig {
             port: 6102,
             rpc_port: 6103,
             absolute_fee_sats: Amount::from_sat(1000),
-            amount_relative_fee_ppb: Amount::from_sat(10_000_000),
             time_relative_fee_ppb: Amount::from_sat(100_000),
-            min_contract_reaction_time: 48,
             min_size: 10_000,
             socks_port: 19050,
             directory_server_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
@@ -101,21 +96,11 @@ impl MakerConfig {
                 default_config.absolute_fee_sats,
             )
             .unwrap_or(default_config.absolute_fee_sats),
-            amount_relative_fee_ppb: parse_field(
-                maker_config_section.get("amount_relative_fee_ppb"),
-                default_config.amount_relative_fee_ppb,
-            )
-            .unwrap_or(default_config.amount_relative_fee_ppb),
             time_relative_fee_ppb: parse_field(
                 maker_config_section.get("time_relative_fee_ppb"),
                 default_config.time_relative_fee_ppb,
             )
             .unwrap_or(default_config.time_relative_fee_ppb),
-            min_contract_reaction_time: parse_field(
-                maker_config_section.get("min_contract_reaction_time"),
-                default_config.min_contract_reaction_time,
-            )
-            .unwrap_or(default_config.min_contract_reaction_time),
             min_size: parse_field(
                 maker_config_section.get("min_size"),
                 default_config.min_size,
@@ -155,9 +140,7 @@ impl MakerConfig {
             port = {}
             rpc_port = {}
             absolute_fee_sats = {}
-            amount_relative_fee_ppb = {}
             time_relative_fee_ppb = {}
-            min_contract_reaction_time = {}
             min_size = {}
             socks_port = {}
             directory_server_address = "{}"
@@ -168,9 +151,7 @@ impl MakerConfig {
             self.port,
             self.rpc_port,
             self.absolute_fee_sats,
-            self.amount_relative_fee_ppb,
             self.time_relative_fee_ppb,
-            self.min_contract_reaction_time,
             self.min_size,
             self.socks_port,
             self.directory_server_address,

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -96,26 +96,6 @@ impl MakerConfig {
                 default_config.rpc_port,
             )
             .unwrap_or(default_config.rpc_port),
-            heart_beat_interval_secs: parse_field(
-                maker_config_section.get("heart_beat_interval_secs"),
-                default_config.heart_beat_interval_secs,
-            )
-            .unwrap_or(default_config.heart_beat_interval_secs),
-            rpc_ping_interval_secs: parse_field(
-                maker_config_section.get("rpc_ping_interval_secs"),
-                default_config.rpc_ping_interval_secs,
-            )
-            .unwrap_or(default_config.rpc_ping_interval_secs),
-            directory_servers_refresh_interval_secs: parse_field(
-                maker_config_section.get("directory_servers_refresh_interval_secs"),
-                default_config.directory_servers_refresh_interval_secs,
-            )
-            .unwrap_or(default_config.directory_servers_refresh_interval_secs),
-            idle_connection_timeout: parse_field(
-                maker_config_section.get("idle_connection_timeout"),
-                default_config.idle_connection_timeout,
-            )
-            .unwrap_or(default_config.idle_connection_timeout),
             absolute_fee_sats: parse_field(
                 maker_config_section.get("absolute_fee_sats"),
                 default_config.absolute_fee_sats,
@@ -131,11 +111,6 @@ impl MakerConfig {
                 default_config.time_relative_fee_ppb,
             )
             .unwrap_or(default_config.time_relative_fee_ppb),
-            required_confirms: parse_field(
-                maker_config_section.get("required_confirms"),
-                default_config.required_confirms,
-            )
-            .unwrap_or(default_config.required_confirms),
             min_contract_reaction_time: parse_field(
                 maker_config_section.get("min_contract_reaction_time"),
                 default_config.min_contract_reaction_time,
@@ -151,14 +126,10 @@ impl MakerConfig {
                 default_config.socks_port,
             )
             .unwrap_or(default_config.socks_port),
-            directory_server_onion_address: maker_config_section
+            directory_server_address: maker_config_section
                 .get("directory_server_onion_address")
                 .map(|s| s.to_string())
-                .unwrap_or(default_config.directory_server_onion_address),
-            directory_server_clearnet_address: maker_config_section
-                .get("directory_server_clearnet_address")
-                .map(|s| s.to_string())
-                .unwrap_or(default_config.directory_server_clearnet_address),
+                .unwrap_or(default_config.directory_server_address),
             fidelity_value: parse_field(
                 maker_config_section.get("fidelity_value"),
                 default_config.fidelity_value,
@@ -183,38 +154,26 @@ impl MakerConfig {
             r#"
             port = {}
             rpc_port = {}
-            heart_beat_interval_secs = {}
-            rpc_ping_interval_secs = {}
-            directory_servers_refresh_interval_secs = {}
-            idle_connection_timeout = {}
             absolute_fee_sats = {}
             amount_relative_fee_ppb = {}
             time_relative_fee_ppb = {}
-            required_confirms = {}
             min_contract_reaction_time = {}
             min_size = {}
             socks_port = {}
-            directory_server_onion_address = "{}"
-            directory_server_clearnet_address = "{}"
+            directory_server_address = "{}"
             fidelity_value = {}
             fidelity_timelock = {}
             connection_type = "{:?}"
             "#,
             self.port,
             self.rpc_port,
-            self.heart_beat_interval_secs,
-            self.rpc_ping_interval_secs,
-            self.directory_servers_refresh_interval_secs,
-            self.idle_connection_timeout,
             self.absolute_fee_sats,
             self.amount_relative_fee_ppb,
             self.time_relative_fee_ppb,
-            self.required_confirms,
             self.min_contract_reaction_time,
             self.min_size,
             self.socks_port,
-            self.directory_server_onion_address,
-            self.directory_server_clearnet_address,
+            self.directory_server_address,
             self.fidelity_value,
             self.fidelity_timelock,
             self.connection_type,
@@ -258,11 +217,6 @@ mod tests {
             [maker_config]
             port = 6102
             rpc_port = 6103
-            heart_beat_interval_secs = 3
-            rpc_ping_interval_secs = 60
-            watchtower_ping_interval_secs = 300
-            directory_servers_refresh_interval_secs = 43200
-            idle_connection_timeout = 300
             absolute_fee_sats = 1000
             amount_relative_fee_ppb = 10000000
             time_relative_fee_ppb = 100000

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -13,32 +13,20 @@ pub struct MakerConfig {
     pub port: u16,
     /// RPC listening port
     pub rpc_port: u16,
-    /// Time interval between connection checks
-    pub heart_beat_interval_secs: u64,
-    /// Time interval to ping the RPC backend
-    pub rpc_ping_interval_secs: u64,
-    /// Time interval ping directory server
-    pub directory_servers_refresh_interval_secs: u64,
-    /// Time interval to close a connection if no response is received
-    pub idle_connection_timeout: u64,
     /// Absolute coinswap fee
     pub absolute_fee_sats: Amount,
     /// Fee rate per swap amount in ppb.
     pub amount_relative_fee_ppb: Amount,
     /// Fee rate for timelocked contract in ppb
     pub time_relative_fee_ppb: Amount,
-    /// No of confirmation required for funding transaction
-    pub required_confirms: u64,
-    // Minimum timelock difference between contract transaction of two hops
+    /// Minimum timelock difference between contract transaction of two hops
     pub min_contract_reaction_time: u16,
     /// Minimum coinswap amount size in sats
     pub min_size: u64,
     /// Socks port
     pub socks_port: u16,
-    /// Directory server onion address
-    pub directory_server_onion_address: String,
-    /// Directory server clearnet address
-    pub directory_server_clearnet_address: String,
+    /// Directory server address (can be clearnet or onion)
+    pub directory_server_address: String,
     /// Fidelity Bond Value
     pub fidelity_value: u64,
     /// Fidelity Bond timelock in Block heights.
@@ -52,20 +40,14 @@ impl Default for MakerConfig {
         Self {
             port: 6102,
             rpc_port: 6103,
-            heart_beat_interval_secs: 3,
-            rpc_ping_interval_secs: 60,
-            directory_servers_refresh_interval_secs: 60 * 60 * 12, //12 Hours
-            idle_connection_timeout: 300,
             absolute_fee_sats: Amount::from_sat(1000),
             amount_relative_fee_ppb: Amount::from_sat(10_000_000),
             time_relative_fee_ppb: Amount::from_sat(100_000),
-            required_confirms: 1,
             min_contract_reaction_time: 48,
             min_size: 10_000,
             socks_port: 19050,
-            directory_server_onion_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
-            directory_server_clearnet_address: "127.0.0.1:8080".to_string(),
-            fidelity_value: 5_000_000, // 5 million  sats
+            directory_server_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
+            fidelity_value: 5_000_000, // 5 million sats
             fidelity_timelock: 26_000, // Approx 6 months of blocks
             connection_type: ConnectionType::TOR,
         }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 use crate::maker::server::{
-    DEFAULT_AMOUNT_RELATIVE_FEE_PPB, DEFAULT_MIN_CONTRACT_REACTION_TIME, DEFAULT_REQUIRED_CONFIRMS,
+    AMOUNT_RELATIVE_FEE_PPB, MIN_CONTRACT_REACTION_TIME, REQUIRED_CONFIRMS,
 };
 /// The Global Handle Message function. Takes in a [`Arc<Maker>`] and handle messages
 /// according to a [ConnectionState].
@@ -97,10 +97,10 @@ pub fn handle_message(
                 let fidelity = fidelity.as_ref().expect("proof expected");
                 Some(MakerToTakerMessage::RespOffer(Box::new(Offer {
                     absolute_fee_sat: maker.config.absolute_fee_sats,
-                    amount_relative_fee_ppb: DEFAULT_AMOUNT_RELATIVE_FEE_PPB,
+                    amount_relative_fee_ppb: AMOUNT_RELATIVE_FEE_PPB,
                     time_relative_fee_ppb: maker.config.time_relative_fee_ppb,
-                    required_confirms: DEFAULT_REQUIRED_CONFIRMS,
-                    minimum_locktime: DEFAULT_MIN_CONTRACT_REACTION_TIME,
+                    required_confirms: REQUIRED_CONFIRMS,
+                    minimum_locktime: MIN_CONTRACT_REACTION_TIME,
                     max_size,
                     min_size: maker.config.min_size,
                     tweakable_point,
@@ -357,10 +357,10 @@ impl Maker {
 
         let calc_coinswap_fees = calculate_coinswap_fee(
             self.config.absolute_fee_sats,
-            DEFAULT_AMOUNT_RELATIVE_FEE_PPB,
+            AMOUNT_RELATIVE_FEE_PPB,
             self.config.time_relative_fee_ppb,
             Amount::from_sat(incoming_amount),
-            DEFAULT_REQUIRED_CONFIRMS, //time_in_blocks just 1 for now
+            REQUIRED_CONFIRMS, //time_in_blocks just 1 for now
         );
 
         let calc_funding_tx_fees = (FUNDING_TX_VBYTE_SIZE

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -47,6 +47,7 @@ use crate::{
     wallet::{IncomingSwapCoin, SwapCoin},
 };
 
+use crate::maker::server::DEFAULT_REQUIRED_CONFIRMS;
 /// The Global Handle Message function. Takes in a [`Arc<Maker>`] and handle messages
 /// according to a [ConnectionState].
 pub fn handle_message(
@@ -96,7 +97,7 @@ pub fn handle_message(
                     absolute_fee_sat: maker.config.absolute_fee_sats,
                     amount_relative_fee_ppb: maker.config.amount_relative_fee_ppb,
                     time_relative_fee_ppb: maker.config.time_relative_fee_ppb,
-                    required_confirms: maker.config.required_confirms,
+                    required_confirms: DEFAULT_REQUIRED_CONFIRMS,
                     minimum_locktime: maker.config.min_contract_reaction_time,
                     max_size,
                     min_size: maker.config.min_size,
@@ -357,7 +358,7 @@ impl Maker {
             self.config.amount_relative_fee_ppb,
             self.config.time_relative_fee_ppb,
             Amount::from_sat(incoming_amount),
-            self.config.required_confirms, //time_in_blocks just 1 for now
+            DEFAULT_REQUIRED_CONFIRMS, //time_in_blocks just 1 for now
         );
 
         let calc_funding_tx_fees = (FUNDING_TX_VBYTE_SIZE

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -47,7 +47,9 @@ use crate::{
     wallet::{IncomingSwapCoin, SwapCoin},
 };
 
-use crate::maker::server::DEFAULT_REQUIRED_CONFIRMS;
+use crate::maker::server::{
+    DEFAULT_AMOUNT_RELATIVE_FEE_PPB, DEFAULT_MIN_CONTRACT_REACTION_TIME, DEFAULT_REQUIRED_CONFIRMS,
+};
 /// The Global Handle Message function. Takes in a [`Arc<Maker>`] and handle messages
 /// according to a [ConnectionState].
 pub fn handle_message(
@@ -95,10 +97,10 @@ pub fn handle_message(
                 let fidelity = fidelity.as_ref().expect("proof expected");
                 Some(MakerToTakerMessage::RespOffer(Box::new(Offer {
                     absolute_fee_sat: maker.config.absolute_fee_sats,
-                    amount_relative_fee_ppb: maker.config.amount_relative_fee_ppb,
+                    amount_relative_fee_ppb: DEFAULT_AMOUNT_RELATIVE_FEE_PPB,
                     time_relative_fee_ppb: maker.config.time_relative_fee_ppb,
                     required_confirms: DEFAULT_REQUIRED_CONFIRMS,
-                    minimum_locktime: maker.config.min_contract_reaction_time,
+                    minimum_locktime: DEFAULT_MIN_CONTRACT_REACTION_TIME,
                     max_size,
                     min_size: maker.config.min_size,
                     tweakable_point,
@@ -355,7 +357,7 @@ impl Maker {
 
         let calc_coinswap_fees = calculate_coinswap_fee(
             self.config.absolute_fee_sats,
-            self.config.amount_relative_fee_ppb,
+            DEFAULT_AMOUNT_RELATIVE_FEE_PPB,
             self.config.time_relative_fee_ppb,
             Amount::from_sat(incoming_amount),
             DEFAULT_REQUIRED_CONFIRMS, //time_in_blocks just 1 for now

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -417,7 +417,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         maker_address
     );
 
-    let heart_beat_interval = maker.config.heart_beat_interval_secs; // All maker internal threads loops at this frequency.
+    let heart_beat_interval = DEFAULT_HEART_BEAT_INTERVAL_SECS; // All maker internal threads loops at this frequency.
 
     // Setup the wallet with fidelity bond.
     let network = maker.get_wallet().read()?.store.network;

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -36,16 +36,16 @@ use crate::{
 use crate::maker::error::MakerError;
 
 // Default values for Maker configurations
-pub const DEFAULT_HEART_BEAT_INTERVAL_SECS: u64 = 3;
-pub const DEFAULT_RPC_PING_INTERVAL_SECS: u64 = 60;
-pub const _DEFAULT_DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
-pub const _DEFAULT_IDLE_CONNECTION_TIMEOUT: u64 = 300;
-pub const DEFAULT_REQUIRED_CONFIRMS: u64 = 1;
-pub const DEFAULT_MIN_CONTRACT_REACTION_TIME: u16 = 48;
+pub const HEART_BEAT_INTERVAL_SECS: u64 = 3;
+pub const RPC_PING_INTERVAL_SECS: u64 = 60;
+pub const _DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
+pub const _IDLE_CONNECTION_TIMEOUT: u64 = 300;
+pub const REQUIRED_CONFIRMS: u64 = 1;
+pub const MIN_CONTRACT_REACTION_TIME: u16 = 48;
 
 /// Fee rate per swap amount in parts per billion (PPB).
 /// E.g., for 1 billion sats (0.01 BTC), a value of 10_000 would result in a 0.1% fee.
-pub const DEFAULT_AMOUNT_RELATIVE_FEE_PPB: Amount = Amount::from_sat(0);
+pub const AMOUNT_RELATIVE_FEE_PPB: Amount = Amount::from_sat(10_000_000);
 
 /// Fetches the Maker and DNS address, and sends maker address to the DNS server.
 /// Depending upon ConnectionType and test/prod environment, different maker address and DNS addresses are returned.
@@ -155,7 +155,7 @@ fn network_bootstrap(
                         maker_port,
                         e
                     );
-                    thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+                    thread::sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
                     continue;
                 }
             },
@@ -171,7 +171,7 @@ fn network_bootstrap(
                             maker_port,
                             e
                         );
-                        thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+                        thread::sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
                         continue;
                     }
                 }
@@ -189,7 +189,7 @@ fn network_bootstrap(
                 maker_port,
                 e
             );
-            thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+            thread::sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
             continue;
         }
         // Payload sent successfully, exit the loop
@@ -306,10 +306,10 @@ fn check_connection_with_core(
         // If connection is live, keep tring at rpc_ping_interval (60 sec).
         match rpc_ping_success {
             true => {
-                sleep(Duration::from_secs(DEFAULT_RPC_PING_INTERVAL_SECS));
+                sleep(Duration::from_secs(RPC_PING_INTERVAL_SECS));
             }
             false => {
-                sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
+                sleep(Duration::from_secs(HEART_BEAT_INTERVAL_SECS));
             }
         }
         if let Err(e) = maker.wallet.read()?.rpc.get_blockchain_info() {
@@ -417,7 +417,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         maker_address
     );
 
-    let heart_beat_interval = DEFAULT_HEART_BEAT_INTERVAL_SECS; // All maker internal threads loops at this frequency.
+    let heart_beat_interval = HEART_BEAT_INTERVAL_SECS; // All maker internal threads loops at this frequency.
 
     // Setup the wallet with fidelity bond.
     let network = maker.get_wallet().read()?.store.network;
@@ -499,7 +499,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // This loop beats at `maker.config.heart_beat_interval_secs`
     while !maker.shutdown.load(Relaxed) {
         let maker = maker.clone(); // This clone is needed to avoid moving the Arc<Maker> in each iterations.
-        let heart_beat_interval = DEFAULT_HEART_BEAT_INTERVAL_SECS;
+        let heart_beat_interval = HEART_BEAT_INTERVAL_SECS;
 
         // Block client connections if accepting_client=false
         if !*accepting_clients.lock()? {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -41,6 +41,11 @@ pub const DEFAULT_RPC_PING_INTERVAL_SECS: u64 = 60;
 pub const _DEFAULT_DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
 pub const _DEFAULT_IDLE_CONNECTION_TIMEOUT: u64 = 300;
 pub const DEFAULT_REQUIRED_CONFIRMS: u64 = 1;
+pub const DEFAULT_MIN_CONTRACT_REACTION_TIME: u16 = 48;
+
+/// Fee rate per swap amount in parts per billion (PPB).
+/// E.g., for 1 billion sats (0.01 BTC), a value of 10_000 would result in a 0.1% fee.
+pub const DEFAULT_AMOUNT_RELATIVE_FEE_PPB: Amount = Amount::from_sat(0);
 
 /// Fetches the Maker and DNS address, and sends maker address to the DNS server.
 /// Depending upon ConnectionType and test/prod environment, different maker address and DNS addresses are returned.

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -35,6 +35,13 @@ use crate::{
 
 use crate::maker::error::MakerError;
 
+// Default values for Maker configurations
+pub const DEFAULT_HEART_BEAT_INTERVAL_SECS: u64 = 3;
+pub const DEFAULT_RPC_PING_INTERVAL_SECS: u64 = 60;
+pub const DEFAULT_DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
+pub const DEFAULT_IDLE_CONNECTION_TIMEOUT: u64 = 300;
+pub const DEFAULT_REQUIRED_CONFIRMS: u64 = 1;
+
 /// Fetches the Maker and DNS address, and sends maker address to the DNS server.
 /// Depending upon ConnectionType and test/prod environment, different maker address and DNS addresses are returned.
 /// Return the Maker address and an optional tor thread handle.

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -38,8 +38,8 @@ use crate::maker::error::MakerError;
 // Default values for Maker configurations
 pub const DEFAULT_HEART_BEAT_INTERVAL_SECS: u64 = 3;
 pub const DEFAULT_RPC_PING_INTERVAL_SECS: u64 = 60;
-pub const DEFAULT_DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
-pub const DEFAULT_IDLE_CONNECTION_TIMEOUT: u64 = 300;
+pub const _DEFAULT_DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 60 * 12; // 12 Hours
+pub const _DEFAULT_IDLE_CONNECTION_TIMEOUT: u64 = 300;
 pub const DEFAULT_REQUIRED_CONFIRMS: u64 = 1;
 
 /// Fetches the Maker and DNS address, and sends maker address to the DNS server.
@@ -59,7 +59,7 @@ fn network_bootstrap(
             let dns_address = if cfg!(feature = "integration-test") {
                 format!("127.0.0.1:{}", 8080)
             } else {
-                maker.config.directory_server_clearnet_address.clone()
+                maker.config.directory_server_address.clone()
             };
             log::info!("[{}] Maker server address : {}", maker_port, maker_address);
 
@@ -123,7 +123,7 @@ fn network_bootstrap(
                     directory_onion_addr.pop();
                     format!("{}:{}", directory_onion_addr, 8080)
                 } else {
-                    maker.config.directory_server_onion_address.clone()
+                    maker.config.directory_server_address.clone()
                 };
 
                 log::info!("[{}] Maker server address : {}", maker_port, maker_address);
@@ -150,7 +150,7 @@ fn network_bootstrap(
                         maker_port,
                         e
                     );
-                    thread::sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+                    thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
                     continue;
                 }
             },
@@ -166,7 +166,7 @@ fn network_bootstrap(
                             maker_port,
                             e
                         );
-                        thread::sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+                        thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
                         continue;
                     }
                 }
@@ -184,7 +184,7 @@ fn network_bootstrap(
                 maker_port,
                 e
             );
-            thread::sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+            thread::sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
             continue;
         }
         // Payload sent successfully, exit the loop
@@ -294,10 +294,10 @@ fn check_connection_with_core(
         // If connection is live, keep tring at rpc_ping_interval (60 sec).
         match rpc_ping_success {
             true => {
-                sleep(Duration::from_secs(maker.config.rpc_ping_interval_secs));
+                sleep(Duration::from_secs(DEFAULT_RPC_PING_INTERVAL_SECS));
             }
             false => {
-                sleep(Duration::from_secs(maker.config.heart_beat_interval_secs));
+                sleep(Duration::from_secs(DEFAULT_HEART_BEAT_INTERVAL_SECS));
             }
         }
         if let Err(e) = maker.wallet.read()?.rpc.get_blockchain_info() {
@@ -484,7 +484,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // This loop beats at `maker.config.heart_beat_interval_secs`
     while !maker.shutdown.load(Relaxed) {
         let maker = maker.clone(); // This clone is needed to avoid moving the Arc<Maker> in each iterations.
-        let heart_beat_interval = maker.config.heart_beat_interval_secs;
+        let heart_beat_interval = DEFAULT_HEART_BEAT_INTERVAL_SECS;
 
         // Block client connections if accepting_client=false
         if !*accepting_clients.lock()? {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -55,6 +55,18 @@ use crate::{
     },
 };
 
+// Default values for Taker configurations
+pub const DEFAULT_REFUND_LOCKTIME: u16 = 48;
+pub const DEFAULT_REFUND_LOCKTIME_STEP: u16 = 48;
+pub const DEFAULT_FIRST_CONNECT_ATTEMPTS: u32 = 5;
+pub const DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC: u64 = 1;
+pub const DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 60;
+pub const DEFAULT_RECONNECT_ATTEMPTS: u32 = 3200;
+pub const DEFAULT_RECONNECT_SHORT_SLEEP_DELAY: u64 = 10;
+pub const DEFAULT_RECONNECT_LONG_SLEEP_DELAY: u64 = 60;
+pub const DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION: u32 = 60;
+pub const DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 300;
+
 /// Swap specific parameters. These are user's policy and can differ among swaps.
 /// SwapParams govern the criteria to find suitable set of makers from the offerbook.
 ///

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -57,16 +57,16 @@ use crate::{
 };
 
 // Default values for Taker configurations
-pub const DEFAULT_REFUND_LOCKTIME: u16 = 48;
-pub const DEFAULT_REFUND_LOCKTIME_STEP: u16 = 48;
-pub const DEFAULT_FIRST_CONNECT_ATTEMPTS: u32 = 5;
-pub const DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC: u64 = 1;
-pub const DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 60;
-pub const DEFAULT_RECONNECT_ATTEMPTS: u32 = 3200;
-pub const DEFAULT_RECONNECT_SHORT_SLEEP_DELAY: u64 = 10;
-pub const DEFAULT_RECONNECT_LONG_SLEEP_DELAY: u64 = 60;
-pub const DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION: u32 = 60;
-pub const DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 300;
+pub const REFUND_LOCKTIME: u16 = 48;
+pub const REFUND_LOCKTIME_STEP: u16 = 48;
+pub const FIRST_CONNECT_ATTEMPTS: u32 = 5;
+pub const FIRST_CONNECT_SLEEP_DELAY_SEC: u64 = 1;
+pub const FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 60;
+pub const RECONNECT_ATTEMPTS: u32 = 3200;
+pub const RECONNECT_SHORT_SLEEP_DELAY: u64 = 10;
+pub const RECONNECT_LONG_SLEEP_DELAY: u64 = 60;
+pub const SHORT_LONG_SLEEP_DELAY_TRANSITION: u32 = 60;
+pub const RECONNECT_ATTEMPT_TIMEOUT_SEC: u64 = 300;
 
 /// Swap specific parameters. These are user's policy and can differ among swaps.
 /// SwapParams govern the criteria to find suitable set of makers from the offerbook.
@@ -340,8 +340,8 @@ impl Taker {
             }
 
             // Refund lock time decreases by `refund_locktime_step` for each hop.
-            let maker_refund_locktime = DEFAULT_REFUND_LOCKTIME
-                + DEFAULT_REFUND_LOCKTIME_STEP
+            let maker_refund_locktime = REFUND_LOCKTIME
+                + REFUND_LOCKTIME_STEP
                     * (self.ongoing_swap_state.swap_params.maker_count - maker_index - 1) as u16;
 
             let funding_tx_infos = self.funding_info_for_next_maker();
@@ -456,8 +456,8 @@ impl Taker {
         self.ongoing_swap_state.taker_position = TakerPosition::FirstPeer;
 
         // Locktime to be used for this swap.
-        let swap_locktime = DEFAULT_REFUND_LOCKTIME
-            + DEFAULT_REFUND_LOCKTIME_STEP * self.ongoing_swap_state.swap_params.maker_count as u16;
+        let swap_locktime = REFUND_LOCKTIME
+            + REFUND_LOCKTIME_STEP * self.ongoing_swap_state.swap_params.maker_count as u16;
 
         // Loop until we find a live maker who responded to our signature request.
         let (maker, funding_txs) = loop {
@@ -795,14 +795,14 @@ impl Taker {
         let reconnect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            DEFAULT_RECONNECT_ATTEMPTS
+            RECONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
+            RECONNECT_SHORT_SLEEP_DELAY
         };
 
         let mut ii = 0;
@@ -828,10 +828,10 @@ impl Taker {
                     );
                     if ii <= reconnect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
+                            if ii <= SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
+                                RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -873,7 +873,7 @@ impl Taker {
             .into_inner(),
         };
 
-        let reconnect_timeout = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
+        let reconnect_timeout = Duration::from_secs(RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
         socket.set_read_timeout(Some(reconnect_timeout))?;
         socket.set_write_timeout(Some(reconnect_timeout))?;
@@ -1330,19 +1330,19 @@ impl Taker {
         maker_hashlock_nonces: &[SecretKey],
         locktime: u16,
     ) -> Result<ContractSigsForSender, TakerError> {
-        let reconnect_time_out = Duration::from_secs(DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC);
+        let reconnect_time_out = Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC);
         // Configurable reconnection attempts for testing
         let first_connect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            DEFAULT_FIRST_CONNECT_ATTEMPTS
+            FIRST_CONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC
+            FIRST_CONNECT_SLEEP_DELAY_SEC
         };
 
         let mut ii = 0;
@@ -1381,10 +1381,10 @@ impl Taker {
                     );
                     if ii <= first_connect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
+                            if ii <= SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
+                                RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -1411,20 +1411,20 @@ impl Taker {
         incoming_swapcoins: &[S],
         receivers_contract_txes: &[Transaction],
     ) -> Result<ContractSigsForRecvr, TakerError> {
-        let reconnect_time_out = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
+        let reconnect_time_out = Duration::from_secs(RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
         // Configurable reconnection attempts for testing
         let reconnect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            DEFAULT_RECONNECT_ATTEMPTS
+            RECONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
+            RECONNECT_SHORT_SLEEP_DELAY
         };
 
         let mut ii = 0;
@@ -1457,10 +1457,10 @@ impl Taker {
                     );
                     if ii <= reconnect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
+                            if ii <= SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
+                                RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -1532,7 +1532,7 @@ impl Taker {
                         .collect::<Vec<_>>()
                 };
 
-            let reconnect_time_out = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
+            let reconnect_time_out = Duration::from_secs(RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
             let mut ii = 0;
 
@@ -1553,14 +1553,14 @@ impl Taker {
             let reconnect_attempts = if cfg!(feature = "integration-test") {
                 10
             } else {
-                DEFAULT_RECONNECT_ATTEMPTS
+                RECONNECT_ATTEMPTS
             };
 
             // Custom sleep delay for testing.
             let sleep_delay = if cfg!(feature = "integration-test") {
                 1
             } else {
-                DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
+                RECONNECT_SHORT_SLEEP_DELAY
             };
 
             loop {
@@ -1583,10 +1583,10 @@ impl Taker {
                         );
                         if ii <= reconnect_attempts {
                             sleep(Duration::from_secs(
-                                if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
+                                if ii <= SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                     sleep_delay
                                 } else {
-                                    DEFAULT_RECONNECT_LONG_SLEEP_DELAY
+                                    RECONNECT_LONG_SLEEP_DELAY
                                 },
                             ));
                             continue;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -340,8 +340,8 @@ impl Taker {
             }
 
             // Refund lock time decreases by `refund_locktime_step` for each hop.
-            let maker_refund_locktime = self.config.refund_locktime
-                + self.config.refund_locktime_step
+            let maker_refund_locktime = DEFAULT_REFUND_LOCKTIME
+                + DEFAULT_REFUND_LOCKTIME_STEP
                     * (self.ongoing_swap_state.swap_params.maker_count - maker_index - 1) as u16;
 
             let funding_tx_infos = self.funding_info_for_next_maker();
@@ -456,9 +456,8 @@ impl Taker {
         self.ongoing_swap_state.taker_position = TakerPosition::FirstPeer;
 
         // Locktime to be used for this swap.
-        let swap_locktime = self.config.refund_locktime
-            + self.config.refund_locktime_step
-                * self.ongoing_swap_state.swap_params.maker_count as u16;
+        let swap_locktime = DEFAULT_REFUND_LOCKTIME
+            + DEFAULT_REFUND_LOCKTIME_STEP * self.ongoing_swap_state.swap_params.maker_count as u16;
 
         // Loop until we find a live maker who responded to our signature request.
         let (maker, funding_txs) = loop {
@@ -796,14 +795,14 @@ impl Taker {
         let reconnect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            self.config.reconnect_attempts
+            DEFAULT_RECONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            self.config.reconnect_short_sleep_delay
+            DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
         };
 
         let mut ii = 0;
@@ -829,10 +828,10 @@ impl Taker {
                     );
                     if ii <= reconnect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= self.config.short_long_sleep_delay_transition {
+                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                self.config.reconnect_long_sleep_delay
+                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -874,7 +873,7 @@ impl Taker {
             .into_inner(),
         };
 
-        let reconnect_timeout = Duration::from_secs(self.config.reconnect_attempt_timeout_sec);
+        let reconnect_timeout = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
         socket.set_read_timeout(Some(reconnect_timeout))?;
         socket.set_write_timeout(Some(reconnect_timeout))?;
@@ -1331,19 +1330,19 @@ impl Taker {
         maker_hashlock_nonces: &[SecretKey],
         locktime: u16,
     ) -> Result<ContractSigsForSender, TakerError> {
-        let reconnect_time_out = Duration::from_secs(self.config.first_connect_attempt_timeout_sec);
+        let reconnect_time_out = Duration::from_secs(DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC);
         // Configurable reconnection attempts for testing
         let first_connect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            self.config.first_connect_attempts
+            DEFAULT_FIRST_CONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            self.config.first_connect_sleep_delay_sec
+            DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC
         };
 
         let mut ii = 0;
@@ -1382,10 +1381,10 @@ impl Taker {
                     );
                     if ii <= first_connect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= self.config.short_long_sleep_delay_transition {
+                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                self.config.reconnect_long_sleep_delay
+                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -1412,20 +1411,20 @@ impl Taker {
         incoming_swapcoins: &[S],
         receivers_contract_txes: &[Transaction],
     ) -> Result<ContractSigsForRecvr, TakerError> {
-        let reconnect_time_out = Duration::from_secs(self.config.reconnect_attempt_timeout_sec);
+        let reconnect_time_out = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
         // Configurable reconnection attempts for testing
         let reconnect_attempts = if cfg!(feature = "integration-test") {
             10
         } else {
-            self.config.reconnect_attempts
+            DEFAULT_RECONNECT_ATTEMPTS
         };
 
         // Custom sleep delay for testing.
         let sleep_delay = if cfg!(feature = "integration-test") {
             1
         } else {
-            self.config.reconnect_short_sleep_delay
+            DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
         };
 
         let mut ii = 0;
@@ -1458,10 +1457,10 @@ impl Taker {
                     );
                     if ii <= reconnect_attempts {
                         sleep(Duration::from_secs(
-                            if ii <= self.config.short_long_sleep_delay_transition {
+                            if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                 sleep_delay
                             } else {
-                                self.config.reconnect_long_sleep_delay
+                                DEFAULT_RECONNECT_LONG_SLEEP_DELAY
                             },
                         ));
                         continue;
@@ -1533,7 +1532,7 @@ impl Taker {
                         .collect::<Vec<_>>()
                 };
 
-            let reconnect_time_out = Duration::from_secs(self.config.reconnect_attempt_timeout_sec);
+            let reconnect_time_out = Duration::from_secs(DEFAULT_RECONNECT_ATTEMPT_TIMEOUT_SEC);
 
             let mut ii = 0;
 
@@ -1554,14 +1553,14 @@ impl Taker {
             let reconnect_attempts = if cfg!(feature = "integration-test") {
                 10
             } else {
-                self.config.reconnect_attempts
+                DEFAULT_RECONNECT_ATTEMPTS
             };
 
             // Custom sleep delay for testing.
             let sleep_delay = if cfg!(feature = "integration-test") {
                 1
             } else {
-                self.config.reconnect_short_sleep_delay
+                DEFAULT_RECONNECT_SHORT_SLEEP_DELAY
             };
 
             loop {
@@ -1584,10 +1583,10 @@ impl Taker {
                         );
                         if ii <= reconnect_attempts {
                             sleep(Duration::from_secs(
-                                if ii <= self.config.short_long_sleep_delay_transition {
+                                if ii <= DEFAULT_SHORT_LONG_SLEEP_DELAY_TRANSITION {
                                     sleep_delay
                                 } else {
-                                    self.config.reconnect_long_sleep_delay
+                                    DEFAULT_RECONNECT_LONG_SLEEP_DELAY
                                 },
                             ));
                             continue;
@@ -1908,14 +1907,14 @@ impl Taker {
     pub fn sync_offerbook(&mut self, maker_count: usize) -> Result<(), TakerError> {
         let directory_address = match self.config.connection_type {
             ConnectionType::CLEARNET => {
-                let mut address = self.config.directory_server_clearnet_address.clone();
+                let mut address = self.config.directory_server_address.clone();
                 if cfg!(feature = "integration-test") {
                     address = format!("127.0.0.1:{}", 8080);
                 }
                 address
             }
             ConnectionType::TOR => {
-                let mut address = self.config.directory_server_onion_address.clone();
+                let mut address = self.config.directory_server_address.clone();
                 if cfg!(feature = "integration-test") {
                     let directory_hs_path_str =
                         "/tmp/tor-rust-directory/hs-dir/hostname".to_string();

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -119,7 +119,7 @@ impl TakerConfig {
 #[cfg(test)]
 mod tests {
 
-    use crate::taker::api::DEFAULT_REFUND_LOCKTIME;
+    use crate::taker::api::REFUND_LOCKTIME;
 
     use super::*;
     use std::{
@@ -166,7 +166,7 @@ mod tests {
         let config = TakerConfig::new(Some(&config_path)).unwrap();
         remove_temp_config(&config_path);
 
-        assert_eq!(DEFAULT_REFUND_LOCKTIME, 48);
+        assert_eq!(REFUND_LOCKTIME, 48);
         assert_eq!(config, TakerConfig::default());
     }
 
@@ -192,7 +192,7 @@ mod tests {
         let config_path = create_temp_config(contents, "different_data_taker_config.toml");
         let config = TakerConfig::new(Some(&config_path)).unwrap();
         remove_temp_config(&config_path);
-        assert_eq!(DEFAULT_REFUND_LOCKTIME, 48);
+        assert_eq!(REFUND_LOCKTIME, 48);
         assert_eq!(
             TakerConfig {
                 socks_port: 19051,        // Configurable via TOML.

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -9,46 +9,24 @@ use crate::utill::{get_taker_dir, parse_field, parse_toml, write_default_config,
 /// Taker configuration with refund, connection, and sleep settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TakerConfig {
-    // TODO: Move all of these to global constants.
-    pub refund_locktime: u16,
-    pub refund_locktime_step: u16,
-
-    pub first_connect_attempts: u32,
-    pub first_connect_sleep_delay_sec: u64,
-    pub first_connect_attempt_timeout_sec: u64,
-
-    pub reconnect_attempts: u32,
-    pub reconnect_short_sleep_delay: u64,
-    pub reconnect_long_sleep_delay: u64,
-    pub short_long_sleep_delay_transition: u32,
-    pub reconnect_attempt_timeout_sec: u64,
-
-    // TODO: Only these should be user facing configs.
+    /// Network listening port
     pub port: u16,
+    /// Socks port
     pub socks_port: u16,
-    pub directory_server_onion_address: String,
-    pub directory_server_clearnet_address: String,
+    /// Directory server address (can be clearnet or onion)
+    pub directory_server_address: String,
+    /// Connection type
     pub connection_type: ConnectionType,
+    /// RPC port
     pub rpc_port: u16,
 }
 
 impl Default for TakerConfig {
     fn default() -> Self {
         Self {
-            refund_locktime: 48,
-            refund_locktime_step: 48,
-            first_connect_attempts: 5,
-            first_connect_sleep_delay_sec: 1,
-            first_connect_attempt_timeout_sec: 60,
-            reconnect_attempts: 3200,
-            reconnect_short_sleep_delay: 10,
-            reconnect_long_sleep_delay: 60,
-            short_long_sleep_delay_transition: 60,
-            reconnect_attempt_timeout_sec: 300,
             port: 8000,
             socks_port: 19050,
-            directory_server_onion_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
-            directory_server_clearnet_address: "127.0.0.1:8080".to_string(),
+            directory_server_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
             connection_type: ConnectionType::TOR,
             rpc_port: 8081,
         }

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -38,8 +38,7 @@ use super::{
 };
 
 use crate::taker::api::{
-    DEFAULT_FIRST_CONNECT_ATTEMPTS, DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC,
-    DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC,
+    FIRST_CONNECT_ATTEMPTS, FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC, FIRST_CONNECT_SLEEP_DELAY_SEC,
 };
 
 use crate::wallet::SwapCoin;
@@ -461,12 +460,8 @@ fn download_maker_offer_attempt_once(
         .into_inner(),
     };
 
-    socket.set_read_timeout(Some(Duration::from_secs(
-        DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC,
-    )))?;
-    socket.set_write_timeout(Some(Duration::from_secs(
-        DEFAULT_FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC,
-    )))?;
+    socket.set_read_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
+    socket.set_write_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
 
     handshake_maker(&mut socket)?;
 
@@ -496,7 +491,7 @@ pub fn download_maker_offer(address: MakerAddress, config: TakerConfig) -> Optio
             Ok(offer) => return Some(OfferAndAddress { offer, address }),
             Err(TakerError::IO(e)) => {
                 if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut {
-                    if ii <= DEFAULT_FIRST_CONNECT_ATTEMPTS {
+                    if ii <= FIRST_CONNECT_ATTEMPTS {
                         log::warn!(
                             "Timeout for request offer from maker {}, reattempting...",
                             address
@@ -513,13 +508,13 @@ pub fn download_maker_offer(address: MakerAddress, config: TakerConfig) -> Optio
             }
 
             Err(e) => {
-                if ii <= DEFAULT_FIRST_CONNECT_ATTEMPTS {
+                if ii <= FIRST_CONNECT_ATTEMPTS {
                     log::warn!(
                         "Failed to request offer from maker {}, reattempting... error={:?}",
                         address,
                         e
                     );
-                    sleep(Duration::from_secs(DEFAULT_FIRST_CONNECT_SLEEP_DELAY_SEC));
+                    sleep(Duration::from_secs(FIRST_CONNECT_SLEEP_DELAY_SEC));
                     continue;
                 } else {
                     log::error!(


### PR DESCRIPTION
### Aims to fix https://github.com/citadel-tech/coinswap/issues/248


- [x] Removed internal parameters from `MakerConfig` and `TakerConfig` that should not be exposed to users.
- [x] Hardcoded default values for internal parameters in `maker/server.rs`.
- [x] Hardcoded default values for internal parameters in `taker/api.rs`.
- [x] Replaced separate `directory_server_onion_address` and `directory_server_clearnet_address` fields with a unified `directory_server_address` field for both `MakerConfig` and `TakerConfig`.
- [x] Set `required_confirms` to a default value of `1` for `MakerConfig`, removing it from user-facing configuration options.
- [X] Adjusted the code to use the constants rather than the struct fields.
- [x] Added documentation wherever needed.