### PR TITLE
randomize amounts and fees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[package]D
+[package]
 name = "coinswap"
 version = "0.1.0"
 authors = ["Developers at Citadel-Tech"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+[package]D
 name = "coinswap"
 version = "0.1.0"
 authors = ["Developers at Citadel-Tech"]
@@ -30,6 +30,7 @@ flate2 = {version = "1.0.35", optional = true}
 tar = {version = "0.4.43", optional = true}
 minreq = { version = "2.12.0", features = ["https"] , optional = true}
 rust-coinselect = "0.1.2"
+rand = "0.9.0"
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -5,7 +5,10 @@ use coinswap::{
     utill::{parse_proxy_auth, setup_maker_logger, ConnectionType},
     wallet::RPCConfig,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
+};
 /// Coinswap Maker Server
 ///
 /// The server requires a Bitcoin Core RPC connection running in Testnet4. It requires some starting balance, around 50,000 sats for Fidelity + Swap Liquidity (suggested 50,000 sats).
@@ -48,6 +51,9 @@ struct Cli {
     /// Optional wallet name. If the wallet exists, load the wallet, else create a new wallet with given name. Default: maker-wallet
     #[clap(name = "WALLET", long, short = 'w')]
     pub(crate) wallet_name: Option<String>,
+    /// Randomize the maker fee (+/- 5%), default: false
+    #[clap(name = "randomize-fee", long)]
+    pub(crate) randomize_fee: bool,
 }
 
 fn main() -> Result<(), MakerError> {
@@ -77,6 +83,7 @@ fn main() -> Result<(), MakerError> {
         None,
         Some(connection_type),
         MakerBehavior::Normal,
+        AtomicBool::new(args.randomize_fee),
     )?);
 
     start_maker_server(maker)?;

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -4,13 +4,12 @@ use clap::Parser;
 use coinswap::{
     taker::{error::TakerError, SwapParams, Taker, TakerBehavior},
     utill::{
-        parse_proxy_auth, setup_taker_logger, ConnectionType, DEFAULT_TX_FEE_RATE,
-        REQUIRED_CONFIRMS, UTXO,
+        parse_proxy_auth, randomize_amount, setup_taker_logger, ConnectionType,
+        DEFAULT_TX_FEE_RATE, REQUIRED_CONFIRMS, UTXO,
     },
     wallet::{Destination, RPCConfig},
 };
 use log::LevelFilter;
-use rand::Rng;
 use serde_json::{json, to_string_pretty};
 use std::{path::PathBuf, str::FromStr};
 /// A simple command line app to operate as coinswap client.
@@ -260,11 +259,4 @@ fn main() -> Result<(), TakerError> {
     }
 
     Ok(())
-}
-
-fn randomize_amount(amount: u64) -> u64 {
-    let mut rng = rand::rng();
-    let percentage: f64 = rng.random_range(-0.05..=0.05);
-    let variation = (amount as f64 * percentage).round() as i64;
-    (amount as i64 + variation).max(0) as u64
 }

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -10,6 +10,7 @@ use coinswap::{
     wallet::{Destination, RPCConfig},
 };
 use log::LevelFilter;
+use rand::Rng;
 use serde_json::{json, to_string_pretty};
 use std::{path::PathBuf, str::FromStr};
 /// A simple command line app to operate as coinswap client.
