### PR TITLE
Manage `fidelity bonds` and update `dns`

### DIFF
--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -64,14 +64,6 @@ enum Commands {
     ShowDataDir,
     /// Shutdown the makerd server
     Stop,
-    /// Redeems the fidelity bond if timelock is matured. Returns the txid of the spending transaction.
-    RedeemFidelity {
-        #[clap(long, short = 'i', default_value = "0")]
-        index: u32,
-        /// Feerate in sats/vByte. Defaults to 2 sats/vByte
-        #[clap(long, short = 'f')]
-        feerate: Option<f64>,
-    },
     /// Show all the fidelity bonds, current and previous, with an (index, {bond_proof, is_spent}) tupple.
     ShowFidelity,
     /// Sync the maker wallet with current blockchain state.
@@ -127,15 +119,6 @@ fn main() -> Result<(), MakerError> {
         }
         Commands::Stop => {
             send_rpc_req(stream, RpcMsgReq::Stop)?;
-        }
-        Commands::RedeemFidelity { index, feerate } => {
-            send_rpc_req(
-                stream,
-                RpcMsgReq::RedeemFidelity {
-                    index,
-                    feerate: feerate.unwrap_or(DEFAULT_TX_FEE_RATE),
-                },
-            )?;
         }
         Commands::ShowFidelity => {
             send_rpc_req(stream, RpcMsgReq::ListFidelity)?;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -51,11 +51,6 @@ use super::{config::MakerConfig, error::MakerError};
 /// Interval for health checks on a stable RPC connection with bitcoind.
 pub const RPC_PING_INTERVAL: u32 = 9;
 
-// Currently we don't refresh address at DNS. The Maker only post it once at startup.
-// If the address record gets deleted, or the DNS gets blasted, the Maker won't know.
-// TODO: Make the maker repost their address to DNS once a day in spawned thread.
-// pub const DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = Duartion::from_days(1); // Once a day.
-
 /// Maker triggers the recovery mechanism, if Taker is idle for more than 15 mins during a swap.
 #[cfg(feature = "integration-test")]
 pub const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
@@ -114,12 +109,19 @@ pub const TIME_RELATIVE_FEE_PCT: f64 = 0.005;
 /// Minimum Coinswap amount; makers will not#[cfg(feature = "integration-test")] accept amounts below this.
 pub const MIN_SWAP_AMOUNT: u64 = 10_000;
 
+/// Interval for redeeming expired bonds, creating new ones if needed,  
+/// and updating the DNS server with the latest bond proof and maker address.
+#[cfg(feature = "integration-test")]
+pub(crate) const FIDELITY_BOND_DNS_UPDATE_INTERVAL: u32 = 30;
+#[cfg(not(feature = "integration-test"))]
+pub(crate) const FIDELITY_BOND_DNS_UPDATE_INTERVAL: u32 = 600; // 1 Block Interval
+
 /// Interval to check if there is enough liquidity for swaps.
 /// If the available balance is below the minimum, maker server won't listen for any swap requests until funds are added.
 #[cfg(feature = "integration-test")]
 pub(crate) const SWAP_LIQUIDITY_CHECK_INTERVAL: u32 = 30;
 #[cfg(not(feature = "integration-test"))]
-pub(crate) const SWAP_LIQUIDITY_CHECK_INTERVAL: u32 = 900; // Equals to DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS.
+pub(crate) const SWAP_LIQUIDITY_CHECK_INTERVAL: u32 = 600; // Equals to FIDELITY_BOND_DNS_UPDATE_INTERVAL
 
 /// Used to configure the maker for testing purposes.
 ///

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -52,7 +52,7 @@ impl Default for MakerConfig {
             #[cfg(not(feature = "integration-test"))]
             fidelity_amount: 50_000, // 50K sats for production
             #[cfg(not(feature = "integration-test"))]
-            fidelity_timelock: 2160, // Approx 15 days of blocks in production
+            fidelity_timelock: 13104, // Approx 3 months of blocks in production
             connection_type: if cfg!(feature = "integration-test") {
                 ConnectionType::CLEARNET
             } else {

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -43,14 +43,6 @@ pub enum RpcMsgReq {
     GetDataDir,
     /// Request to stop the Maker server.
     Stop,
-    /// Request to reddem a fidelity bond for a given (index, feerate).
-    RedeemFidelity {
-        /// Index of the fidelity bond
-        index: u32,
-
-        /// Feerate in sats/vByte
-        feerate: f64,
-    },
     /// Request to list all active and past fidelity bonds.
     ListFidelity,
     /// Request to sync the internal wallet with blockchain.

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -114,15 +114,6 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
             RpcMsgResp::Shutdown
         }
 
-        RpcMsgReq::RedeemFidelity { index, feerate } => {
-            let txid = maker
-                .get_wallet()
-                .write()?
-                .redeem_fidelity(index, feerate)?;
-
-            maker.get_wallet().write()?.sync_no_fail();
-            RpcMsgResp::FidelitySpend(txid)
-        }
         RpcMsgReq::ListFidelity => {
             let list = maker.get_wallet().read()?.display_fidelity_bonds()?;
             RpcMsgResp::ListBonds(list)

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -4,8 +4,10 @@
 //! The server maintains the thread pool for P2P Connection, Watchtower, Bitcoin Backend and RPC Client Request.
 //! The server listens at two port 6102 for P2P, and 6103 for RPC Client request.
 
+use crate::{protocol::messages::FidelityProof, taker::api::MINER_FEE};
 use bitcoin::{absolute::LockTime, Amount};
 use bitcoind::bitcoincore_rpc::RpcApi;
+use socks::Socks5Stream;
 use std::{
     io::ErrorKind,
     net::{Ipv4Addr, TcpListener, TcpStream},
@@ -14,8 +16,6 @@ use std::{
     thread::{self, sleep},
     time::Duration,
 };
-
-use socks::Socks5Stream;
 
 use crate::utill::get_tor_hostname;
 
@@ -27,7 +27,7 @@ use crate::{
         api::{
             check_for_broadcasted_contracts, check_for_idle_states,
             restore_broadcasted_contracts_on_reboot, ConnectionState,
-            SWAP_LIQUIDITY_CHECK_INTERVAL,
+            FIDELITY_BOND_DNS_UPDATE_INTERVAL, SWAP_LIQUIDITY_CHECK_INTERVAL,
         },
         handlers::handle_message,
         rpc::start_rpc_server,
@@ -39,16 +39,13 @@ use crate::{
 
 use crate::maker::error::MakerError;
 
-// Default values for Maker configurations
-pub(crate) const DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS: u64 = 60 * 15; // 15 minutes
-
 /// Fetches the Maker and DNS address, and sends maker address to the DNS server.
 /// Depending upon ConnectionType and test/prod environment, different maker address and DNS addresses are returned.
 /// Return the Maker address and an optional tor thread handle.
 ///
 /// Tor thread is spawned only if ConnectionType=TOR and --feature=tor is enabled.
 /// Errors if ConncetionType=TOR but, the tor feature is not enabled.
-fn network_bootstrap(maker: Arc<Maker>) -> Result<Option<Child>, MakerError> {
+fn network_bootstrap(maker: Arc<Maker>) -> Result<(Option<Child>, String, String), MakerError> {
     let maker_port = maker.config.network_port;
     let (maker_address, dns_address, tor_handle) = match maker.config.connection_type {
         ConnectionType::CLEARNET => {
@@ -76,21 +73,29 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<Option<Child>, MakerError> {
 
     setup_fidelity_bond(&maker, &maker_address)?;
 
-    log::info!(
-        "[{}] Server is listening at {}",
-        maker.config.network_port,
-        maker_address
-    );
+    manage_fidelity_bonds_and_update_dns(maker.as_ref(), &maker_address, &dns_address)?;
 
-    let proof = maker
-        .highest_fidelity_proof
-        .read()?
-        .as_ref()
-        .unwrap()
-        .clone();
+    Ok((tor_handle, maker_address, dns_address))
+}
+
+/// Manages the maker's fidelity bonds and ensures the DNS server is updated with the latest bond proof and maker address.
+///
+/// It performs the following operations:
+/// 1. Redeems all expired fidelity bonds in the maker's wallet, if any are found.
+/// 2. Creates a new fidelity bond if no valid bonds remain after redemption.
+/// 3. Sends a POST request to the DNS server containing the maker's address and the proof of the fidelity bond
+///    with the highest value.
+fn manage_fidelity_bonds_and_update_dns(
+    maker: &Maker,
+    maker_addr: &str,
+    dns_addr: &str,
+) -> Result<(), MakerError> {
+    maker.wallet.write()?.redeem_expired_fidelity_bonds()?;
+
+    let proof = setup_fidelity_bond(maker, maker_addr)?;
 
     let dns_metadata = DnsMetadata {
-        url: maker_address.clone(),
+        url: maker_addr.to_string(),
         proof,
     };
 
@@ -98,80 +103,36 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<Option<Child>, MakerError> {
         metadata: dns_metadata,
     };
 
-    thread::spawn(move || {
-        let trigger_count = DIRECTORY_SERVERS_REFRESH_INTERVAL_SECS / HEART_BEAT_INTERVAL.as_secs();
-        let mut i = 0;
+    let network_port = maker.config.network_port;
 
-        while !maker.shutdown.load(Relaxed) {
-            if i >= trigger_count || i == 0 {
-                let mut stream = match maker.config.connection_type {
-                    ConnectionType::CLEARNET => match TcpStream::connect(&dns_address) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::warn!(
-                                "[{}] TCP connection error with directory, reattempting: {}",
-                                maker_port,
-                                e
-                            );
-                            thread::sleep(HEART_BEAT_INTERVAL);
-                            continue;
-                        }
-                    },
-                    ConnectionType::TOR => {
-                        match Socks5Stream::connect(
-                            format!("127.0.0.1:{}", maker.config.socks_port),
-                            dns_address.as_str(),
-                        )
-                        .map(|stream| stream.into_inner())
-                        {
-                            Ok(s) => s,
-                            Err(e) => {
-                                log::warn!(
-                                    "[{}] TCP connection error with directory, reattempting: {}",
-                                    maker_port,
-                                    e
-                                );
-                                thread::sleep(HEART_BEAT_INTERVAL);
-                                continue;
-                            }
-                        }
-                    }
-                };
+    log::info!("[{}] Connecting to DNS: {}", network_port, dns_addr);
 
-                log::info!(
-                    "[{}] Connecting to DNS: {}",
-                    maker.config.network_port,
-                    dns_address
-                );
+    while !maker.shutdown.load(Relaxed) {
+        let stream = match maker.config.connection_type {
+            ConnectionType::CLEARNET => TcpStream::connect(dns_addr),
+            ConnectionType::TOR => {
+                Socks5Stream::connect(format!("127.0.0.1:{}", maker.config.socks_port), dns_addr)
+                    .map(|s| s.into_inner())
+            }
+        };
 
-                if let Err(e) = send_message(&mut stream, &request) {
-                    log::warn!(
-                        "[{}] Failed to send request to DNS : {} | reattempting..",
-                        maker_port,
-                        e
-                    );
-                    thread::sleep(HEART_BEAT_INTERVAL);
-                    continue;
-                }
-
-                match read_message(&mut stream) {
+        match stream {
+            Ok(mut stream) => match send_message(&mut stream, &request) {
+                Ok(_) => match read_message(&mut stream) {
                     Ok(dns_msg_bytes) => {
                         match serde_cbor::from_slice::<DnsResponse>(&dns_msg_bytes) {
                             Ok(dns_msg) => match dns_msg {
                                 DnsResponse::Ack => {
-                                    log::info!("[{}] <=== {}", maker.config.network_port, dns_msg);
-                                    log::info!(
-                                        "[{}] Successfully sent our address and fidelity proof to DNS at {}",
-                                        maker_port,
-                                        dns_address
-                                    );
+                                    log::info!("[{}] <=== {}", network_port, dns_msg);
+                                    log::info!( "[{}] Successfully sent our address and fidelity proof to DNS at {}",network_port, dns_addr);
+                                    break;
                                 }
                                 DnsResponse::Nack(reason) => {
-                                    log::error!("<=== DNS Nack: {}", reason);
+                                    log::error!("<=== DNS Nack: {}", reason)
                                 }
                             },
                             Err(e) => {
-                                log::warn!("CBOR deserialization failed: {}", e);
+                                log::warn!("CBOR deserialization failed: {} | Reattempting...", e)
                             }
                         }
                     }
@@ -187,25 +148,40 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<Option<Child>, MakerError> {
                                     maker.config.network_port,
                                     e
                                 );
-                                continue;
                             }
                         }
                     }
-                }
-                // Reset counter when success
-                i = 0;
-            }
-            i += 1;
-            thread::sleep(HEART_BEAT_INTERVAL);
+                },
+                Err(e) => log::warn!(
+                    "[{}] Failed to send request to DNS : {} | reattempting...",
+                    network_port,
+                    e
+                ),
+            },
+            Err(e) => log::warn!(
+                "[{}] Failed to establish TCP connection with DNS : {} | reattempting...",
+                network_port,
+                e
+            ),
         }
-    });
 
-    Ok(tor_handle)
+        thread::sleep(HEART_BEAT_INTERVAL);
+    }
+
+    Ok(())
 }
 
-/// Checks if the wallet already has fidelity bonds. if not, create the first fidelity bond.
-fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), MakerError> {
+/// Ensures the wallet has a valid fidelity bond. If no active bond exists, it creates a new one.
+///
+/// ### NOTE ON VALID FIDELITY BOND:
+/// A valid fidelity bond is one that has not expired, been redeemed, or spent.
+///
+/// ## Returns:
+/// - The highest **FidelityProof**, proving ownership of the highest valid fidelity bond, the maker has.
+fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityProof, MakerError> {
     let highest_index = maker.get_wallet().read()?.get_highest_fidelity_index()?;
+    let mut proof = maker.highest_fidelity_proof.write()?;
+
     if let Some(i) = highest_index {
         let wallet_read = maker.get_wallet().read()?;
         let (bond, _, _) = wallet_read.store.fidelity_bond.get(&i).unwrap();
@@ -221,20 +197,23 @@ fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), Ma
             .generate_fidelity_proof(i, maker_address)?;
 
         log::info!(
-            "Highest bond at outpoint {} |  index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
+            "Highest bond at outpoint {} | index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
             highest_proof.bond.outpoint,
             i,
             bond.amount.to_sat(),
             bond.lock_time.to_consensus_u32() - current_height,
             wallet_read.calculate_bond_value(i)?.to_sat()
         );
-        log::info!("Bond amount : {:?}", bond.amount.to_sat());
 
-        let mut proof = maker.highest_fidelity_proof.write()?;
         *proof = Some(highest_proof);
     } else {
-        // No bond in the wallet. Lets attempt to create one.
+        log::info!("No active Fidelity Bonds found. Creating one.");
+
         let amount = Amount::from_sat(maker.config.fidelity_amount);
+
+        log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
+        log::info!("Fidelity Tx fee = {} sats", MINER_FEE);
+
         let current_height = maker
             .get_wallet()
             .read()?
@@ -250,15 +229,13 @@ fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), Ma
                 .map_err(WalletError::Locktime)?
         };
 
+        log::info!(
+            "Fidelity timelock {:?} blocks",
+            locktime.to_consensus_u32() - current_height
+        );
+
         let sleep_increment = 10;
         let mut sleep_multiplier = 0;
-        log::info!("No active Fidelity Bonds found. Creating one.");
-        log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
-        log::info!("Fidelity Tx fee = 300 sats");
-        log::info!(
-            "Fidelity timelock {} blocks",
-            maker.config.fidelity_timelock
-        );
 
         while !maker.shutdown.load(Relaxed) {
             sleep_multiplier += 1;
@@ -307,7 +284,7 @@ fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), Ma
                         .get_wallet()
                         .read()?
                         .generate_fidelity_proof(i, maker_address)?;
-                    let mut proof = maker.highest_fidelity_proof.write()?;
+
                     *proof = Some(highest_proof);
 
                     // sync and save the wallet data to disk
@@ -317,8 +294,11 @@ fn setup_fidelity_bond(maker: &Arc<Maker>, maker_address: &str) -> Result<(), Ma
                 }
             }
         }
-    }
-    Ok(())
+    };
+
+    Ok(proof
+        .clone()
+        .expect("Fidelity Proof must exist after creating a bond"))
 }
 
 /// Checks if the maker has enough liquidity for swaps.
@@ -461,9 +441,9 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
 /// - Detecting and handling broadcasted contract transactions.  
 /// - Running an RPC server for communication with `maker-cli`.  
 ///
-/// The server continuously listens for incoming P2P client connections.  
-/// Periodic checks ensure liquidity availability and backend connectivity.  
-/// It also attempts to recover any incomplete swaps detected in the wallet.  
+/// The server continuously listens for incoming P2P client connections.
+/// It performs periodic checks to ensure liquidity availability, update fidelity bonds,  
+/// and maintain backend connectivity while avoiding interruptions during active swaps.  
 ///
 /// The server continues to run until a shutdown signal is detected, at which point
 /// it performs cleanup tasks, such as sync and saving wallet data, joining all threads, etc.
@@ -471,7 +451,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     log::info!("Starting Maker Server");
 
     // Setup the wallet with fidelity bond.
-    let _tor_thread = network_bootstrap(maker.clone())?;
+    let (_tor_thread, maker_addr, dns_addr) = network_bootstrap(maker.clone())?;
 
     // Tracks the elapsed time in heartbeat intervals to schedule periodic checks and avoid redundant executions.
     let mut interval_tracker = 0;
@@ -482,22 +462,19 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // This ensures these functions are not executed twice in quick succession.
     interval_tracker += HEART_BEAT_INTERVAL.as_secs() as u32;
 
-    let port = maker.config.network_port;
+    let network_port = maker.config.network_port;
 
     {
         let wallet = maker.get_wallet().read()?;
-        log::info!("[{}] Bitcoin Network: {}", port, wallet.store.network);
+        log::info!(
+            "[{}] Bitcoin Network: {}",
+            network_port,
+            wallet.store.network
+        );
         log::info!(
             "[{}] Spendable Wallet Balance: {}",
-            port,
+            network_port,
             wallet.get_balances(None)?.spendable
-        );
-
-        log::info!(
-            "[{}] Minimum Swap Size {} SATS | Maximum Swap Size {} SATS",
-            port,
-            maker.config.min_swap_amount,
-            wallet.store.offer_maxsize
         );
     }
 
@@ -515,7 +492,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
             .spawn(move || {
                 log::info!(
                     "[{}] Spawning Client connection status checker thread",
-                    port
+                    network_port
                 );
                 if let Err(e) = check_for_idle_states(maker_clone.clone()) {
                     log::error!("Failed checking client's idle state {:?}", e);
@@ -532,7 +509,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         let contract_watcher_thread = thread::Builder::new()
             .name("Contract Watcher Thread".to_string())
             .spawn(move || {
-                log::info!("[{}] Spawning contract-watcher thread", port);
+                log::info!("[{}] Spawning contract-watcher thread", network_port);
                 if let Err(e) = check_for_broadcasted_contracts(maker_clone.clone()) {
                     maker_clone.shutdown.store(true, Relaxed);
                     log::error!("Failed checking broadcasted contracts {:?}", e);
@@ -546,7 +523,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         let rpc_thread = thread::Builder::new()
             .name("RPC Thread".to_string())
             .spawn(move || {
-                log::info!("[{}] Spawning RPC server thread", port);
+                log::info!("[{}] Spawning RPC server thread", network_port);
                 match start_rpc_server(maker_clone.clone()) {
                     Ok(_) => (),
                     Err(e) => {
@@ -559,15 +536,16 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         maker.thread_pool.add_thread(rpc_thread);
 
         sleep(HEART_BEAT_INTERVAL); // wait for 1 beat, to complete spawns of all the threads.
+
+        // Check if recovery is needed.
+        let (inc, out) = maker.wallet.read()?.find_unfinished_swapcoins();
+        if !inc.is_empty() || !out.is_empty() {
+            log::info!("Incomplete swaps detected in the wallet. Starting recovery");
+            restore_broadcasted_contracts_on_reboot(&maker)?;
+        }
+
         maker.is_setup_complete.store(true, Relaxed);
         log::info!("[{}] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.", maker.config.network_port);
-    }
-
-    // Check if recovery is needed.
-    let (inc, out) = maker.wallet.read()?.find_unfinished_swapcoins();
-    if !inc.is_empty() || !out.is_empty() {
-        log::info!("Incomplete swaps detected in the wallet. Starting recovery");
-        restore_broadcasted_contracts_on_reboot(&maker)?;
     }
 
     while !maker.shutdown.load(Relaxed) {
@@ -575,41 +553,55 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
             check_connection_with_core(maker.as_ref())?;
         }
 
-        if interval_tracker % SWAP_LIQUIDITY_CHECK_INTERVAL == 0 {
-            check_swap_liquidity(maker.as_ref())?;
-            interval_tracker = 0;
-        }
+        // Perform fidelity bond and liquidity checks only when no coinswap is in progress.
+        // This prevents the server from getting blocked while creating a new bond or waiting
+        // for additional funds, which could otherwise interrupt an ongoing swap.
+        // Running these checks during an active swap might cause the maker to stop responding,
+        // potentially aborting the swap.
+        if maker.ongoing_swap_state.lock()?.is_empty() {
+            if interval_tracker % FIDELITY_BOND_DNS_UPDATE_INTERVAL == 0 {
+                manage_fidelity_bonds_and_update_dns(maker.as_ref(), &maker_addr, &dns_addr)?;
+                interval_tracker = 0;
+            }
 
+            if interval_tracker % SWAP_LIQUIDITY_CHECK_INTERVAL == 0 {
+                check_swap_liquidity(maker.as_ref())?;
+            }
+        }
         match listener.accept() {
             Ok((mut stream, _)) => {
-                log::info!(
-                    "[{}] Received incoming connection",
-                    maker.config.network_port
-                );
+                log::info!("[{}] Received incoming connection", network_port);
 
                 if let Err(e) = handle_client(&maker, &mut stream) {
-                    log::error!("[{}] Error Handling client request {:?}", port, e);
+                    log::error!("[{}] Error Handling client request {:?}", network_port, e);
                 }
             }
 
             Err(e) => {
-                if e.kind() == ErrorKind::WouldBlock {
-                    // Do nothing
-                } else {
+                if e.kind() != ErrorKind::WouldBlock {
                     log::error!(
                         "[{}] Error accepting incoming connection: {:?}",
-                        maker.config.network_port,
+                        network_port,
                         e
                     );
                 }
             }
         };
 
-        interval_tracker += HEART_BEAT_INTERVAL.as_secs() as u32;
+        // Increment **interval_tracker** only if no coinswap is in progress or if no pending
+        // swap liquidity and fidelity bond checks are due. This ensures these checks are
+        // not skipped due to an ongoing coinswap and are performed once it completes.
+        if maker.ongoing_swap_state.lock()?.is_empty()
+            || interval_tracker % SWAP_LIQUIDITY_CHECK_INTERVAL != 0
+            || interval_tracker % FIDELITY_BOND_DNS_UPDATE_INTERVAL != 0
+        {
+            interval_tracker += HEART_BEAT_INTERVAL.as_secs() as u32;
+        }
+
         sleep(HEART_BEAT_INTERVAL);
     }
 
-    log::info!("[{}] Maker is shutting down.", port);
+    log::info!("[{}] Maker is shutting down.", network_port);
     maker.thread_pool.join_all_threads()?;
 
     log::info!("Shutdown wallet sync initiated.");

--- a/tests/maker.rs
+++ b/tests/maker.rs
@@ -197,25 +197,14 @@ fn test_bond_registration_before_confirmation(
     );
     generate_blocks(&maker_cli.bitcoind, bond_timelock);
 
-    let _ = maker_cli.execute_maker_cli(&["redeem-fidelity", "-i", "0"]); // TODO: Hardcoded bond index; will be fixed in PR #424.
-
     await_message(&rx, "Fidelity redeem transaction broadcasted");
 
-    // Restart required for maker to detect bond expiration; will be fixed in PR #424.
-    println!("Shutting down maker server");
+    await_message(&rx, "No active Fidelity Bonds found. Creating one.");
+    await_message(&rx, "seen in mempool, waiting for confirmation");
+
+    println!("Shutting down maker server while waiting for confirmation");
     maker.kill().unwrap();
     maker.wait().unwrap();
-
-    {
-        let (rx, mut maker) = maker_cli.start_makerd();
-
-        await_message(&rx, "No active Fidelity Bonds found. Creating one.");
-        await_message(&rx, "seen in mempool, waiting for confirmation");
-
-        println!("Shutting down maker server while waiting for confirmation");
-        maker.kill().unwrap();
-        maker.wait().unwrap();
-    }
 
     println!("Generate a block to confirm the new fidelity bond");
     generate_blocks(&maker_cli.bitcoind, 1);


### PR DESCRIPTION
This pr aims to fix: 
- #388  
- #359  

It includes: 
 - It includes periodic checks for any bonds that got expired.
 - Redeem such bonds & update the maker fidelity proof
 - make `POST` request to DNS after the maker's updated proof.


## Note to the Reviewers: 
- This PR is smaller version of #390  aiming to solve particular issue.

