### PR TITLE
Feature/noise protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libtor = { version = "47.13.0", optional = true, features = ["vendored-openssl"]
 mitosis = { version = "0.1.1", optional = true }
 log4rs = "1.3.0"
 openssl-sys = { version = "0.9.68", optional = true }
+snow = { version = "0.9.6", features = ["ring-accelerated"]}
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ pub enum NetError {
 
     /// Error indicating an invalid CLI application network.
     InvalidAppNetwork,
+
+    NoiseError(snow::Error),
 }
 
 impl std::fmt::Display for NetError {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -198,6 +198,8 @@ impl Drop for Taker {
     }
 }
 
+const NOISE_PARAMS = "Noise_NK_25519_ChaChaPoly_SHA256";
+
 impl Taker {
     // ######## MAIN PUBLIC INTERFACE ############
 
@@ -1436,6 +1438,7 @@ impl Taker {
     fn req_sigs_for_sender<S: SwapCoin>(
         &self,
         maker_address: &MakerAddress,
+        maker_noise_static_public_key: &[u8],
         outgoing_swapcoins: &[S],
         maker_multisig_nonces: &[SecretKey],
         maker_hashlock_nonces: &[SecretKey],
@@ -1472,6 +1475,7 @@ impl Taker {
 
         socket.set_read_timeout(Some(reconnect_time_out))?;
         socket.set_write_timeout(Some(reconnect_time_out))?;
+
 
         loop {
             ii += 1;


### PR DESCRIPTION
This is draft pull request. I did an early implementation for the noise protocol in coinswap with the handshake pattern NK. I did it only for the req_sigs_for_sender step in the protocol, to get feedbacks before continuing further. Notice: 
- This is not compiling yet, because I changed the send_message logic, etc.
- I added a very verbose description of almost every new line of code so you could understand better what I am doing without having to read the noise protocol framework specification. 
- I added only one static noise pair key for every maker, only for developing purposes. We need to handle that static private key carefully, with persistence and of course it should be a different random one for each maker.
- I used Noise_NK_25519_ChaChaPoly_SHA256 pattern, it can be changed, for example ChaCha20-Poly1305 for AES256-GCM or the hash funcion. 
- I combined the coinswap handshake with the noise NK handshake for minimizing overhead, but we can do also noise handshake, and then, after the transport state is settled, we can do coinswap handshake. 

Good to check:
Noise protocol spec: https://noiseprotocol.org/noise.html
Snow crate: https://github.com/mcginty/snow
NoiseExplorer for the NK pattern: https://noiseexplorer.com/patterns/NK/ -> it gives a security analysis for each message in the NK pattern