### PR TITLE
[WIP] Refactor `taker-cli` & remove `rpc_port` from `TakerConfig`

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -89,16 +89,13 @@ enum Commands {
         #[clap(name = "send_amount")]
         send_amount: u64,
         /// Sets the fee-rate.
-        #[clap(name = "fee_rate")]
+        #[clap(name = "fee_rate")] //TODO: WILL BE REMOVED AFTER MAKER FEE
         fee_rate: u64,
         /// Sets the required on-chain confirmations.
-        #[clap(name = "required_confirms")] // TODO: Should we have default as 1?
+        #[clap(name = "required_confirms")] // TODO: WILL BE REMOVED AFTER MAKER FEE
         required_confirms: u64,
         /// Sets the maker count to initiate coinswap with.
         #[clap(name = "maker_count", default_value = "2")]
-        // THINK: I do not want to  discard its default value as `maker_count =2`` resembles the coinswap protocol example.
-        // But due to which this arg has to kept after the required ones -> so will it makes sense to have this arg at the end even though
-        // It's the most important aspect of `do-coinswap`?
         maker_count: usize,
         /// Sets the transaction count.
         #[clap(name = "tx_count", default_value = "3")]

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -97,7 +97,7 @@ fn network_bootstrap(
                     maker_port,
                     format!("/tmp/tor-rust-maker{}", maker_port),
                 ));
-                thread::sleep(Duration::from_secs(10));
+                thread::sleep(Duration::from_secs(1));
 
                 if let Err(e) = monitor_log_for_completion(&PathBuf::from(tor_log_dir), "100%") {
                     log::error!("[{}] Error monitoring log file: {}", maker_port, e);

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -241,7 +241,7 @@ pub fn start_directory_server(directory: Arc<DirectoryServer>) -> Result<(), Dir
                     "/tmp/tor-rust-directory".to_string(),
                 ));
 
-                sleep(Duration::from_secs(10));
+                sleep(Duration::from_secs(1));
 
                 if let Err(e) = monitor_log_for_completion(&PathBuf::from(tor_log_dir), "100%") {
                     log::error!("Error monitoring Directory log file: {}", e);

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1906,6 +1906,9 @@ impl Taker {
         }
     }
 
+    pub fn list_offers(&self) -> &Vec<OfferAndAddress> {
+        &self.offerbook.all_makers
+    }
     /// Synchronizes the offer book with addresses obtained from directory servers and local configurations.
     pub fn sync_offerbook(&mut self, maker_count: usize) -> Result<(), TakerError> {
         let directory_address = match self.config.connection_type {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -258,7 +258,7 @@ impl Taker {
                         "/tmp/tor-rust-taker".to_string(),
                     ));
 
-                    thread::sleep(Duration::from_secs(10));
+                    thread::sleep(Duration::from_secs(1));
 
                     if let Err(e) = monitor_log_for_completion(&PathBuf::from(tor_log_dir), "100%")
                     {
@@ -438,6 +438,7 @@ impl Taker {
             // Fail early if not enough good makers in the list to satisfy swap requirements.
             let untried_maker_count = self.offerbook.get_all_untried().len();
 
+            log::info!("untried_maker_count {:?}", untried_maker_count);
             if untried_maker_count < (self.ongoing_swap_state.swap_params.maker_count) {
                 log::error!("Not enough makers to satisfy swap requirements.");
                 return Err(TakerError::NotEnoughMakersInOfferBook);
@@ -515,7 +516,7 @@ impl Taker {
         };
 
         log::debug!(
-            "Outgoing SwapCoins: {:?}",
+            "Outgoing SwapCoins: {:#?}",
             self.ongoing_swap_state.outgoing_swapcoins
         );
 
@@ -1947,6 +1948,7 @@ impl Taker {
             maker_count,
             self.config.connection_type,
         )?;
+        log::info!("addresses from file : \n{:?}", addresses_from_dns);
         let offers = fetch_offer_from_makers(addresses_from_dns, &self.config)?;
 
         let new_offers = offers
@@ -1973,6 +1975,7 @@ impl Taker {
                 log::info!("Fideity Bond verification succes. Adding offer to our OfferBook");
                 self.offerbook.add_new_offer(&offer);
             }
+            log::debug!("Offerbook : \n{:?}", self.offerbook);
         }
         Ok(())
     }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -299,7 +299,10 @@ impl Taker {
         // Try first hop. Abort if error happens.
         if let Err(e) = self.init_first_hop() {
             log::error!("Could not initiate first hop: {:?}", e);
-            self.recover_from_swap()?;
+            if !self.ongoing_swap_state.funding_txs.is_empty() {
+                self.recover_from_swap()?;
+            }
+
             return Err(e);
         }
 

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -9,7 +9,14 @@ use std::{io, io::Write, path::Path};
 /// Taker configuration with refund, connection, and sleep settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TakerConfig {
-    /// Network listening port
+    /// Network listening port.
+    /// This port is used by the Tor hidden service to bind and listen for incoming connections.  
+    /// While the taker does not function as a traditional server, this port is crucial for  
+    /// establishing a Tor hidden service. The Tor process leverages this port to create an  
+    /// internal endpoint, enabling secure communication with peers, such as makers, over the  
+    /// Tor network.  
+    /// By binding to this port, the taker facilitates private and anonymous peer-to-peer (P2P)  
+    /// interactions, preventing its real IP address from being exposed.
     pub port: u16,
     /// Socks port
     pub socks_port: u16,
@@ -17,8 +24,6 @@ pub struct TakerConfig {
     pub directory_server_address: String,
     /// Connection type
     pub connection_type: ConnectionType,
-    /// RPC port
-    pub rpc_port: u16,
 }
 
 impl Default for TakerConfig {
@@ -28,7 +33,6 @@ impl Default for TakerConfig {
             socks_port: 19050,
             directory_server_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
             connection_type: ConnectionType::TOR,
-            rpc_port: 8081,
         }
     }
 }
@@ -77,7 +81,6 @@ impl TakerConfig {
                 config_map.get("connection_type"),
                 default_config.connection_type,
             ),
-            rpc_port: parse_field(config_map.get("rpc_port"), default_config.rpc_port),
         })
     }
 
