### PR TITLE
Add control_port and tor_auth_password to write_to_file

### DIFF
--- a/maker.toml
+++ b/maker.toml
@@ -14,3 +14,10 @@ fidelity_amount =  5000000
 fidelity_timelock = 26000
 # Connection type
 connection_type = TOR
+
+# Control Port for application to talk to TOR
+control_port = 9051
+
+# TOR auth password in string
+tor_auth_password = yourpassword
+

--- a/maker.toml
+++ b/maker.toml
@@ -19,5 +19,5 @@ connection_type = TOR
 control_port = 9051
 
 # TOR auth password in string
-tor_auth_password = yourpassword
+tor_auth_password = 
 

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -42,7 +42,7 @@ impl Default for MakerConfig {
             network_port: 6102,
             control_port: 9051,
             socks_port: 9050,
-            tor_auth_password: "".to_string(),
+            tor_auth_password: "yourpassword".to_string(),
             directory_server_address:
                 "ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz65qd.onion:8080".to_string(),
             #[cfg(feature = "integration-test")]
@@ -139,6 +139,8 @@ directory_server_address = {}
 fidelity_amount = {}
 fidelity_timelock = {}
 connection_type = {:?}
+control_port = {}
+tor_auth_password = {}
 ",
             self.network_port,
             self.rpc_port,
@@ -147,7 +149,9 @@ connection_type = {:?}
             self.directory_server_address,
             self.fidelity_amount,
             self.fidelity_timelock,
-            self.connection_type
+            self.connection_type,
+            self.control_port,
+            self.tor_auth_password
         );
 
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -42,7 +42,7 @@ impl Default for MakerConfig {
             network_port: 6102,
             control_port: 9051,
             socks_port: 9050,
-            tor_auth_password: "yourpassword".to_string(),
+            tor_auth_password: "".to_string(),
             directory_server_address:
                 "ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz65qd.onion:8080".to_string(),
             #[cfg(feature = "integration-test")]

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -149,7 +149,7 @@ impl Default for DirectoryServer {
             network_port: 8080,
             socks_port: 9050,
             control_port: 9051,
-            tor_auth_password: "yourpassword".to_string(),
+            tor_auth_password: "".to_string(),
             connection_type: if cfg!(feature = "integration-test") {
                 ConnectionType::CLEARNET
             } else {

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -149,7 +149,7 @@ impl Default for DirectoryServer {
             network_port: 8080,
             socks_port: 9050,
             control_port: 9051,
-            tor_auth_password: "".to_string(),
+            tor_auth_password: "yourpassword".to_string(),
             connection_type: if cfg!(feature = "integration-test") {
                 ConnectionType::CLEARNET
             } else {

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -26,7 +26,7 @@ impl Default for TakerConfig {
         Self {
             control_port: 9051,
             socks_port: 9050,
-            tor_auth_password: "".to_string(),
+            tor_auth_password: "yourpassword".to_string(),
             directory_server_address:
                 "ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz65qd.onion:8080".to_string(),
             connection_type: if cfg!(feature = "integration-test") {
@@ -95,9 +95,12 @@ impl TakerConfig {
             "network_port = {}
 socks_port = {}
 directory_server_address = {}
-connection_type = {:?}",
-            self.control_port, self.socks_port, self.directory_server_address, self.connection_type
-        );
+connection_type = {:?}
+control_port = {}
+tor_auth_password = {}",
+            self.control_port, self.socks_port, self.directory_server_address, self.connection_type,
+            self.control_port, self.tor_auth_password
+            );
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
         let mut file = std::fs::File::create(path)?;
         file.write_all(toml_data.as_bytes())?;

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -26,7 +26,7 @@ impl Default for TakerConfig {
         Self {
             control_port: 9051,
             socks_port: 9050,
-            tor_auth_password: "yourpassword".to_string(),
+            tor_auth_password: "".to_string(),
             directory_server_address:
                 "ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz65qd.onion:8080".to_string(),
             connection_type: if cfg!(feature = "integration-test") {

--- a/taker.toml
+++ b/taker.toml
@@ -8,3 +8,9 @@ directory_server_address=bhbzkndgad52ojm75w4goii7xsi6ou73fzyvorxas7swg2snlto4c4a
 connection_type= TOR
 # RPC port
 rpc_port= 8081
+
+# Control Port for application to talk to TOR
+control_port = 9051
+
+# TOR auth password in string
+tor_auth_password = yourpassword

--- a/taker.toml
+++ b/taker.toml
@@ -13,4 +13,4 @@ rpc_port= 8081
 control_port = 9051
 
 # TOR auth password in string
-tor_auth_password = yourpassword
+tor_auth_password = 


### PR DESCRIPTION
- Updated `write_to_file` to include `control_port` and `tor_auth_password`.
- Ensures these fields are preserved when loading from an existing `config.toml`.