### PR TITLE
fix the connection state map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 description = "Functioning, minimal-viable binaries and libraries to perform a trustless, p2p Maxwell-Belcher Coinswap Protocol"
 license = "MIT OR Apache-2.0"          
-license-file = "LICENSE"               
 documentation = "https://docs.rs/coinswap"
 homepage = "https://github.com/citadel-tech/coinswap" 
 repository = "https://github.com/citadel-tech/coinswap" 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -26,7 +26,6 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::RpcApi;
 use std::{
     collections::HashMap,
-    net::IpAddr,
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
@@ -226,7 +225,7 @@ pub struct Maker {
     /// A flag to trigger shutdown event
     pub shutdown: AtomicBool,
     /// Map of IP address to Connection State + last Connected instant
-    pub(crate) connection_state: Mutex<HashMap<IpAddr, (ConnectionState, Instant)>>,
+    pub(crate) connection_state: Mutex<HashMap<String, (ConnectionState, Instant)>>,
     /// Highest Value Fidelity Proof
     pub(crate) highest_fidelity_proof: RwLock<Option<FidelityProof>>,
     /// Is setup complete
@@ -566,7 +565,7 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
                                 );
                             }
                         }
-                        failed_swap_ip.push(*ip);
+                        failed_swap_ip.push(ip.clone());
 
                         // Spawn a separate thread to wait for contract maturity and broadcasting timelocked.
                         let maker_clone = maker.clone();
@@ -697,7 +696,7 @@ pub(crate) fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError>
                         let incoming_contract = ic_sc.get_fully_signed_contract_tx()?;
                         incomings.push((ic_sc.get_multisig_redeemscript(), incoming_contract));
                     }
-                    bad_ip.push(*ip);
+                    bad_ip.push(ip.clone());
                     // Spawn a separate thread to wait for contract maturity and broadcasting timelocked.
                     let maker_clone = maker.clone();
                     log::info!(

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -1295,6 +1295,7 @@ mod test {
             }],
             refund_locktime: u16::default(),
             contract_feerate: u64::default(),
+            id: "random".to_string(),
         };
 
         // case with same hash value
@@ -1324,6 +1325,7 @@ mod test {
             }],
             refund_locktime: u16::default(),
             contract_feerate: u64::default(),
+            id: "random".to_string(),
         };
 
         let hash_value_from_fn = check_hashvalues_are_equal(&funding_proof).unwrap_err();

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -144,6 +144,7 @@ pub(crate) struct ProofOfFunding {
     pub(crate) next_coinswap_info: Vec<NextHopInfo>,
     pub(crate) refund_locktime: u16,
     pub(crate) contract_feerate: u64,
+    pub(crate) id: String,
 }
 
 /// Signatures required for an intermediate Maker to perform receiving and sending of coinswaps.
@@ -159,6 +160,8 @@ pub(crate) struct ContractSigsForRecvrAndSender {
     pub(crate) receivers_sigs: Vec<Signature>,
     /// Sigs from the next peer for Contract Tx of next hop, (coinswap sent by this Maker).
     pub(crate) senders_sigs: Vec<Signature>,
+    /// Unique ID for a swap
+    pub(crate) id: String,
 }
 
 /// Message to Transfer [`HashPreimage`] from Taker to Makers.

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -260,6 +260,7 @@ pub(crate) fn send_proof_of_funding_and_init_next_hop(
     tmi: ThisMakerInfo,
     npi: NextMakerInfo,
     hashvalue: Hash160,
+    id: String,
 ) -> Result<(ContractSigsAsRecvrAndSender, Vec<ScriptBuf>), TakerError> {
     // Send POF
     let next_coinswap_info = npi
@@ -279,6 +280,7 @@ pub(crate) fn send_proof_of_funding_and_init_next_hop(
         next_coinswap_info,
         refund_locktime: tmi.this_maker_refund_locktime,
         contract_feerate: MINER_FEE,
+        id,
     });
 
     send_message(socket, &pof_msg)?;


### PR DESCRIPTION
Use a unique swap ID to key the maker's internal connection state map and allow multiple swaps to occur simultaneously. 