@@ -86,14 +89,9 @@ impl TakerConfig {
         let toml_data = format!(
             "port = {}
 socks_port = {}
-rpc_port = {}
 directory_server_address = {}
 connection_type = {:?}",
-            self.port,
-            self.socks_port,
-            self.rpc_port,
-            self.directory_server_address,
-            self.connection_type
+            self.port, self.socks_port, self.directory_server_address, self.connection_type
         );
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
         let mut file = std::fs::File::create(path)?;

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -9,16 +9,10 @@ use std::{io, io::Write, path::Path};
 /// Taker configuration with refund, connection, and sleep settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TakerConfig {
-    /// Network listening port.
-    /// This port is used by the Tor hidden service to bind and listen for incoming connections.  
-    /// While the taker does not function as a traditional server, this port is crucial for  
-    /// establishing a Tor hidden service. The Tor process leverages this port to create an  
-    /// internal endpoint, enabling secure communication with peers, such as makers, over the  
-    /// Tor network.  
-    /// By binding to this port, the taker facilitates private and anonymous peer-to-peer (P2P)  
-    /// interactions, preventing its real IP address from being exposed.
+    /// Used by the Tor hidden service to bind and accept connections.
+    /// This port enables secure and private peer-to-peer communication over the Tor network without exposing the taker's real IP address.
     pub port: u16,
-    /// Socks port
+    /// Port for routing traffic through the SOCKS proxy to connect to the Tor network.
     pub socks_port: u16,
     /// Directory server address (can be clearnet or onion)
     pub directory_server_address: String,

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -25,7 +25,7 @@ impl Default for TakerConfig {
         Self {
             port: 8000,
             socks_port: 19050,
-            directory_server_address: "directoryhiddenserviceaddress.onion:8080".to_string(),
+            directory_server_address: "127.0.0.1:8080".to_string(),
             connection_type: ConnectionType::TOR,
         }
     }

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -164,9 +164,9 @@ pub fn fetch_offer_from_makers(
         );
         let join_result = thread.join();
         if let Ok(r) = join_result {
-            log::info!("Thread closing result: {:?}", r)
+            log::debug!("Thread closing result: {:?}", r)
         } else if let Err(e) = join_result {
-            log::info!("Error in internal thread: {:?}", e);
+            log::debug!("Error in internal thread: {:?}", e);
         }
     }
     Ok(result)

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -449,6 +449,7 @@ fn download_maker_offer_attempt_once(
     config: &TakerConfig,
 ) -> Result<Offer, TakerError> {
     let address = addr.to_string();
+    log::info!("connecting to maker");
     let mut socket = match config.connection_type {
         ConnectionType::CLEARNET => TcpStream::connect(address)?,
         ConnectionType::TOR => Socks5Stream::connect(
@@ -486,7 +487,9 @@ pub fn download_maker_offer(address: MakerAddress, config: TakerConfig) -> Optio
 
     loop {
         ii += 1;
-        match download_maker_offer_attempt_once(&address, &config) {
+        let result = download_maker_offer_attempt_once(&address, &config);
+        log::info!("result :{:?}", result);
+        match result {
             Ok(offer) => return Some(OfferAndAddress { offer, address }),
             Err(TakerError::IO(e)) => {
                 if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut {
@@ -522,6 +525,15 @@ pub fn download_maker_offer(address: MakerAddress, config: TakerConfig) -> Optio
                     );
                     return None;
                 }
+            }
+        }
+
+
+
+        let a= match result{
+            Ok(offer)=>Some(OfferAndAddress { offer, address }), 
+            Err(e) => {
+                
             }
         }
     }

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -401,6 +401,7 @@ pub fn monitor_log_for_completion(log_file: &Path, pattern: &str) -> io::Result<
 
             for line in lines {
                 if let Ok(line) = line {
+                    // log::info!("{line}");
                     if line.contains(pattern) {
                         log::info!("Tor instance bootstrapped");
                         return Ok(());

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1054,6 +1054,7 @@ impl Wallet {
         // the simplest largest first coinselection.
         for unspent in unspents {
             if remaining.checked_sub(unspent.0.amount).is_none() {
+                remaining = Amount::ZERO;
                 selected_utxo.push(unspent);
                 break;
             } else {
@@ -1061,6 +1062,18 @@ impl Wallet {
                 selected_utxo.push(unspent);
             }
         }
+        log::info!("selected utxo :\n\n {:#?}", selected_utxo);
+
+        log::info!("remainig :{:?}", remaining);
+        if remaining != Amount::ZERO {
+            log::info!("remainig :{:?}", remaining);
+
+            return Err(WalletError::InsufficientFund {
+                available: (amount - remaining).to_btc(),
+                required: amount.to_btc(),
+            });
+        }
+
         Ok(selected_utxo)
     }
 

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -56,7 +56,7 @@ impl Wallet {
         //     return ret;
         // }
 
-        log::info!(target: "wallet", "failed to create funding txes with any method");
+        log::info!(target: "wallet", "failed to create funding txes");
         ret
     }
 
@@ -148,11 +148,14 @@ impl Wallet {
 
             let fee = fee_rate;
             let remaining = Amount::from_sat(output_value);
-            let selected_utxo = self.coin_select(remaining)?;
+            let selected_utxo = self.coin_select(remaining + fee)?;
+            log::info!("selected utxo: {:?}", selected_utxo);
             let total_input_amount = selected_utxo.iter().fold(Amount::ZERO, |acc, (unspet, _)| {
                 acc.checked_add(unspet.amount)
                     .expect("Amount sum overflowed")
             });
+
+            log::info!("total_input amount : {:?}", total_input_amount);
             let change_amount = total_input_amount.checked_sub(remaining + fee);
             let mut tx_outs = vec![TxOut {
                 value: Amount::from_sat(output_value),


### PR DESCRIPTION
This pr aims to: 
* remove `rpc_port` from `TakerConfig` as Taker is just a application which doesn't require a `rpc_port`.
but it requires `port` just for having `hidden services` while running on tor for maintaining privacy so Documented that point.
* move all `do-coinswap`  related arguments inside the command.
* remove `sync-offerbook` call as this syncing process is done while performing `coinswap` and thus we don't require to have a seperate command for that.
* create `list-offerbook` call to see all the offers which taker has in his offerbook.


## Work left to be done here ( after merging of #305 ,  #311 ) : 
- There is a potential bug while calling `do-coinswap` call -> I am planning to include that bug fix in this pr itself 
- I'll also extend the `taker-cli` IT to test the remaining commands 
