### PR TITLE
fidelity clean-ups

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -26,7 +26,7 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::RpcApi;
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
         Arc, Mutex, RwLock,
@@ -241,7 +241,7 @@ pub struct Maker {
     /// Is setup complete
     pub is_setup_complete: AtomicBool,
     /// Path for the data directory.
-    pub(crate) data_dir: PathBuf,
+    data_dir: PathBuf,
     /// Thread pool for managing all spawned threads
     pub(crate) thread_pool: Arc<ThreadPool>,
 }
@@ -349,7 +349,8 @@ impl Maker {
         })
     }
 
-    pub(crate) fn get_data_dir(&self) -> &PathBuf {
+    /// Returns data directory of Maker
+    pub fn get_data_dir(&self) -> &Path {
         &self.data_dir
     }
 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -369,7 +369,7 @@ impl Maker {
                 .store
                 .fidelity_bond
                 .iter()
-                .filter_map(|(i, (bond, _, _))| {
+                .filter_map(|(i, (bond, _))| {
                     if bond.conf_height.is_none() && bond.cert_expiry.is_none() {
                         let conf_height = wallet_read
                             .wait_for_fidelity_tx_confirmation(bond.outpoint.txid)

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -96,10 +96,7 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
 
             RpcMsgResp::SendToAddressResp(txid.to_string())
         }
-        RpcMsgReq::GetDataDir => {
-            let path = maker.get_data_dir();
-            RpcMsgResp::GetDataDirResp(path.clone())
-        }
+        RpcMsgReq::GetDataDir => RpcMsgResp::GetDataDirResp(maker.get_data_dir().to_path_buf()),
         RpcMsgReq::GetTorAddress => {
             if maker.config.connection_type == ConnectionType::CLEARNET {
                 RpcMsgResp::GetTorAddressResp("Maker is not running on TOR".to_string())

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -105,7 +105,7 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
                 RpcMsgResp::GetTorAddressResp("Maker is not running on TOR".to_string())
             } else {
                 let hostname = get_tor_hostname(
-                    maker.data_dir.clone(),
+                    maker.get_data_dir(),
                     maker.config.control_port,
                     maker.config.network_port,
                     &maker.config.tor_auth_password,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -72,8 +72,6 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<(String, String), MakerError> 
         .as_ref()
         .track_and_update_unconfirmed_fidelity_bonds()?;
 
-    setup_fidelity_bond(&maker, &maker_address)?;
-
     manage_fidelity_bonds_and_update_dns(maker.as_ref(), &maker_address, &dns_address)?;
 
     Ok((maker_address, dns_address))

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -56,7 +56,7 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<(String, String), MakerError> 
         }
         ConnectionType::TOR => {
             let maker_hostname = get_tor_hostname(
-                maker.data_dir.clone(),
+                maker.get_data_dir(),
                 maker.config.control_port,
                 maker.config.network_port,
                 &maker.config.tor_auth_password,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -185,7 +185,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
 
     if let Some(i) = highest_index {
         let wallet_read = maker.get_wallet().read()?;
-        let (bond, _, _) = wallet_read.store.fidelity_bond.get(&i).unwrap();
+        let (bond, _) = wallet_read.store.fidelity_bond.get(&i).unwrap();
 
         let current_height = wallet_read
             .rpc

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -382,7 +382,7 @@ pub fn start_directory_server(
             let network_port = directory.network_port;
             log::info!("tor is ready!!");
             let hostname = get_tor_hostname(
-                directory.data_dir.clone(),
+                &directory.data_dir,
                 directory.control_port,
                 directory.network_port,
                 &directory.tor_auth_password,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -705,12 +705,12 @@ pub(crate) fn get_emphemeral_address(
 }
 
 pub(crate) fn get_tor_hostname(
-    datadir: PathBuf,
+    data_dir: &Path,
     control_port: u16,
     target_port: u16,
     password: &str,
 ) -> Result<String, TorError> {
-    let tor_config_path = datadir.join("tor/hostname");
+    let tor_config_path = data_dir.join("tor/hostname");
 
     if tor_config_path.exists() {
         if let Ok(tor_metadata) = fs::read(&tor_config_path) {

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -545,19 +545,16 @@ impl Wallet {
 
     /// Checks if a UTXO belongs to fidelity bonds, and then returns corresponding UTXOSpendInfo
     fn check_if_fidelity(&self, utxo: &ListUnspentResultEntry) -> Option<UTXOSpendInfo> {
-        self.store
-            .fidelity_bond
-            .iter()
-            .find_map(|(i, (bond, _, _))| {
-                if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
-                    Some(UTXOSpendInfo::FidelityBondCoin {
-                        index: *i,
-                        input_value: bond.amount,
-                    })
-                } else {
-                    None
-                }
-            })
+        self.store.fidelity_bond.iter().find_map(|(i, (bond, _))| {
+            if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
+                Some(UTXOSpendInfo::FidelityBondCoin {
+                    index: *i,
+                    input_value: bond.amount,
+                })
+            } else {
+                None
+            }
+        })
     }
 
     /// Checks if a UTXO belongs to live contracts, and then returns corresponding UTXOSpendInfo
@@ -1315,9 +1312,9 @@ impl Wallet {
         descriptors_to_import.extend(
             self.store
                 .fidelity_bond
-                .iter()
-                .map(|(_, (_, spk, _))| {
-                    let descriptor_without_checksum = format!("raw({:x})", spk);
+                .values()
+                .map(|(bond, _)| {
+                    let descriptor_without_checksum = format!("raw({:x})", bond.script_pub_key());
                     Ok(format!(
                         "{}#{}",
                         descriptor_without_checksum,

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -36,8 +36,8 @@ pub(crate) struct WalletStore {
     pub(super) outgoing_swapcoins: HashMap<ScriptBuf, OutgoingSwapCoin>,
     /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
-    /// Map for all the fidelity bond information. (index, (Bond, script_pubkey, is_spent)).
-    pub(crate) fidelity_bond: HashMap<u32, (FidelityBond, ScriptBuf, bool)>,
+    /// Map for all the fidelity bond information. (index, (Bond, redeemed)).
+    pub(crate) fidelity_bond: HashMap<u32, (FidelityBond, bool)>,
     pub(super) last_synced_height: Option<u64>,
 
     pub(super) wallet_birthday: Option<u64>,

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -78,20 +78,20 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, 0);
 
-        let (bond, _, _) = wallet_read
+        let (bond, _) = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
         let bond_value = wallet_read.calculate_bond_value(bond).unwrap();
         assert_eq!(bond_value, Amount::from_sat(10814));
 
-        let (bond, _, is_spent) = wallet_read
+        let (bond, redeemed) = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
 
         assert_eq!(bond.amount, Amount::from_sat(5000000));
-        assert!(!is_spent);
+        assert!(!redeemed);
 
         bond.lock_time.to_consensus_u32()
     };
@@ -121,9 +121,9 @@ fn test_fidelity() {
         //let bond_value = wallet_read.calculate_bond_value(index).unwrap();
         // assert_eq!(bond_value, Amount::from_sat(1474));
 
-        let (bond, _, is_spent) = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        let (bond, redeemed) = wallet_read.get_fidelity_bonds().get(&index).unwrap();
         assert_eq!(bond.amount, Amount::from_sat(8000000));
-        assert!(!is_spent);
+        assert!(!redeemed);
 
         bond.lock_time.to_consensus_u32()
     };


### PR DESCRIPTION
This pr aims to : 
1)  fix #441
2) rename `is_spent` field in `fidelity_map` & `BondAlreadySpent` error variant in `FidelityError` to `redeemed` &
  `BondAlreadyRedeemed`
  
  **Reason**: With the merging of #424 ,  any expired bond can be  automatically redeemed -> thus a fidelity bond cannot lie in the state where it got got expired but not spent.
  
## Note to the Reviewers: 
- There are some  TODO's mentioned in this PR , would appreciate your feedback on them..
-  The proposed changes in this pr contradicts #447 to some extent.