### PR TITLE
fix: assert `tor_handle.is_none()` when tor disabled

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -188,7 +188,7 @@ impl Drop for Taker {
         log::info!("Wallet data saved to disk.");
 
         if !cfg!(feature = "tor") {
-            assert!(self.tor_handle.is_some(), "Tor handle should not exist")
+            assert!(self.tor_handle.is_none(), "Tor handle should not exist")
         }
 
         #[cfg(feature = "tor")]


### PR DESCRIPTION
fixes #394 

Test by running the integration tests with `--no-default-features` flag