@@ -243,8 +244,9 @@ fn main() -> Result<(), TakerError> {
             }
         }
         Commands::Coinswap { makers, amount } => {
+            let random_amount = randomize_amount(amount);
             let swap_params = SwapParams {
-                send_amount: Amount::from_sat(amount),
+                send_amount: Amount::from_sat(random_amount),
                 maker_count: makers,
                 tx_count: 1,
                 required_confirms: REQUIRED_CONFIRMS,
@@ -258,4 +260,11 @@ fn main() -> Result<(), TakerError> {
     }
 
     Ok(())
+}
+
+fn randomize_amount(amount: u64) -> u64 {
+    let mut rng = rand::rng();
+    let percentage: f64 = rng.random_range(-0.05..=0.05);
+    let variation = (amount as f64 * percentage).round() as i64;
+    (amount as i64 + variation).max(0) as u64
 }

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -244,6 +244,8 @@ pub struct Maker {
     data_dir: PathBuf,
     /// Thread pool for managing all spawned threads
     pub(crate) thread_pool: Arc<ThreadPool>,
+    /// A flag to randomize fees
+    pub randomize_fees: AtomicBool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -272,6 +274,7 @@ impl Maker {
         socks_port: Option<u16>,
         connection_type: Option<ConnectionType>,
         behavior: MakerBehavior,
+        randomize_fees: AtomicBool,
     ) -> Result<Self, MakerError> {
         // Get provided data directory or the default data directory.
         let data_dir = data_dir.unwrap_or(get_maker_dir());
@@ -346,6 +349,7 @@ impl Maker {
             is_setup_complete: AtomicBool::new(false),
             data_dir,
             thread_pool: Arc::new(ThreadPool::new(network_port)),
+            randomize_fees,
         })
     }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -38,7 +38,7 @@ use crate::{
         },
         Hash160,
     },
-    utill::{DEFAULT_TX_FEE_RATE, REQUIRED_CONFIRMS},
+    utill::{randomize_amount, DEFAULT_TX_FEE_RATE, REQUIRED_CONFIRMS},
     wallet::{IncomingSwapCoin, SwapCoin, WalletError, WalletSwapCoin},
 };
 
