### PR TITLE
Don't timeout waiting for funding confirmation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Currently, it is required to run the apps from the project root dirtectory only.
 The apps also requires a fully synced, non-prunded `bitcoind` node with RPC access on Testnet4 with `-txindex` enabled. 
 
 An example `bitcoin.conf` with the required and other optional flags:
-```
+```bash
 testnet4=1 #Required
 server=1
 txindex=1 #Required

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -21,4 +21,13 @@ if ! cargo hack --feature-powerset check; then
     exit 1
 fi
 
+# Check for unit tests
+echo "Checking Unit Tests..."
+if ! cargo test; then
+    echo "unit test failed"
+    echo "Please fix the issues before committing."
+    exit 1
+fi
+
+
 exit 0 

--- a/notes.md
+++ b/notes.md
@@ -1,2 +1,0 @@
-# Install c-compiler essentials.
-sudo apt install build-essential automake libtool

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -105,7 +105,13 @@ enum Commands {
 
 fn main() -> Result<(), TakerError> {
     let args = Cli::parse();
-    setup_taker_logger(LevelFilter::from_str(&args.verbosity).unwrap());
+    setup_taker_logger(
+        LevelFilter::from_str(&args.verbosity).unwrap(),
+        matches!(
+            args.command,
+            Commands::Recover | Commands::FetchOffers | Commands::Coinswap { .. }
+        ),
+    );
 
     let rpc_config = RPCConfig {
         url: args.rpc,
@@ -168,7 +174,7 @@ fn main() -> Result<(), TakerError> {
             println!("{:?}", balance);
         }
         Commands::GetBalance => {
-            let balance = taker.get_wallet().spendable_balance()?;
+            let balance = taker.get_wallet().spendable_balance(None)?;
             println!("{:?}", balance);
         }
         Commands::GetNewAddress => {

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -56,8 +56,8 @@ pub const RPC_PING_INTERVAL: Duration = Duration::from_secs(10);
 // TODO: Make the maker repost their address to DNS once a day in spawned thread.
 // pub const DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = Duartion::from_days(1); // Once a day.
 
-/// Maker triggers the recovery mechanism, if Taker is idle for more than 1 hour.
-pub const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+/// Maker triggers the recovery mechanism, if Taker is idle for more than 15 mins during a swap.
+pub const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60 * 15);
 
 /// The minimum difference in locktime (in blocks) between the incoming and outgoing swaps.
 ///

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -49,6 +49,20 @@ pub(crate) fn handle_message(
     connection_state: &mut ConnectionState,
     message: TakerToMakerMessage,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
+    // If taker is waiting for funding confirmation, reset the timer.
+    if let TakerToMakerMessage::WaitingFundingConfirmation(id) = &message {
+        log::info!(
+            "[{}] Taker is waiting for funding confirmation. Reseting timer.",
+            maker.config.network_port
+        );
+        maker
+            .connection_state
+            .lock()?
+            .entry(id.clone())
+            .and_modify(|(_, timer)| *timer = Instant::now());
+        return Ok(None);
+    }
+
     let outgoing_message = match connection_state.allowed_message {
         ExpectedMessage::TakerHello => {
             if let TakerToMakerMessage::TakerHello(m) = message {
@@ -397,7 +411,7 @@ impl Maker {
             .expect("This should not overflow as we just above.");
 
         log::info!(
-            "[{}] Outgoing Funding Txids: {:?}.",
+            "[{}] Prepared outgoing funding txs: {:?}.",
             self.config.network_port,
             my_funding_txes
                 .iter()
@@ -514,7 +528,7 @@ impl Maker {
             my_funding_txids.push(txid);
         }
         log::info!(
-            "[{}] Outgoing Funding Txids: {:?}",
+            "[{}] Broadcasted funding txs: {:?}",
             self.config.network_port,
             my_funding_txids
         );

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -73,7 +73,7 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
             RpcMsgResp::FidelityBalanceResp(balance.to_sat())
         }
         RpcMsgReq::Balance => {
-            let balance = maker.get_wallet().read()?.spendable_balance()?;
+            let balance = maker.get_wallet().read()?.spendable_balance(None)?;
             RpcMsgResp::SeedBalanceResp(balance.to_sat())
         }
         RpcMsgReq::SwapBalance => {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -469,13 +469,26 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // Initialize network connections.
 
     // Setup the wallet with fidelity bond.
+    let _tor_thread = network_bootstrap(maker.clone())?;
+
     let port = maker.config.network_port;
     let network = maker.get_wallet().read()?.store.network;
-    let balance = maker.get_wallet().read()?.spendable_balance()?;
-    log::info!("[{}] Currency Network: {}", port, network);
-    log::info!("[{}] Total Wallet Balance: {}", port, balance);
-
-    let _tor_thread = network_bootstrap(maker.clone())?;
+    let offer_max_size = maker.get_wallet().read()?.store.offer_maxsize;
+    let utxos = maker.get_wallet().read()?.get_all_utxo()?;
+    let balance = maker.get_wallet().read()?.spendable_balance(Some(&utxos))?;
+    let fidelity_amount = maker
+        .get_wallet()
+        .read()?
+        .balance_fidelity_bonds(Some(&utxos))?;
+    log::info!("[{}] Bitcoin Network: {}", port, network);
+    log::info!("[{}] Spenable Wallet Balance: {}", port, balance);
+    log::info!("[{}] Fidelity Bond Amount : {}", port, fidelity_amount);
+    log::info!(
+        "[{}] Minimum Swap Size {}",
+        port,
+        maker.config.min_swap_amount
+    );
+    log::info!("[{}] Maximum Swap Size {}", port, offer_max_size);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, maker.config.network_port))
         .map_err(NetError::IO)?;
@@ -570,6 +583,12 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // Each client connection will spawn a new handler thread, which is added back in the global thread_pool.
     // This loop beats at `maker.config.heart_beat_interval_secs`
     while !maker.shutdown.load(Relaxed) {
+        if offer_max_size <= maker.config.min_swap_amount {
+            log::warn!("Swap liquidity less than minimum threshold, Please put more funds in the wallet | Min required {} sats | Available {} sats", maker.config.min_swap_amount, offer_max_size);
+            sleep(HEART_BEAT_INTERVAL);
+            continue;
+        }
+
         let maker = maker.clone(); // This clone is needed to avoid moving the Arc<Maker> in each iterations.
 
         // Block client connections if accepting_client=false

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -204,6 +204,7 @@ pub(crate) enum TakerToMakerMessage {
     RespHashPreimage(HashPreimage),
     /// Respond by handing over the Private Keys of coinswap multisig. This denotes the completion of the whole swap.
     RespPrivKeyHandover(PrivKeyHandover),
+    WaitingFundingConfirmation(String),
 }
 
 impl Display for TakerToMakerMessage {
@@ -219,6 +220,7 @@ impl Display for TakerToMakerMessage {
             Self::ReqContractSigsForRecvr(_) => write!(f, "ReqContractSigsForRecvr"),
             Self::RespHashPreimage(_) => write!(f, "RespHashPreimage"),
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
+            Self::WaitingFundingConfirmation(_) => write!(f, "WaitingFundingConfirmation"),
         }
     }
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -395,10 +395,10 @@ impl Taker {
         self.ongoing_swap_state.swap_params = swap_params;
         self.ongoing_swap_state.id = unique_id;
 
-        let available = self.wallet.spendable_balance()?;
+        let available = self.wallet.spendable_balance(None)?;
 
         // TODO: Make more exact estimate of swap cost and ensure balanbce.
-        // For now ensure at least swap_amount + 10000 is available.
+        // For now ensure at least swap_amount + 1000 sats is available.
         let required = swap_params.send_amount + Amount::from_sat(1000);
         if available < required {
             let err = WalletError::InsufficientFund {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -9,7 +9,7 @@
 //! [Taker::do_coinswap]: The routine running all other protocol subroutines.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     io::BufWriter,
     net::TcpStream,
     path::PathBuf,
@@ -631,7 +631,7 @@ impl Taker {
             .iter()
             .map(|tx| {
                 let txid = self.wallet.send_tx(tx)?;
-                log::info!("Funding Txid: {}", txid);
+                log::info!("Broadcasted Funding tx. txid: {}", txid);
                 assert_eq!(txid, tx.compute_txid());
                 Ok(txid)
             })
@@ -668,30 +668,39 @@ impl Taker {
         let mut txid_tx_map = HashMap::<Txid, Transaction>::new();
         let mut txid_blockhash_map = HashMap::<Txid, BlockHash>::new();
 
-        // Required confirmation target for the funding txs.
-        let required_confirmations =
+        // Find next maker's details
+        let (required_confirmations, maker_addr) =
             if self.ongoing_swap_state.taker_position == TakerPosition::LastPeer {
-                self.ongoing_swap_state.swap_params.required_confirms
+                (self.ongoing_swap_state.swap_params.required_confirms, None)
             } else {
                 self.ongoing_swap_state
                     .peer_infos
                     .last()
+                    .map(|npi| {
+                        (
+                            npi.peer.offer.required_confirms,
+                            Some(npi.peer.address.clone()),
+                        )
+                    })
                     .expect("Maker information expected in swap state")
-                    .peer
-                    .offer
-                    .required_confirms
             };
         log::info!(
-            "Waiting for funding transaction confirmations ({} conf required)",
-            required_confirmations
+            "Waiting for funding transaction confirmation. Txids : {:?}",
+            funding_txids
         );
-        let mut txids_seen_once = HashSet::<Txid>::new();
 
         // Wait for this much time for txs to appear in mempool.
-        let wait_time = if cfg!(feature = "integration-test") {
+        let mempool_wait_timeout = if cfg!(feature = "integration-test") {
             10u64 // 10 secs for the tests
         } else {
             60 * 5 // 5mins for production
+        };
+
+        // Check for funding confirmation at this frequency
+        let sleep_interval = if cfg!(feature = "integration-test") {
+            1u64 // 1 secs for the tests
+        } else {
+            30 // 30 secs for production
         };
 
         let start_time = Instant::now();
@@ -701,14 +710,14 @@ impl Taker {
             // TODO: Find the culprit Maker, and ban it's fidelity bond.
             let contracts_broadcasted = self.check_for_broadcasted_contract_txes();
             if !contracts_broadcasted.is_empty() {
-                log::info!(
-                    "Contract transactions were broadcasted : {:?}",
+                log::error!(
+                    "Fatal! Contract txs broadcasted by makers. Txids : {:?}",
                     contracts_broadcasted
                 );
                 return Err(TakerError::ContractsBroadcasted(contracts_broadcasted));
             }
 
-            // Check for funding transactions
+            // Check for each funding transactions if they are confirmed
             for txid in funding_txids {
                 if txid_tx_map.contains_key(txid) {
                     continue;
@@ -718,29 +727,39 @@ impl Taker {
                     // Transaction haven't arrived in our mempool, keep looping.
                     Err(_e) => {
                         let elapsed = start_time.elapsed().as_secs();
-                        log::info!("Waiting for mempool transaction for {}secs", elapsed);
-                        if elapsed > wait_time {
+                        log::info!(
+                            "Waiting for funding tx to appear in mempool | {} secs",
+                            elapsed
+                        );
+                        if elapsed > mempool_wait_timeout {
+                            log::error!("Timed out waiting for funding tx to appear in mempool. | No tx seen in {} secs", elapsed);
                             return Err(TakerError::FundingTxWaitTimeOut);
                         }
                         continue;
                     }
                 };
-                if !txids_seen_once.contains(txid) {
-                    txids_seen_once.insert(*txid);
-                    if gettx.confirmations.is_none() {
-                        let mempool_tx = match self.wallet.rpc.get_mempool_entry(txid) {
-                            Ok(m) => m,
-                            Err(_e) => {
-                                continue;
-                            }
-                        };
-                        log::info!(
-                            "Tx {} Seen in Mempool | [{:.1} sat/vbyte]",
-                            txid,
-                            (mempool_tx.fees.base.to_sat() as f32) / (mempool_tx.vsize as f32)
-                        );
+
+                // log that its waiting for confirmation.
+                if gettx.confirmations.is_none() {
+                    let elapsed = start_time.elapsed().as_secs();
+                    log::info!(
+                        "Funding tx Seen in Mempool. Waiting for confirmation for {} secs",
+                        elapsed,
+                    );
+
+                    if let Some(maker_addr) = &maker_addr {
+                        self.send_to_maker(
+                            maker_addr,
+                            TakerToMakerMessage::WaitingFundingConfirmation(
+                                self.ongoing_swap_state.id.clone(),
+                            ),
+                        )?;
+                    } else {
+                        log::info!("Waiting for our incoming funding tx.");
                     }
                 }
+
+                // handle confirmations
                 //TODO handle confirm<0
                 if gettx.confirmations >= Some(required_confirmations) {
                     txid_tx_map.insert(
@@ -780,7 +799,7 @@ impl Taker {
                     .map_err(WalletError::from)?;
                 return Ok((txes, merkleproofs));
             }
-            sleep(Duration::from_millis(1000));
+            sleep(Duration::from_secs(sleep_interval));
         }
     }
 
@@ -2005,6 +2024,11 @@ impl Taker {
             }
 
             // Everything is broadcasted. Clear the connectionstate and break the loop
+            log::info!(
+                "{} outgoing contracts detected | {} timelock txs broadcasted.",
+                outgoing_infos.len(),
+                timelock_boardcasted.len()
+            );
             if timelock_boardcasted.len() == outgoing_infos.len() {
                 log::info!("All outgoing contracts reedemed. Cleared ongoing swap state");
                 // TODO: Reevaluate this.
@@ -2113,5 +2137,33 @@ impl Taker {
         self.tor_handle = self.setup_tor()?;
         self.sync_offerbook()?;
         Ok(&self.offerbook)
+    }
+
+    /// Send any message to a maker
+    fn send_to_maker(
+        &self,
+        maker_addr: &MakerAddress,
+        msg: TakerToMakerMessage,
+    ) -> Result<(), TakerError> {
+        // Notify the maker that we are waiting for funding confirmation
+        let address = maker_addr.to_string();
+        let mut socket = match self.config.connection_type {
+            ConnectionType::CLEARNET => TcpStream::connect(address)?,
+            #[cfg(feature = "tor")]
+            ConnectionType::TOR => Socks5Stream::connect(
+                format!("127.0.0.1:{}", self.config.socks_port).as_str(),
+                address.as_str(),
+            )?
+            .into_inner(),
+        };
+
+        let reconnect_timeout = Duration::from_secs(TCP_TIMEOUT_SECONDS);
+
+        socket.set_write_timeout(Some(reconnect_timeout))?;
+
+        send_message(&mut socket, &msg)?;
+        log::info!("===> Sent {} to {}", msg, maker_addr);
+
+        Ok(())
     }
 }

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -482,7 +482,7 @@ fn download_maker_offer_attempt_once(
         }
     };
 
-    log::info!("Got offer from : {} | {:?}", maker_addr, offer);
+    log::info!("Got offer from : {} ", maker_addr);
 
     Ok(*offer)
 }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -281,9 +281,12 @@ impl Wallet {
     }
 
     /// Calculates the total spendable balance of the wallet. Includes all utxos except the fidelity bond.
-    pub fn spendable_balance(&self) -> Result<Amount, WalletError> {
+    pub fn spendable_balance(
+        &self,
+        utxos: Option<&Vec<ListUnspentResultEntry>>,
+    ) -> Result<Amount, WalletError> {
         Ok(self
-            .list_all_utxo_spend_info(None)?
+            .list_all_utxo_spend_info(utxos)?
             .iter()
             .filter(|(_, spend_info)| !matches!(spend_info, UTXOSpendInfo::FidelityBondCoin { .. }))
             .fold(Amount::ZERO, |a, (utxo, _)| a + utxo.amount))

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -182,16 +182,31 @@ impl Wallet {
 
             let lock_time = LockTime::from_height(current_height as u32)?;
 
+            let actual_fee = total_input_amount
+                - (tx_outs.iter().fold(Amount::ZERO, |a, txo| {
+                    a.checked_add(txo.value)
+                        .expect("output amount sumation overflowred")
+                }));
+
             let mut funding_tx = Transaction {
                 input: tx_inputs,
                 output: tx_outs,
                 lock_time,
                 version: Version::TWO,
             };
+
             let mut input_info = selected_utxo
                 .iter()
                 .map(|(_, spend_info)| spend_info.clone());
             self.sign_transaction(&mut funding_tx, &mut input_info)?;
+            let tx_size = funding_tx.weight().to_vbytes_ceil();
+            let actual_feerate = actual_fee.to_sat() as f32 / tx_size as f32;
+
+            log::info!(
+                "Created Funding tx, txid : {} | Feerate: {:.2} sats/vb",
+                funding_tx.compute_txid(),
+                actual_feerate
+            );
 
             self.rpc.lock_unspent(
                 &funding_tx


### PR DESCRIPTION
This PR packages many small improvements along with a big one. Taker sends a new message to maker while its waiting for the funding confirmation. Upon receiving the maker restarts the timer.

This allows us to wait for variable confirmation time (which is hard to predict in testnet) without timing out the connections.

Some other auxiliary improves:
- Improve some loging in taker and maker.
- Raise a warning if the maker's swap liquidity is less than `min_offer_size`. It will not listen for a swap request unless enough balance is sent to the wallet.
- Calculate funding tx feerate manually, don't need to make another rpc call for it.
- add `cargo test` to precommit-hook.
- Reduce connection timeout for maker to 15 mins. Because now we will only timeout for actual connection drops. Now Takers in average sends a message approx every minute.  