### PR TITLE
Last unwraps

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,6 @@
 
 use std::error::Error;
 
-use bitcoin::Amount;
-
-use crate::protocol::error::ContractError;
-
 /// Includes all network-related errors.
 #[derive(Debug)]
 pub enum NetError {
@@ -38,22 +34,5 @@ impl From<std::io::Error> for NetError {
 impl From<serde_cbor::Error> for NetError {
     fn from(value: serde_cbor::Error) -> Self {
         Self::Cbor(value)
-    }
-}
-
-/// Includes all Protocol-level errors.
-#[derive(Debug)]
-pub enum ProtocolError {
-    WrongMessage { expected: String, received: String },
-    WrongNumOfSigs { expected: usize, received: usize },
-    WrongNumOfContractTxs { expected: usize, received: usize },
-    WrongNumOfPrivkeys { expected: usize, received: usize },
-    IncorrectFundingAmount { expected: Amount, found: Amount },
-    Contract(ContractError),
-}
-
-impl From<ContractError> for ProtocolError {
-    fn from(value: ContractError) -> Self {
-        Self::Contract(value)
     }
 }

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -288,7 +288,7 @@ impl Maker {
 
             //check that the provided contract matches the scriptpubkey from the
             //cache which was populated when the ReqContractSigsForSender message arrived
-            let contract_spk = redeemscript_to_scriptpubkey(&funding_info.contract_redeemscript);
+            let contract_spk = redeemscript_to_scriptpubkey(&funding_info.contract_redeemscript)?;
 
             if !self.wallet.read()?.does_prevout_match_cached_contract(
                 &(OutPoint {

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -4,11 +4,7 @@ use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 
 use bitcoin::secp256k1;
 
-use crate::{
-    error::{NetError, ProtocolError},
-    protocol::error::ContractError,
-    wallet::WalletError,
-};
+use crate::{error::NetError, protocol::error::ProtocolError, wallet::WalletError};
 
 use super::MakerBehavior;
 
@@ -62,9 +58,9 @@ impl From<secp256k1::Error> for MakerError {
     }
 }
 
-impl From<ContractError> for MakerError {
-    fn from(value: ContractError) -> Self {
-        Self::Protocol(ProtocolError::from(value))
+impl From<ProtocolError> for MakerError {
+    fn from(value: ProtocolError) -> Self {
+        Self::Protocol(value)
     }
 }
 
@@ -83,11 +79,5 @@ impl From<MakerBehavior> for MakerError {
 impl From<NetError> for MakerError {
     fn from(value: NetError) -> Self {
         Self::Net(value)
-    }
-}
-
-impl From<ProtocolError> for MakerError {
-    fn from(value: ProtocolError) -> Self {
-        Self::Protocol(value)
     }
 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -345,15 +345,18 @@ impl Maker {
         }
 
         // Calculate output amounts for the next hop
-        let incoming_amount = message.confirmed_funding_txes.iter().fold(0u64, |acc, fi| {
-            let index = find_funding_output_index(fi).unwrap();
-            let txout = fi
-                .funding_tx
-                .output
-                .get(index as usize)
-                .expect("output at index expected");
-            acc + txout.value.to_sat()
-        });
+        let incoming_amount = message
+            .confirmed_funding_txes
+            .iter()
+            .try_fold(0u64, |acc, fi| {
+                let index = find_funding_output_index(fi)?;
+                let txout = fi
+                    .funding_tx
+                    .output
+                    .get(index as usize)
+                    .expect("output at index expected");
+                Ok::<_, MakerError>(acc + txout.value.to_sat())
+            })?;
 
         let calc_coinswap_fees = calculate_coinswap_fee(
             self.config.absolute_fee_sats,

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -17,9 +17,9 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
-    error::ProtocolError,
     maker::api::recover_from_swap,
     protocol::{
+        error::ProtocolError,
         messages::{MakerHello, MultisigPrivkey, PrivKeyHandover},
         Hash160,
     },
@@ -301,7 +301,7 @@ impl Maker {
                 funding_output.value,
                 &funding_info.contract_redeemscript,
                 Amount::from_sat(message.next_fee_rate),
-            );
+            )?;
 
             let (tweakable_privkey, _) = self.wallet.read()?.get_tweakable_keypair()?;
             let multisig_privkey =

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -152,7 +152,7 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
         }
         RpcMsgReq::GetTorAddress => {
             let path = get_maker_dir().join("tor");
-            let resp = RpcMsgResp::GetTorAddressResp(get_tor_addrs(&path));
+            let resp = RpcMsgResp::GetTorAddressResp(get_tor_addrs(&path)?);
             if let Err(e) = send_message(socket, &resp) {
                 log::info!("Error sending RPC response {:?}", e);
             };

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -249,7 +249,7 @@ pub fn start_directory_server(directory: Arc<DirectoryServer>) -> Result<(), Dir
 
                 log::info!("Directory tor is instantiated");
 
-                let onion_addr = get_tor_addrs(&PathBuf::from("/tmp/tor-rust-directory"));
+                let onion_addr = get_tor_addrs(&PathBuf::from("/tmp/tor-rust-directory"))?;
 
                 log::info!(
                     "Directory Server is listening at {}:{}",

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -1,43 +1,57 @@
 //! All Contract related errors.
 
-use bitcoin::secp256k1;
+use bitcoin::{secp256k1, Amount};
 
-/// Enum for handling contract-related errors.
+/// Includes all Protocol-level errors.
 #[derive(Debug)]
-pub enum ContractError {
+pub enum ProtocolError {
     Secp(secp256k1::Error),
-    Protocol(&'static str),
     Script(bitcoin::blockdata::script::Error),
     Hash(bitcoin::hashes::FromSliceError),
     Key(bitcoin::key::FromSliceError),
     Sighash(bitcoin::transaction::InputsIndexError),
+    WrongMessage { expected: String, received: String },
+    WrongNumOfSigs { expected: usize, received: usize },
+    WrongNumOfContractTxs { expected: usize, received: usize },
+    WrongNumOfPrivkeys { expected: usize, received: usize },
+    IncorrectFundingAmount { expected: Amount, found: Amount },
+    // This is returned if we ever encounter a non-segwit script_pubkey. The protocol only works with V0_Segwit transactions.
+    ScriptPubkey(bitcoin::script::witness_program::Error),
+    // Any other error not included in the above list
+    General(&'static str),
 }
 
-impl From<secp256k1::Error> for ContractError {
+impl From<bitcoin::script::witness_program::Error> for ProtocolError {
+    fn from(value: bitcoin::script::witness_program::Error) -> Self {
+        Self::ScriptPubkey(value)
+    }
+}
+
+impl From<secp256k1::Error> for ProtocolError {
     fn from(value: secp256k1::Error) -> Self {
         Self::Secp(value)
     }
 }
 
-impl From<bitcoin::blockdata::script::Error> for ContractError {
+impl From<bitcoin::blockdata::script::Error> for ProtocolError {
     fn from(value: bitcoin::blockdata::script::Error) -> Self {
         Self::Script(value)
     }
 }
 
-impl From<bitcoin::hashes::FromSliceError> for ContractError {
+impl From<bitcoin::hashes::FromSliceError> for ProtocolError {
     fn from(value: bitcoin::hashes::FromSliceError) -> Self {
         Self::Hash(value)
     }
 }
 
-impl From<bitcoin::key::FromSliceError> for ContractError {
+impl From<bitcoin::key::FromSliceError> for ProtocolError {
     fn from(value: bitcoin::key::FromSliceError) -> Self {
         Self::Key(value)
     }
 }
 
-impl From<bitcoin::transaction::InputsIndexError> for ContractError {
+impl From<bitcoin::transaction::InputsIndexError> for ProtocolError {
     fn from(value: bitcoin::transaction::InputsIndexError) -> Self {
         Self::Sighash(value)
     }

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -1,9 +1,4 @@
 //! All Taker-related errors.
-
-use bitcoin::Txid;
-
-use bitcoind::bitcoincore_rpc::Error as RpcError;
-
 use crate::{
     error::{NetError, ProtocolError},
     market::directory::DirectoryServerError,
@@ -14,8 +9,7 @@ use crate::{
 #[derive(Debug)]
 pub enum TakerError {
     IO(std::io::Error),
-    ContractsBroadcasted(Vec<Txid>),
-    RPCError(RpcError),
+    ContractsBroadcasted(Vec<bitcoin::Txid>),
     NotEnoughMakersInOfferBook,
     Wallet(WalletError),
     Directory(DirectoryServerError),
@@ -24,17 +18,12 @@ pub enum TakerError {
     SendAmountNotSet,
     FundingTxWaitTimeOut,
     Deserialize(serde_cbor::Error),
+    MPSC(String),
 }
 
 impl From<serde_cbor::Error> for TakerError {
     fn from(value: serde_cbor::Error) -> Self {
         Self::Deserialize(value)
-    }
-}
-
-impl From<RpcError> for TakerError {
-    fn from(value: RpcError) -> Self {
-        Self::RPCError(value)
     }
 }
 
@@ -65,5 +54,17 @@ impl From<NetError> for TakerError {
 impl From<ProtocolError> for TakerError {
     fn from(value: ProtocolError) -> Self {
         Self::Protocol(value)
+    }
+}
+
+impl From<std::sync::mpsc::RecvError> for TakerError {
+    fn from(value: std::sync::mpsc::RecvError) -> Self {
+        Self::MPSC(value.to_string())
+    }
+}
+
+impl<T> From<std::sync::mpsc::SendError<T>> for TakerError {
+    fn from(value: std::sync::mpsc::SendError<T>) -> Self {
+        Self::MPSC(value.to_string())
     }
 }

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -1,7 +1,6 @@
 //! All Taker-related errors.
 use crate::{
-    error::{NetError, ProtocolError},
-    market::directory::DirectoryServerError,
+    error::NetError, market::directory::DirectoryServerError, protocol::error::ProtocolError,
     wallet::WalletError,
 };
 
@@ -14,10 +13,10 @@ pub enum TakerError {
     Wallet(WalletError),
     Directory(DirectoryServerError),
     Net(NetError),
-    Protocol(ProtocolError),
     SendAmountNotSet,
     FundingTxWaitTimeOut,
     Deserialize(serde_cbor::Error),
+    // MPSC channel failure error. Only occurs in internal thread communications.
     MPSC(String),
 }
 
@@ -53,7 +52,7 @@ impl From<NetError> for TakerError {
 
 impl From<ProtocolError> for TakerError {
     fn from(value: ProtocolError) -> Self {
-        Self::Protocol(value)
+        Self::Wallet(value.into())
     }
 }
 

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -11,10 +11,8 @@ use std::{
 
 use bitcoin::{
     hashes::{sha256, Hash},
-    secp256k1::{
-        rand::{rngs::OsRng, RngCore},
-        Secp256k1, SecretKey,
-    },
+    key::{rand::thread_rng, Keypair},
+    secp256k1::{Secp256k1, SecretKey},
     PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
 };
 use log::LevelFilter;
@@ -34,10 +32,11 @@ use std::{
 
 use crate::{
     error::NetError,
-    protocol::{contract::derive_maker_pubkey_and_nonce, messages::MultisigPrivkey},
+    protocol::{
+        contract::derive_maker_pubkey_and_nonce, error::ContractError, messages::MultisigPrivkey,
+    },
     wallet::{SwapCoin, WalletError},
 };
-use serde_json::Value;
 
 const INPUT_CHARSET: &str =
     "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
@@ -75,12 +74,12 @@ impl FromStr for ConnectionType {
 }
 
 /// Read the tor address given an hidden_service directory path
-pub fn get_tor_addrs(hs_dir: &Path) -> String {
+pub fn get_tor_addrs(hs_dir: &Path) -> io::Result<String> {
     let hostname_file_path = hs_dir.join("hs-dir").join("hostname");
     let mut hostname_file = File::open(hostname_file_path).unwrap();
     let mut tor_addrs: String = String::new();
-    hostname_file.read_to_string(&mut tor_addrs).unwrap();
-    tor_addrs
+    hostname_file.read_to_string(&mut tor_addrs)?;
+    Ok(tor_addrs)
 }
 
 /// Get the system specific home directory.
@@ -215,85 +214,81 @@ pub fn check_and_apply_maker_private_keys<S: SwapCoin>(
 /// Nonce values are random integers and resulting Pubkeys are derived by tweaking
 ///
 /// the Maker's advertised Pubkey with these two nonces.
+#[allow(clippy::type_complexity)]
 pub fn generate_maker_keys(
     tweakable_point: &PublicKey,
     count: u32,
-) -> (
-    Vec<PublicKey>,
-    Vec<SecretKey>,
-    Vec<PublicKey>,
-    Vec<SecretKey>,
-) {
-    let (multisig_pubkeys, multisig_nonces): (Vec<_>, Vec<_>) = (0..count)
-        .map(|_| derive_maker_pubkey_and_nonce(tweakable_point).unwrap())
-        .unzip();
-    let (hashlock_pubkeys, hashlock_nonces): (Vec<_>, Vec<_>) = (0..count)
-        .map(|_| derive_maker_pubkey_and_nonce(tweakable_point).unwrap())
-        .unzip();
+) -> Result<
     (
+        Vec<PublicKey>,
+        Vec<SecretKey>,
+        Vec<PublicKey>,
+        Vec<SecretKey>,
+    ),
+    ContractError,
+> {
+    // Closure to derive public keys and nonces
+    let derive_keys = |count: u32| {
+        (0..count)
+            .map(|_| derive_maker_pubkey_and_nonce(tweakable_point))
+            .collect::<Result<Vec<_>, _>>()
+    };
+
+    // Generate multisig and hashlock keys.
+    let (multisig_pubkeys, multisig_nonces): (Vec<_>, Vec<_>) =
+        derive_keys(count)?.into_iter().unzip();
+    let (hashlock_pubkeys, hashlock_nonces): (Vec<_>, Vec<_>) =
+        derive_keys(count)?.into_iter().unzip();
+
+    Ok((
         multisig_pubkeys,
         multisig_nonces,
         hashlock_pubkeys,
         hashlock_nonces,
-    )
-}
-
-/// Converts a Bitcoin amount from JSON-RPC representation to satoshis.
-pub fn convert_json_rpc_bitcoin_to_satoshis(amount: &Value) -> u64 {
-    //to avoid floating point arithmetic, convert the bitcoin amount to
-    //string with 8 decimal places, then remove the decimal point to
-    //obtain the value in satoshi
-    //this is necessary because the json rpc represents bitcoin values
-    //as floats :(
-    format!("{:.8}", amount.as_f64().unwrap())
-        .replace('.', "")
-        .parse::<u64>()
-        .unwrap()
+    ))
 }
 
 /// Extracts hierarchical deterministic (HD) path components from a descriptor.
 ///
 /// Parses an input descriptor string and returns `Some` with a tuple containing the HD path
-/// components if it's an HD descriptor. If it's not an HD descriptor, it returns `None`.
+/// components if it's an HD descriptor. If the descriptor doesn't have path info, it returns `None`.
+/// This method only works for single key descriptors.
 pub fn get_hd_path_from_descriptor(descriptor: &str) -> Option<(&str, u32, i32)> {
-    //e.g
-    //"desc": "wpkh([a945b5ca/1/1]029b77637989868dcd502dbc07d6304dc2150301693ae84a60b379c3b696b289ad)#aq759em9",
     let open = descriptor.find('[');
     let close = descriptor.find(']');
-    if open.is_none() || close.is_none() {
-        //unexpected, so printing it to stdout
-        log::error!("unknown descriptor = {}", descriptor);
+
+    let path = if let (Some(open), Some(close)) = (open, close) {
+        &descriptor[open + 1..close]
+    } else {
+        // No hard error. Just print it to stdout.
+        log::error!("Descriptor doesn't have path = {}", descriptor);
         return None;
-    }
-    let path = &descriptor[open.unwrap() + 1..close.unwrap()];
+    };
+
     let path_chunks: Vec<&str> = path.split('/').collect();
     if path_chunks.len() != 3 {
-        return None;
-        //unexpected descriptor = wsh(multi(2,[f67b69a3]0245ddf535f08a04fd86d794b76f8e3949f27f7ae039b641bf277c6a4552b4c387,[dbcd3c6e]030f781e9d2a6d3a823cee56be2d062ed4269f5a6294b20cb8817eb540c641d9a2))#8f70vn2q
-    }
-    let addr_type = path_chunks[1].parse::<u32>();
-    if addr_type.is_err() {
-        log::error!(target: "wallet", "unexpected address_type = {}", path);
+        // No hard error. Just print it to stdout.
+        log::error!("Path is not a triplet. Path chunks = {:?}", path_chunks);
         return None;
     }
-    let index = path_chunks[2].parse::<i32>();
-    if index.is_err() {
-        return None;
+
+    if let (Ok(addr_type), Ok(index)) =
+        (path_chunks[1].parse::<u32>(), path_chunks[2].parse::<i32>())
+    {
+        Some((path_chunks[0], addr_type, index))
+    } else {
+        None
     }
-    Some((path_chunks[0], addr_type.unwrap(), index.unwrap()))
 }
 
 /// Generates a keypair using the secp256k1 elliptic curve.
 pub fn generate_keypair() -> (PublicKey, SecretKey) {
-    let mut privkey = [0u8; 32];
-    OsRng.fill_bytes(&mut privkey);
-    let secp = Secp256k1::new();
-    let privkey = SecretKey::from_slice(&privkey).unwrap();
+    let keypair = Keypair::new(&Secp256k1::new(), &mut thread_rng());
     let pubkey = PublicKey {
         compressed: true,
-        inner: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &privkey),
+        inner: keypair.public_key(),
     };
-    (pubkey, privkey)
+    (pubkey, keypair.secret_key())
 }
 
 /// Convert a redeemscript into p2wsh scriptpubkey.
@@ -303,7 +298,6 @@ pub fn redeemscript_to_scriptpubkey(redeemscript: &ScriptBuf) -> ScriptBuf {
         &redeemscript.wscript_hash().to_byte_array(),
     )
     .unwrap();
-    //p2wsh address
     ScriptBuf::new_witness_program(&witness_program)
 }
 
@@ -418,7 +412,7 @@ pub fn compute_checksum(descriptor: &str) -> Result<String, WalletError> {
             CHECKSUM_CHARSET
                 .chars()
                 .nth(((checksum >> (5 * (7 - i))) & 31) as usize)
-                .unwrap()
+                .expect("checksum character expected")
         })
         .collect::<String>();
 
@@ -447,8 +441,6 @@ mod tests {
         secp256k1::Scalar,
         PubkeyHash,
     };
-
-    use serde_json::json;
 
     use crate::protocol::messages::{MakerHello, MakerToTakerMessage};
 
@@ -480,19 +472,6 @@ mod tests {
         send_message(&mut stream, &message).unwrap();
     }
 
-    #[test]
-    fn test_convert_json_rpc_bitcoin_to_satoshis() {
-        // Test with an integer value
-        let amount = json!(1);
-        assert_eq!(convert_json_rpc_bitcoin_to_satoshis(&amount), 100_000_000);
-
-        // Test with a very large value
-        let amount = json!(12345678.12345678);
-        assert_eq!(
-            convert_json_rpc_bitcoin_to_satoshis(&amount),
-            1_234_567_812_345_678
-        );
-    }
     #[test]
     fn test_redeemscript_to_scriptpubkey_custom() {
         // Create a custom puzzle script
@@ -596,7 +575,7 @@ mod tests {
         )
         .unwrap();
         let (multisig_pubkeys, multisig_nonces, hashlock_pubkeys, hashlock_nonces) =
-            generate_maker_keys(&tweak_point, 1);
+            generate_maker_keys(&tweak_point, 1).unwrap();
         // test returned multisg part
         let returned_nonce = multisig_nonces[0];
         let returned_pubkey = multisig_pubkeys[0];

--- a/src/wallet/direct_send.rs
+++ b/src/wallet/direct_send.rs
@@ -138,7 +138,7 @@ impl Wallet {
                 if !a.as_unchecked().is_valid_for_network(self.store.network)
                     && !testnet_signet_type
                 {
-                    return Err(WalletError::Protocol(
+                    return Err(WalletError::General(
                         "Wrong address type in destinations.".to_string(),
                     ));
                 }

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -1,7 +1,8 @@
 //! All Wallet-related errors.
 
+use crate::protocol::error::ProtocolError;
+
 use super::fidelity::FidelityError;
-use crate::protocol::error::ContractError;
 
 /// Enum for handling wallet-related errors.
 #[derive(Debug)]
@@ -9,10 +10,10 @@ pub enum WalletError {
     IO(std::io::Error),
     Cbor(serde_cbor::Error),
     Rpc(bitcoind::bitcoincore_rpc::Error),
-    Protocol(String),
     BIP32(bitcoin::bip32::Error),
     BIP39(bip39::Error),
-    Contract(ContractError),
+    General(String),
+    Protocol(ProtocolError),
     Fidelity(FidelityError),
     Locktime(bitcoin::blockdata::locktime::absolute::ConversionError),
     Secp(bitcoin::secp256k1::Error),
@@ -44,9 +45,9 @@ impl From<bip39::Error> for WalletError {
     }
 }
 
-impl From<ContractError> for WalletError {
-    fn from(value: ContractError) -> Self {
-        Self::Contract(value)
+impl From<ProtocolError> for WalletError {
+    fn from(value: ProtocolError) -> Self {
+        Self::Protocol(value)
     }
 }
 

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -91,3 +91,9 @@ impl From<bitcoin::transaction::InputsIndexError> for WalletError {
         Self::Consensus(value.to_string())
     }
 }
+
+impl From<bitcoin::consensus::encode::Error> for WalletError {
+    fn from(value: bitcoin::consensus::encode::Error) -> Self {
+        Self::Consensus(value.to_string())
+    }
+}

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -59,7 +59,7 @@ pub enum FidelityError {
 /// Old script: <locktime> <OP_CLTV> <OP_DROP> <pubkey> <OP_CHECKSIG>
 /// The new script drops the extra byte <OP_DROP>
 /// New script: <pubkey> <OP_CHECKSIGVERIFY> <locktime> <OP_CLTV>
-pub fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> ScriptBuf {
+fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> ScriptBuf {
     Builder::new()
         .push_key(pubkey)
         .push_opcode(OP_CHECKSIGVERIFY)
@@ -70,9 +70,7 @@ pub fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> Script
 
 #[allow(unused)]
 /// Reads the locktime from a fidelity redeemscript.
-pub fn read_locktime_from_fidelity_script(
-    redeemscript: &ScriptBuf,
-) -> Result<LockTime, FidelityError> {
+fn read_locktime_from_fidelity_script(redeemscript: &ScriptBuf) -> Result<LockTime, FidelityError> {
     if let Some(Ok(Instruction::PushBytes(locktime_bytes))) = redeemscript.instructions().nth(2) {
         let mut u4slice: [u8; 4] = [0; 4];
         u4slice[..locktime_bytes.len()].copy_from_slice(locktime_bytes.as_bytes());
@@ -139,7 +137,7 @@ impl FidelityBond {
 
     /// Get the script_pubkey for this bond.
     pub fn script_pub_key(&self) -> ScriptBuf {
-        redeemscript_to_scriptpubkey(&self.redeem_script())
+        redeemscript_to_scriptpubkey(&self.redeem_script()).expect("This can never panic as fidelity redeemscript template is hardcoded in a private function.")
     }
 
     /// Generate the bond's certificate hash.

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Various mechanisms of creating the swap funding transactions.
 //!
 //! This module contains routines for creating funding transactions within a wallet. It leverages
@@ -40,18 +41,20 @@ impl Wallet {
             return ret;
         }
 
-        let ret = self.create_funding_txes_utxo_max_sends(coinswap_amount, destinations, fee_rate);
-        if ret.is_ok() {
-            log::info!(target: "wallet", "created funding txes with fully-spending utxos");
-            return ret;
-        }
+        // TODO: Unlock this code when we are sure that the routines actually works.
 
-        let ret =
-            self.create_funding_txes_use_biggest_utxos(coinswap_amount, destinations, fee_rate);
-        if ret.is_ok() {
-            log::info!(target: "wallet", "created funding txes with using the biggest utxos");
-            return ret;
-        }
+        // let ret = self.create_funding_txes_utxo_max_sends(coinswap_amount, destinations, fee_rate);
+        // if ret.is_ok() {
+        //     log::info!(target: "wallet", "created funding txes with fully-spending utxos");
+        //     return ret;
+        // }
+
+        // let ret =
+        //     self.create_funding_txes_use_biggest_utxos(coinswap_amount, destinations, fee_rate);
+        // if ret.is_ok() {
+        //     log::info!(target: "wallet", "created funding txes with using the biggest utxos");
+        //     return ret;
+        // }
 
         log::info!(target: "wallet", "failed to create funding txes with any method");
         ret
@@ -83,7 +86,7 @@ impl Wallet {
                 return Ok(fractions);
             }
         }
-        Err(WalletError::Protocol(
+        Err(WalletError::General(
             "Unable to generate amount fractions, probably amount too small".to_string(),
         ))
     }
@@ -435,7 +438,7 @@ impl Wallet {
 
         let total_tx_inputs_len = selected_utxo.len();
         if total_tx_inputs_len < destinations.len() {
-            return Err(WalletError::Protocol(
+            return Err(WalletError::General(
                 "not enough UTXOs found, cant use this method".to_string(),
             ));
         }
@@ -468,7 +471,7 @@ impl Wallet {
 
         let mut list_unspent_result = seed_coin_utxo;
         if list_unspent_result.len() < destinations.len() {
-            return Err(WalletError::Protocol(
+            return Err(WalletError::General(
                 "Not enough UTXOs to create this many funding txes".to_string(),
             ));
         }
@@ -490,7 +493,7 @@ impl Wallet {
             }
         }
         if list_unspent_count.is_none() {
-            return Err(WalletError::Protocol(
+            return Err(WalletError::General(
                 "Not enough UTXOs/value to create funding txes".to_string(),
             ));
         }
@@ -503,7 +506,7 @@ impl Wallet {
             .any(|utxo_value| utxo_value > coinswap_amount.to_sat())
         {
             // TODO: Handle this case
-            Err(WalletError::Protocol(
+            Err(WalletError::General(
                 "Some stupid error that will never occur".to_string(),
             ))
         } else {

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -51,7 +51,7 @@ impl TryFrom<&RPCConfig> for Client {
             config.auth.clone(),
         )?;
         if config.network != rpc.get_blockchain_info()?.chain {
-            return Err(WalletError::Protocol(
+            return Err(WalletError::General(
                 "RPC Network not mathcing with RPCConfig".to_string(),
             ));
         }


### PR DESCRIPTION
Resolves #253, #237 

Removes unwraps from `utill.rs` and `taker` modules. 

Note: `setup_logger` unwraps are kept intact. As this is only used once in cli apps, where unwraps at `main.rs` it doesn't have any effect. We will later refator this anyway for custom logger. Wasn't worth to add one more error variants just for this.

Added a few more unwraps removal from maker and market. 