### PR TITLE
replace `config_path` by `data_dir` in directory initialization

### DIFF
--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -8,18 +8,18 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, BufRead, BufReader, Write},
     net::{Ipv4Addr, TcpListener, TcpStream},
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, RwLock},
     thread::{self, sleep},
     time::Duration,
 };
 
-use crate::market::rpc::start_rpc_server_thread;
-use std::path::PathBuf;
-
-use crate::utill::{
-    get_dns_dir, get_tor_addrs, monitor_log_for_completion, parse_field, parse_toml,
-    write_default_config, ConnectionType,
+use crate::{
+    market::rpc::start_rpc_server_thread,
+    utill::{
+        get_dns_dir, get_tor_addrs, monitor_log_for_completion, parse_field, parse_toml,
+        write_default_config, ConnectionType,
+    },
 };
 
 /// Represents errors that can occur during directory server operations.
@@ -64,13 +64,13 @@ impl DirectoryServer {
     /// Default data-dir for linux: `~/.coinswap/`
     /// Default config locations: `~/.coinswap/dns/config.toml`.
     pub fn new(
-        config_path: Option<PathBuf>,
+        directory: Option<PathBuf>,
         connection_type: Option<ConnectionType>,
     ) -> io::Result<Self> {
         let default_config = Self::default();
 
-        let default_config_path = get_dns_dir().join("config.toml");
-        let config_path = config_path.unwrap_or(default_config_path);
+        let data_dir = directory.unwrap_or(get_dns_dir());
+        let config_path = data_dir.join("config.toml");
 
         // This will create parent directories if they don't exist
         if !config_path.exists() {
@@ -82,7 +82,7 @@ impl DirectoryServer {
         }
 
         // Its okay to unwrap as we just created the parent directory above
-        let data_dir = config_path.parent().unwrap().to_path_buf();
+        // let data_dir = config_path.parent().unwrap().to_path_buf();
 
         let section = parse_toml(&config_path)?;
         log::info!(

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -64,12 +64,12 @@ impl DirectoryServer {
     /// Default data-dir for linux: `~/.coinswap/`
     /// Default config locations: `~/.coinswap/dns/config.toml`.
     pub fn new(
-        directory: Option<PathBuf>,
+        data_dir: Option<PathBuf>,
         connection_type: Option<ConnectionType>,
     ) -> io::Result<Self> {
         let default_config = Self::default();
 
-        let data_dir = directory.unwrap_or(get_dns_dir());
+        let data_dir = data_dir.unwrap_or(get_dns_dir());
         let config_path = data_dir.join("config.toml");
 
         // This will create parent directories if they don't exist
@@ -80,9 +80,6 @@ impl DirectoryServer {
                 config_path.display()
             );
         }
-
-        // Its okay to unwrap as we just created the parent directory above
-        // let data_dir = config_path.parent().unwrap().to_path_buf();
 
         let section = parse_toml(&config_path)?;
         log::info!(
@@ -285,8 +282,8 @@ mod tests {
         "#;
         create_temp_config(contents, &temp_dir);
         let config = DirectoryServer::new(Some(temp_dir.path().to_path_buf()), None).unwrap();
-
         let default_config = DirectoryServer::default();
+
         assert_eq!(config.port, default_config.port);
         assert_eq!(config.socks_port, default_config.socks_port);
 
@@ -318,8 +315,8 @@ mod tests {
         "#;
         create_temp_config(contents, &temp_dir);
         let config = DirectoryServer::new(Some(temp_dir.path().to_path_buf()), None).unwrap();
-
         let default_config = DirectoryServer::default();
+
         assert_eq!(config.port, default_config.port);
         assert_eq!(config.socks_port, default_config.socks_port);
 
@@ -329,10 +326,9 @@ mod tests {
     #[test]
     fn test_missing_file() {
         let temp_dir = TempDir::new().unwrap();
-
         let config = DirectoryServer::new(Some(temp_dir.path().to_path_buf()), None).unwrap();
-
         let default_config = DirectoryServer::default();
+
         assert_eq!(config.port, default_config.port);
         assert_eq!(config.socks_port, default_config.socks_port);
 


### PR DESCRIPTION
Currently we give config_path as parameter to the directory server initialization. But we want to provide it directory, and then it should derive the config_path in using directory, not the other way around.
https://github.com/citadel-tech/coinswap/blob/291187157da01e7b33f10f706e428701de7d88b2/src/market/directory.rs#L66-L70