### PR TITLE
add github_check annotation to codecov

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,3 +11,5 @@ coverage:
         target: auto
         threshold: 100%
         base: auto
+github_checks:
+    annotations: false


### PR DESCRIPTION
This PR removes codecov annotation in github diff checker.