### PR TITLE
optimization: send only sender_pubkey instead of multisig_redeemscript

### DIFF
--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -92,7 +92,7 @@ pub(crate) struct ContractTxInfoForSender {
     pub(crate) hashlock_nonce: SecretKey,
     pub(crate) timelock_pubkey: PublicKey,
     pub(crate) senders_contract_tx: Transaction,
-    pub(crate) multisig_redeemscript: ScriptBuf,
+    pub(crate) sender_pubkey: PublicKey,
     pub(crate) funding_input_value: Amount,
 }
 

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -118,7 +118,7 @@ pub(crate) fn req_sigs_for_sender_once<S: SwapCoin>(
                     hashlock_nonce: hashlock_key_nonce,
                     timelock_pubkey: outgoing_swapcoin.get_timelock_pubkey()?,
                     senders_contract_tx: outgoing_swapcoin.get_contract_tx(),
-                    multisig_redeemscript: outgoing_swapcoin.get_multisig_redeemscript(),
+                    sender_pubkey: outgoing_swapcoin.get_sender_pubkey()?,
                     funding_input_value: outgoing_swapcoin.get_funding_amount(),
                 })
             },

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -118,6 +118,8 @@ pub(crate) trait SwapCoin {
     fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError>;
     /// Apply a private key to the swap coin.
     fn apply_privkey(&mut self, privkey: SecretKey) -> Result<(), ProtocolError>;
+
+    fn get_sender_pubkey(&self) -> Result<PublicKey, WalletError>;
 }
 
 /// Trait representing swap coin functionality specific to a wallet.
@@ -514,6 +516,9 @@ impl SwapCoin for IncomingSwapCoin {
         self.other_privkey = Some(privkey);
         Ok(())
     }
+    fn get_sender_pubkey(&self) -> Result<PublicKey, WalletError> {
+        Ok(self.other_pubkey)
+    }
 }
 
 impl SwapCoin for OutgoingSwapCoin {
@@ -549,6 +554,9 @@ impl SwapCoin for OutgoingSwapCoin {
         } else {
             Err(ProtocolError::General("not correct privkey"))
         }
+    }
+    fn get_sender_pubkey(&self) -> Result<PublicKey, WalletError> {
+        Ok(self.other_pubkey)
     }
 }
 
@@ -595,6 +603,9 @@ impl SwapCoin for WatchOnlySwapCoin {
             &self.sender_pubkey,
             &sig.signature,
         )?)
+    }
+    fn get_sender_pubkey(&self) -> Result<PublicKey, WalletError> {
+        Ok(self.sender_pubkey)
     }
 }
 


### PR DESCRIPTION
closes #332 

This PR optimizes the `ContractTxInfoForSender` message by replacing the full `multisig_redeemscript` with just the `sender_pubkey`. Instead of sending the complete redeem script, the taker now sends only the sender's public key, allowing the maker to construct the `multisig redeem script` on its side.

## Changes

- Modified `ContractTxInfoForSender` struct to use `sender_pubkey: PublicKey` instead of `multisig_redeemscript: ScriptBuf`
- Added `get_sender_pubkey()` method to the SwapCoin trait
- Updated the maker's `verify_and_sign_contract_tx` function to construct the `multisig redeem script` from the `sender's pubkey`
-  Updated the `req_sigs_for_sender_once` function to use `get_sender_pubkey()` instead of the redeem script
- Implemented `get_sender_pubkey()` for all types implementing SwapCoin