### PR TITLE
Add loop in bufreader in rpc server

### DIFF
--- a/src/market/rpc/server.rs
+++ b/src/market/rpc/server.rs
@@ -1,3 +1,9 @@
+use super::{RpcMsgReq, RpcMsgResp};
+use crate::{
+    error::NetError,
+    market::directory::{DirectoryServer, DirectoryServerError},
+    utill::{read_message, send_message},
+};
 use std::{
     collections::HashSet,
     io::ErrorKind,
@@ -6,14 +12,6 @@ use std::{
     thread::sleep,
     time::Duration,
 };
-
-use crate::{
-    error::NetError,
-    market::directory::{DirectoryServer, DirectoryServerError},
-    utill::{read_message, send_message},
-};
-
-use super::{RpcMsgReq, RpcMsgResp};
 
 fn handle_request(
     socket: &mut TcpStream,


### PR DESCRIPTION
Adding a loop at the point where we're reading the buffer while making rpc requests.

Issue: Getting `failed to fill whole buffer` while making a POST request.
For linux we won't face this, but for mac, we do, as the file descriptors don't get immediately filled and usually, a time lag is observed for macos.