@@ -361,7 +361,7 @@ impl Maker {
         let calc_coinswap_fees = calculate_coinswap_fee(
             incoming_amount,
             message.refund_locktime,
-            BASE_FEE,
+            randomize_amount(BASE_FEE),
             AMOUNT_RELATIVE_FEE_PCT,
             TIME_RELATIVE_FEE_PCT,
         );

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -171,6 +171,7 @@ pub struct Taker {
     ongoing_swap_state: OngoingSwapState,
     behavior: TakerBehavior,
     data_dir: PathBuf,
+    randomize_fee: bool,
 }
 
 impl Drop for Taker {
@@ -209,6 +210,7 @@ impl Taker {
         control_port: Option<u16>,
         tor_auth_password: Option<String>,
         connection_type: Option<ConnectionType>,
+        randomize_fee: bool,
     ) -> Result<Taker, TakerError> {
         // Get provided data directory or the default data directory.
         let data_dir = data_dir.unwrap_or(get_taker_dir());
@@ -290,6 +292,7 @@ impl Taker {
             ongoing_swap_state: OngoingSwapState::default(),
             behavior,
             data_dir,
+            randomize_fee,
         })
     }
 
@@ -509,7 +512,10 @@ impl Taker {
                     &maker.offer.tweakable_point,
                     self.ongoing_swap_state.swap_params.tx_count,
                 )?;
-            let random_fee = randomize_amount(MINER_FEE);
+            let mut fee = MINER_FEE;
+            if self.randomize_fee {
+                fee = randomize_amount(MINER_FEE);
+            }
             let (funding_txs, mut outgoing_swapcoins, funding_fee) =
                 self.wallet.initalize_coinswap(
                     self.ongoing_swap_state.swap_params.send_amount,
@@ -517,7 +523,7 @@ impl Taker {
                     &hashlock_pubkeys,
                     self.get_preimage_hash(),
                     swap_locktime,
-                    Amount::from_sat(random_fee),
+                    Amount::from_sat(fee),
                 )?;
 
             let contract_reedemscripts = outgoing_swapcoins

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -8,7 +8,6 @@
 //!
 //! [Taker::do_coinswap]: The routine running all other protocol subroutines.
 
-use rand::Rng;
 use std::{
     collections::{HashMap, HashSet},
     io::BufWriter,
@@ -510,7 +509,7 @@ impl Taker {
                     &maker.offer.tweakable_point,
                     self.ongoing_swap_state.swap_params.tx_count,
                 )?;
-            let random_fee = randomize_fee(MINER_FEE);
+            let random_fee = randomize_amount(MINER_FEE);
             let (funding_txs, mut outgoing_swapcoins, funding_fee) =
                 self.wallet.initalize_coinswap(
                     self.ongoing_swap_state.swap_params.send_amount,
@@ -2168,11 +2167,4 @@ impl Taker {
 
         Ok(serde_json::to_string_pretty(&offer)?)
     }
-}
-
-fn randomize_fee(amount: u64) -> u64 {
-    let mut rng = rand::rng();
-    let percentage: f64 = rng.random_range(-0.05..=0.05);
-    let variation = (amount as f64 * percentage).round() as i64;
-    (amount as i64 + variation).max(0) as u64
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -8,6 +8,7 @@
 //!
 //! [Taker::do_coinswap]: The routine running all other protocol subroutines.
 
+use rand::Rng;
 use std::{
     collections::{HashMap, HashSet},
     io::BufWriter,
@@ -509,6 +510,7 @@ impl Taker {
                     &maker.offer.tweakable_point,
                     self.ongoing_swap_state.swap_params.tx_count,
                 )?;
+            let random_fee = randomize_fee(MINER_FEE);
             let (funding_txs, mut outgoing_swapcoins, funding_fee) =
                 self.wallet.initalize_coinswap(
                     self.ongoing_swap_state.swap_params.send_amount,
@@ -516,7 +518,7 @@ impl Taker {
                     &hashlock_pubkeys,
                     self.get_preimage_hash(),
                     swap_locktime,
-                    Amount::from_sat(MINER_FEE),
+                    Amount::from_sat(random_fee),
                 )?;
 
             let contract_reedemscripts = outgoing_swapcoins
@@ -2166,4 +2168,11 @@ impl Taker {
 
         Ok(serde_json::to_string_pretty(&offer)?)
     }
+}
+
+fn randomize_fee(amount: u64) -> u64 {
+    let mut rng = rand::rng();
+    let percentage: f64 = rng.random_range(-0.05..=0.05);
+    let variation = (amount as f64 * percentage).round() as i64;
+    (amount as i64 + variation).max(0) as u64
 }

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -24,6 +24,7 @@ use std::{
     sync::Once,
 };
 
+use rand::Rng;
 use std::{
     collections::HashMap,
     io::{self, Write},
@@ -756,6 +757,14 @@ pub(crate) fn get_tor_hostname(
     Ok(hostname)
 }
 
+/// randomize the given amount +/- 5%.
+pub fn randomize_amount(amount: u64) -> u64 {
+    let mut rng = rand::rng();
+    let percentage: f64 = rng.random_range(-0.05..=0.05);
+    let variation = (amount as f64 * percentage).round() as i64;
+    (amount as i64 + variation).max(0) as u64
+}
+
 #[cfg(test)]
 mod tests {
     use std::{net::TcpListener, thread};
@@ -931,5 +940,12 @@ mod tests {
             .add_exp_tweak(&secp, &scalar_from_nonce)
             .unwrap();
         assert_eq!(returned_pubkey.to_string(), tweaked_pubkey.to_string());
+    }
+
+    #[test]
+    fn test_randomize_amount() {
+        let amount = 20000;
+        let randomized_amount = randomize_amount(amount);
+        assert_ne!(amount, randomized_amount)
     }
 }

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -538,6 +538,7 @@ impl TestFramework {
             None,
             None,
             Some(connection_type),
+            false,
         )
         .unwrap();
 
@@ -562,6 +563,7 @@ impl TestFramework {
                         port.1,
                         Some(connection_type),
                         behavior,
+                        AtomicBool::new(false),
                     )
                     .unwrap(),
                 )


### PR DESCRIPTION
Closes #427

This PR adds a function to randomize amounts within a range (+/- 5%) to break amount correlation attacks, but it's up to user to opt-in, just in case they prefer keep accounting under control.

This randomization is applied to amount spend in the coinswap, the transactions fees and the maker fees.

The ways this is kept optional is adding boolean flags to the cli commands.

![Screenshot From 2025-03-02 12-51-10](https://github.com/user-attachments/assets/23594da2-4eb0-45db-a21e-51f3a960da45)

![Screenshot From 2025-03-02 12-51-30](https://github.com/user-attachments/assets/87625046-5c37-4046-b553-fc469d9a32d2)

![Screenshot From 2025-03-02 12-52-15](https://github.com/user-attachments/assets/21625875-d0d7-4524-bc8d-10514b64137f)
