### PR TITLE
Primitives converted to BITCOIN TYPES

### DIFF
--- a/maker.toml
+++ b/maker.toml
@@ -1,4 +1,4 @@
-# Listening port  
+# Listening port
 port = 6102 
 # RPC listening port
 rpc_port

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -1,5 +1,6 @@
 use std::{net::TcpStream, time::Duration};
 
+use bitcoin::Amount;
 use clap::Parser;
 use coinswap::{
     maker::{MakerError, RpcMsgReq, RpcMsgResp},
@@ -53,7 +54,7 @@ enum Commands {
         address: String,
         /// Amount to send in sats
         #[clap(long, short = 'a')]
-        amount: u64,
+        amount: Amount,
         /// Feerate in sats/vByte. Defaults to 2 sats/vByte
         #[clap(long, short = 'f')]
         feerate: Option<f64>,

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), MakerError> {
                 RpcMsgReq::SendToAddress {
                     address,
                     amount,
-                    feerate: feerate.unwrap_or(DEFAULT_TX_FEE_RATE),
+                    feerate: DEFAULT_TX_FEE_RATE,
                 },
             )?;
         }

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -206,7 +206,7 @@ fn main() -> Result<(), TakerError> {
             )]);
 
             let tx = taker.get_wallet_mut().spend_from_wallet(
-                feerate.unwrap_or(DEFAULT_TX_FEE_RATE),
+                DEFAULT_TX_FEE_RATE,
                 destination,
                 &coins_to_spend,
             )?;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -19,8 +19,9 @@ use crate::{
     wallet::{RPCConfig, SwapCoin, WalletSwapCoin},
 };
 use bitcoin::{
+    absolute::Height as AbsoluteHeight,
     ecdsa::Signature,
-    relative::{Height, LockTime as RelativeLockTime},
+    relative::LockTime as RelativeLockTime,
     secp256k1::{self, Secp256k1},
     Amount, OutPoint, PublicKey, ScriptBuf, Transaction,
 };
@@ -375,7 +376,7 @@ impl Maker {
                         None
                     }
                 })
-                .collect::<HashMap<u32, Height>>()
+                .collect::<HashMap<u32, AbsoluteHeight>>()
         };
 
         bond_conf_heights.into_iter().try_for_each(|(i, ht)| {

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use bitcoin::{
     ecdsa::Signature,
-    relative::LockTime as RelativeLockTime,
+    relative::{Height, LockTime as RelativeLockTime},
     secp256k1::{self, Secp256k1},
     Amount, OutPoint, PublicKey, ScriptBuf, Transaction,
 };
@@ -375,7 +375,7 @@ impl Maker {
                         None
                     }
                 })
-                .collect::<HashMap<u32, u32>>()
+                .collect::<HashMap<u32, Height>>()
         };
 
         bond_conf_heights.into_iter().try_for_each(|(i, ht)| {

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -22,7 +22,7 @@ use bitcoin::{
     ecdsa::Signature,
     relative::LockTime as RelativeLockTime,
     secp256k1::{self, Secp256k1},
-    OutPoint, PublicKey, ScriptBuf, Transaction,
+    Amount, OutPoint, PublicKey, ScriptBuf, Transaction,
 };
 use bitcoind::bitcoincore_rpc::RpcApi;
 use std::{
@@ -101,14 +101,14 @@ pub const AMOUNT_RELATIVE_FEE_PCT: f64 = 2.50;
 pub const TIME_RELATIVE_FEE_PCT: f64 = 0.10;
 
 #[cfg(not(feature = "integration-test"))]
-pub const BASE_FEE: u64 = 100;
+pub const BASE_FEE: Amount = Amount::from_sat(100);
 #[cfg(not(feature = "integration-test"))]
 pub const AMOUNT_RELATIVE_FEE_PCT: f64 = 0.1;
 #[cfg(not(feature = "integration-test"))]
 pub const TIME_RELATIVE_FEE_PCT: f64 = 0.005;
 
 /// Minimum Coinswap amount; makers will not#[cfg(feature = "integration-test")] accept amounts below this.
-pub const MIN_SWAP_AMOUNT: u64 = 10_000;
+pub const MIN_SWAP_AMOUNT: Amount = Amount::from_sat(10_000);
 
 /// Interval for redeeming expired bonds, creating new ones if needed,  
 /// and updating the DNS server with the latest bond proof and maker address.

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -6,6 +6,7 @@ use std::{io, path::Path};
 use std::io::Write;
 
 use crate::utill::{get_maker_dir, parse_field, ConnectionType};
+use bitcoin::Amount;
 
 use super::api::MIN_SWAP_AMOUNT;
 
@@ -15,7 +16,7 @@ pub struct MakerConfig {
     /// RPC listening port
     pub rpc_port: u16,
     /// Minimum Coinswap amount
-    pub min_swap_amount: u64,
+    pub min_swap_amount: Amount,
     /// target listening port
     pub network_port: u16,
     /// control port
@@ -27,7 +28,7 @@ pub struct MakerConfig {
     /// Directory server address (can be clearnet or onion)
     pub directory_server_address: String,
     /// Fidelity Bond amount
-    pub fidelity_amount: u64,
+    pub fidelity_amount: Amount,
     /// Fidelity Bond timelock in Block heights.
     pub fidelity_timelock: u32,
     /// Connection type
@@ -50,7 +51,7 @@ impl Default for MakerConfig {
             #[cfg(feature = "integration-test")]
             fidelity_timelock: 26_000, // Approx 6 months of blocks for test
             #[cfg(not(feature = "integration-test"))]
-            fidelity_amount: 50_000, // 50K sats for production
+            fidelity_amount: Amount::from_sat(50_000), // 50K sats for production
             #[cfg(not(feature = "integration-test"))]
             fidelity_timelock: 13104, // Approx 3 months of blocks in production
             connection_type: if cfg!(feature = "integration-test") {

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -6,7 +6,7 @@ use std::{io, path::Path};
 use std::io::Write;
 
 use crate::utill::{get_maker_dir, parse_field, ConnectionType};
-use bitcoin::Amount;
+use bitcoin::{relative::Height, Amount};
 
 use super::api::MIN_SWAP_AMOUNT;
 
@@ -30,7 +30,7 @@ pub struct MakerConfig {
     /// Fidelity Bond amount
     pub fidelity_amount: Amount,
     /// Fidelity Bond timelock in Block heights.
-    pub fidelity_timelock: u32,
+    pub fidelity_timelock: Height,
     /// Connection type
     pub connection_type: ConnectionType,
 }
@@ -53,7 +53,7 @@ impl Default for MakerConfig {
             #[cfg(not(feature = "integration-test"))]
             fidelity_amount: Amount::from_sat(50_000), // 50K sats for production
             #[cfg(not(feature = "integration-test"))]
-            fidelity_timelock: 13104, // Approx 3 months of blocks in production
+            fidelity_timelock: Height::from_height(13104), // Approx 3 months of blocks in production
             connection_type: if cfg!(feature = "integration-test") {
                 ConnectionType::CLEARNET
             } else {

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -11,7 +11,6 @@ use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use bitcoin::{
     hashes::Hash,
-    relative::{Height, LockTime as RelativeLockTime},
     secp256k1::{self, Secp256k1},
     Amount, OutPoint, PublicKey, Transaction, Txid,
 };
@@ -361,7 +360,7 @@ impl Maker {
 
         let calc_coinswap_fees = calculate_coinswap_fee(
             Amount::from_sat(incoming_amount),
-            RelativeLockTime::Blocks(Height::from_height(message.refund_locktime)),
+            message.refund_locktime,
             Amount::from_sat(BASE_FEE),
             AMOUNT_RELATIVE_FEE_PCT,
             TIME_RELATIVE_FEE_PCT,

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use bitcoin::{Amount, Txid};
+use bitcoin::{Amount, FeeRate, Txid};
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_string_pretty};
@@ -35,7 +35,7 @@ pub enum RpcMsgReq {
         /// The amount to send.
         amount: Amount,
         /// The transaction fee to include.
-        feerate: f64,
+        feerate: FeeRate,
     },
     /// Request to retrieve the Tor address of the Maker.
     GetTorAddress,

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use bitcoin::Txid;
+use bitcoin::{Amount, Txid};
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_string_pretty};
@@ -33,7 +33,7 @@ pub enum RpcMsgReq {
         /// The recipient's address.
         address: String,
         /// The amount to send.
-        amount: u64,
+        amount: Amount,
         /// The transaction fee to include.
         feerate: f64,
     },

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use bitcoin::{Address, Amount};
+use bitcoin::Address;
 
 use super::messages::RpcMsgReq;
 use crate::{
@@ -76,7 +76,6 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
             amount,
             feerate,
         } => {
-            let amount = Amount::from_sat(amount);
             let destination = Destination::Multi(vec![(
                 Address::from_str(&address).unwrap().assume_checked(),
                 amount,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -5,7 +5,7 @@
 //! The server listens at two port 6102 for P2P, and 6103 for RPC Client request.
 
 use crate::{protocol::messages::FidelityProof, taker::api::MINER_FEE};
-use bitcoin::absolute::LockTime;
+use bitcoin::{absolute::LockTime, relative::Height};
 use bitcoind::bitcoincore_rpc::RpcApi;
 use socks::Socks5Stream;
 use std::{
@@ -210,24 +210,29 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
         log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
         log::info!("Fidelity Tx fee = {} sats", MINER_FEE);
 
-        let current_height = maker
-            .get_wallet()
-            .read()?
-            .rpc
-            .get_block_count()
-            .map_err(WalletError::Rpc)? as u32;
+        let current_height = Height::from_height(
+            maker
+                .get_wallet()
+                .read()?
+                .rpc
+                .get_block_count()
+                .map_err(WalletError::Rpc)? as u16,
+        );
 
         // Set 950 blocks locktime for test
         let locktime = if cfg!(feature = "integration-test") {
-            LockTime::from_height(current_height + 950).map_err(WalletError::Locktime)?
-        } else {
-            LockTime::from_height(maker.config.fidelity_timelock + current_height)
+            LockTime::from_height(current_height.value() as u32 + 950)
                 .map_err(WalletError::Locktime)?
+        } else {
+            LockTime::from_height(
+                maker.config.fidelity_timelock.value() as u32 + current_height.value() as u32,
+            )
+            .map_err(WalletError::Locktime)?
         };
 
         log::info!(
             "Fidelity timelock {:?} blocks",
-            locktime.to_consensus_u32() - current_height
+            locktime.to_consensus_u32() - current_height.value() as u32
         );
 
         let sleep_increment = 10;

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -5,7 +5,7 @@
 //! The server listens at two port 6102 for P2P, and 6103 for RPC Client request.
 
 use crate::{protocol::messages::FidelityProof, taker::api::MINER_FEE};
-use bitcoin::{absolute::LockTime, Amount};
+use bitcoin::absolute::LockTime;
 use bitcoind::bitcoincore_rpc::RpcApi;
 use socks::Socks5Stream;
 use std::{
@@ -205,7 +205,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
     } else {
         log::info!("No active Fidelity Bonds found. Creating one.");
 
-        let amount = Amount::from_sat(maker.config.fidelity_amount);
+        let amount = maker.config.fidelity_amount;
 
         log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
         log::info!("Fidelity Tx fee = {} sats", MINER_FEE);
@@ -257,7 +257,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
                         let amount = required - available;
                         let addr = maker.get_wallet().write()?.get_next_external_address()?;
 
-                        log::info!("Send at least {:.8} BTC to {:?} | If you send extra, that will be added to your wallet balance", Amount::from_sat(amount).to_btc(), addr);
+                        log::info!("Send at least {:.8} BTC to {:?} | If you send extra, that will be added to your wallet balance", amount.to_btc(), addr);
 
                         let total_sleep = sleep_increment * sleep_multiplier.min(10 * 60);
                         log::info!("Next sync in {:?} secs", total_sleep);

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -5,7 +5,7 @@
 //! The server listens at two port 6102 for P2P, and 6103 for RPC Client request.
 
 use crate::{protocol::messages::FidelityProof, taker::api::MINER_FEE};
-use bitcoin::{absolute::LockTime, relative::Height};
+use bitcoin::absolute::{Height as AbsoluteHeight, LockTime};
 use bitcoind::bitcoincore_rpc::RpcApi;
 use socks::Socks5Stream;
 use std::{
@@ -210,29 +210,30 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
         log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
         log::info!("Fidelity Tx fee = {} sats", MINER_FEE);
 
-        let current_height = Height::from_height(
+        let current_height = AbsoluteHeight::from_consensus(
             maker
                 .get_wallet()
                 .read()?
                 .rpc
                 .get_block_count()
-                .map_err(WalletError::Rpc)? as u16,
-        );
+                .map_err(WalletError::Rpc)? as u32,
+        )
+        .unwrap();
 
         // Set 950 blocks locktime for test
         let locktime = if cfg!(feature = "integration-test") {
-            LockTime::from_height(current_height.value() as u32 + 950)
+            LockTime::from_height(current_height.to_consensus_u32() + 950)
                 .map_err(WalletError::Locktime)?
         } else {
             LockTime::from_height(
-                maker.config.fidelity_timelock.value() as u32 + current_height.value() as u32,
+                maker.config.fidelity_timelock.value() as u32 + current_height.to_consensus_u32(),
             )
             .map_err(WalletError::Locktime)?
         };
 
         log::info!(
             "Fidelity timelock {:?} blocks",
-            locktime.to_consensus_u32() - current_height.value() as u32
+            locktime.to_consensus_u32() - current_height.to_consensus_u32()
         );
 
         let sleep_increment = 10;

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -3,7 +3,7 @@
 //! Handles market-related logic where Makers post their offers. Also provides functions to synchronize
 //! maker addresses from directory servers, post maker addresses to directory servers,
 
-use bitcoin::{transaction::ParseOutPointError, OutPoint};
+use bitcoin::{absolute::Height as AbsoluteHeight, transaction::ParseOutPointError, OutPoint};
 use bitcoind::bitcoincore_rpc::{self, Client, RpcApi};
 
 use crate::{
@@ -449,7 +449,8 @@ fn handle_client(
 
             let txid = metadata.proof.bond.outpoint.txid;
             let transaction = rpc.get_raw_transaction(&txid, None)?;
-            let current_height = rpc.get_block_count()?;
+            let current_height =
+                AbsoluteHeight::from_consensus(rpc.get_block_count()? as u32).unwrap();
 
             match verify_fidelity_checks(
                 &metadata.proof,

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -1,4 +1,4 @@
-//! Definition of the Cract Transaction.
+//! Definition of the Coinswap Contract Transaction.
 //!
 //! This module includes most of the fundamental functions defining the coinswap protocol.
 
@@ -448,7 +448,7 @@ pub(crate) fn is_contract_out_valid(
     }
 
     let redeemscript_from_request =
-        create_contract_redeemscript(hashlock_pubkey, timelock_pubkey, hashvalue, &locktime);
+        create_contract_redeemscript(hashlock_pubkey, timelock_pubkey, hashvalue, locktime);
     let contract_spk_from_request = redeemscript_to_scriptpubkey(&redeemscript_from_request)?;
     if contract_output.script_pubkey != contract_spk_from_request {
         return Err(ProtocolError::General(

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -243,13 +243,13 @@ pub struct FidelityProof {
 /// Represents an offer in the context of the Coinswap protocol.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub(crate) struct Offer {
-    pub(crate) base_fee: u64,                // base fee in sats
+    pub(crate) base_fee: Amount,             // base fee in sats
     pub(crate) amount_relative_fee_pct: f64, // % fee on total amount
     pub(crate) time_relative_fee_pct: f64, // amount * refund_locktime * TRF% = fees for locking the fund.
     pub(crate) required_confirms: u32,
     pub(crate) minimum_locktime: RelativeLockTime,
-    pub(crate) max_size: u64,
-    pub(crate) min_size: u64,
+    pub(crate) max_size: Amount,
+    pub(crate) min_size: Amount,
     pub(crate) tweakable_point: PublicKey,
     pub(crate) fidelity: FidelityProof,
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -58,8 +58,8 @@
 use std::fmt::Display;
 
 use bitcoin::{
-    ecdsa::Signature, hashes::sha256d::Hash, secp256k1::SecretKey, Amount, PublicKey, ScriptBuf,
-    Transaction,
+    ecdsa::Signature, hashes::sha256d::Hash, relative::LockTime as RelativeLockTime,
+    secp256k1::SecretKey, Amount, PublicKey, ScriptBuf, Transaction,
 };
 
 use serde::{Deserialize, Serialize};
@@ -101,7 +101,7 @@ pub(crate) struct ContractTxInfoForSender {
 pub(crate) struct ReqContractSigsForSender {
     pub(crate) txs_info: Vec<ContractTxInfoForSender>,
     pub(crate) hashvalue: Hash160,
-    pub(crate) locktime: u16,
+    pub(crate) locktime: RelativeLockTime,
 }
 
 /// Contract Sigs requesting information for the Receiver side of the hop.
@@ -142,7 +142,7 @@ pub(crate) struct ProofOfFunding {
     pub(crate) confirmed_funding_txes: Vec<FundingTxInfo>,
     // TODO: Directly use Vec of Pubkeys.
     pub(crate) next_coinswap_info: Vec<NextHopInfo>,
-    pub(crate) refund_locktime: u16,
+    pub(crate) refund_locktime: RelativeLockTime,
     pub(crate) contract_feerate: u64,
     pub(crate) id: String,
 }
@@ -247,7 +247,7 @@ pub(crate) struct Offer {
     pub(crate) amount_relative_fee_pct: f64, // % fee on total amount
     pub(crate) time_relative_fee_pct: f64, // amount * refund_locktime * TRF% = fees for locking the fund.
     pub(crate) required_confirms: u32,
-    pub(crate) minimum_locktime: u16,
+    pub(crate) minimum_locktime: RelativeLockTime,
     pub(crate) max_size: u64,
     pub(crate) min_size: u64,
     pub(crate) tweakable_point: PublicKey,

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -78,7 +78,7 @@ pub(crate) const MINER_FEE: u64 = 1000;
 
 /// This fee is used for both funding and contract txs.
 #[cfg(not(feature = "integration-test"))]
-pub(crate) const MINER_FEE: u64 = 300; // around 2 sats/vb for funding tx
+pub(crate) const MINER_FEE: Amount = Amount::from_sat(300); // around 2 sats/vb for funding tx
 
 /// Swap specific parameters. These are user's policy and can differ among swaps.
 /// SwapParams govern the criteria to find suitable set of makers from the offerbook.
@@ -320,8 +320,8 @@ impl Taker {
         let required = swap_params.send_amount + Amount::from_sat(1000);
         if available < required {
             let err = WalletError::InsufficientFund {
-                available: available.to_sat(),
-                required: required.to_sat(),
+                available,
+                required,
             };
             log::error!("Not enough balance to do swap : {:?}", err);
             return Err(err.into());
@@ -516,7 +516,7 @@ impl Taker {
                     &hashlock_pubkeys,
                     self.get_preimage_hash(),
                     swap_locktime,
-                    Amount::from_sat(MINER_FEE),
+                    MINER_FEE,
                 )?;
 
             let contract_reedemscripts = outgoing_swapcoins
@@ -1266,7 +1266,7 @@ impl Taker {
                         previous_funding_output,
                         maker_funding_tx_value,
                         next_contract_redeemscript,
-                        Amount::from_sat(MINER_FEE),
+                        MINER_FEE,
                     )
                 },
             )
@@ -1762,8 +1762,8 @@ impl Taker {
             .all_good_makers()
             .iter()
             .find(|oa| {
-                send_amount >= Amount::from_sat(oa.offer.min_size)
-                    && send_amount <= Amount::from_sat(oa.offer.max_size)
+                send_amount >= oa.offer.min_size
+                    && send_amount <= oa.offer.max_size
                     && !self
                         .ongoing_swap_state
                         .peer_infos

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -155,7 +155,7 @@ mod tests {
         let config = TakerConfig::new(Some(&config_path)).unwrap();
         remove_temp_config(&config_path);
 
-        assert_eq!(REFUND_LOCKTIME, 20);
+        assert_eq!(REFUND_LOCKTIME.to_consensus_u32(), 20);
         assert_eq!(config, TakerConfig::default());
     }
 
@@ -181,7 +181,7 @@ mod tests {
         let config_path = create_temp_config(contents, "different_data_taker_config.toml");
         let config = TakerConfig::new(Some(&config_path)).unwrap();
         remove_temp_config(&config_path);
-        assert_eq!(REFUND_LOCKTIME, 20);
+        assert_eq!(REFUND_LOCKTIME.to_consensus_u32(), 20);
         assert_eq!(
             TakerConfig {
                 socks_port: 9050,         // Configurable via TOML.

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -31,7 +31,8 @@ use crate::{
     wallet::WalletError,
 };
 use bitcoin::{
-    locktime::relative::LockTime, secp256k1::SecretKey, Amount, PublicKey, ScriptBuf, Transaction,
+    locktime::relative::LockTime as RelativeLockTime, secp256k1::SecretKey, Amount, PublicKey,
+    ScriptBuf, Transaction,
 };
 
 use super::{
@@ -106,7 +107,7 @@ pub(crate) fn req_sigs_for_sender_once<S: SwapCoin>(
     outgoing_swapcoins: &[S],
     maker_multisig_nonces: &[SecretKey],
     maker_hashlock_nonces: &[SecretKey],
-    locktime: u16,
+    locktime: RelativeLockTime,
 ) -> Result<ContractSigsForSender, TakerError> {
     handshake_maker(socket)?;
     let txs_info = maker_multisig_nonces
@@ -231,7 +232,7 @@ pub(crate) struct ThisMakerInfo {
     pub(crate) this_maker: OfferAndAddress,
     pub(crate) funding_tx_infos: Vec<FundingTxInfo>,
     pub(crate) this_maker_contract_txs: Vec<Transaction>,
-    pub this_maker_refund_locktime: u16,
+    pub this_maker_refund_locktime: RelativeLockTime,
 }
 
 // Type for information related to the next peer // why not next Maker?
@@ -327,7 +328,7 @@ pub(crate) fn send_proof_of_funding_and_init_next_hop(
 
     let coinswap_fees = calculate_coinswap_fee(
         Amount::from_sat(this_amount),
-        LockTime::from_height(tmi.this_maker_refund_locktime),
+        tmi.this_maker_refund_locktime,
         Amount::from_sat(tmi.this_maker.offer.base_fee),
         tmi.this_maker.offer.amount_relative_fee_pct,
         tmi.this_maker.offer.time_relative_fee_pct,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     hashes::Hash,
     key::{rand::thread_rng, Keypair},
     secp256k1::{Message, Secp256k1, SecretKey},
-    Address, Amount, PublicKey, ScriptBuf, Transaction, WitnessProgram, WitnessVersion,
+    Address, Amount, FeeRate, PublicKey, ScriptBuf, Transaction, WitnessProgram, WitnessVersion,
 };
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 use log::LevelFilter;
@@ -63,7 +63,7 @@ pub(crate) const HEART_BEAT_INTERVAL: Duration = Duration::from_secs(3);
 pub const REQUIRED_CONFIRMS: u32 = 1;
 
 /// Default Transaction Fees in sats/vByte
-pub const DEFAULT_TX_FEE_RATE: f64 = 2.0;
+pub const DEFAULT_TX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(2); // 2 sat/vB
 
 /// Specifies the type of connection: TOR or Clearnet.
 ///

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -1,7 +1,7 @@
 //! Various utility and helper functions for both Taker and Maker.
 
 use bitcoin::{
-    absolute::LockTime,
+    absolute::{Height as AbsoluteHeight, LockTime},
     hashes::Hash,
     key::{rand::thread_rng, Keypair},
     secp256k1::{Message, Secp256k1, SecretKey},
@@ -539,10 +539,10 @@ pub(crate) fn verify_fidelity_checks(
     proof: &FidelityProof,
     addr: &str,
     tx: Transaction,
-    current_height: u64,
+    current_height: AbsoluteHeight,
 ) -> Result<(), WalletError> {
     // Check if bond lock time has expired
-    let lock_time = LockTime::from_height(current_height as u32)?;
+    let lock_time = LockTime::from_height(current_height.to_consensus_u32())?;
     if lock_time > proof.bond.lock_time {
         return Err(FidelityError::BondLocktimeExpired.into());
     }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -11,6 +11,7 @@ use bip39::Mnemonic;
 use bitcoin::{
     bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
     hashes::hash160::Hash as Hash160,
+    relative::LockTime as RelativeLocktime,
     secp256k1,
     secp256k1::{Secp256k1, SecretKey},
     sighash::{EcdsaSighashType, SighashCache},
@@ -1094,7 +1095,7 @@ impl Wallet {
         other_multisig_pubkeys: &[PublicKey],
         hashlock_pubkeys: &[PublicKey],
         hashvalue: Hash160,
-        locktime: u16,
+        locktime: RelativeLocktime,
         fee_rate: Amount,
     ) -> Result<(Vec<Transaction>, Vec<OutgoingSwapCoin>, Amount), WalletError> {
         let (coinswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = other_multisig_pubkeys

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1160,7 +1160,7 @@ impl Wallet {
         Ok((
             create_funding_txes_result.funding_txes,
             outgoing_swapcoins,
-            Amount::from_sat(create_funding_txes_result.total_miner_fee),
+            create_funding_txes_result.total_miner_fee,
         ))
     }
 

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -894,7 +894,7 @@ impl Wallet {
     /// Refreshes the offer maximum size cache based on the current wallet's unspent transaction outputs (UTXOs).
     pub(crate) fn refresh_offer_maxsize_cache(&mut self) -> Result<(), WalletError> {
         let balance = self.get_balances(None)?.spendable;
-        self.store.offer_maxsize = balance.to_sat();
+        self.store.offer_maxsize = balance;
         Ok(())
     }
 

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -3,6 +3,7 @@
 use crate::protocol::error::ProtocolError;
 
 use super::fidelity::FidelityError;
+use bitcoin::Amount;
 
 /// Represents various errors that can occur within a wallet.
 ///
@@ -69,9 +70,9 @@ pub enum WalletError {
     /// - `required`: The amount of funds needed to complete the operation.
     InsufficientFund {
         /// The amount of funds available in the wallet.
-        available: u64,
+        available: Amount,
         /// The amount of funds needed to complete the operation.
-        required: u64,
+        required: Amount,
     },
 }
 

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -402,7 +402,7 @@ impl Wallet {
 
         self.lock_unspendable_utxos()?;
 
-        let fee = Amount::from_sat(MINER_FEE);
+        let fee = MINER_FEE;
 
         let remaining = coinswap_amount;
 

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -25,7 +25,7 @@ use super::error::WalletError;
 pub(crate) struct CreateFundingTxesResult {
     pub(crate) funding_txes: Vec<Transaction>,
     pub(crate) payment_output_positions: Vec<u32>,
-    pub(crate) total_miner_fee: u64,
+    pub(crate) total_miner_fee: Amount,
 }
 
 impl Wallet {
@@ -139,7 +139,7 @@ impl Wallet {
 
         let mut funding_txes = Vec::<Transaction>::new();
         let mut payment_output_positions = Vec::<u32>::new();
-        let mut total_miner_fee = 0;
+        let mut total_miner_fee = Amount::ZERO;
         for ((address, &output_value), change_address) in destinations
             .iter()
             .zip(output_values.iter())
@@ -220,7 +220,7 @@ impl Wallet {
 
             funding_txes.push(funding_tx);
             payment_output_positions.push(payment_pos);
-            total_miner_fee += fee_rate.to_sat();
+            total_miner_fee += fee_rate;
         }
 
         Ok(CreateFundingTxesResult {
@@ -241,7 +241,7 @@ impl Wallet {
     ) -> Result<CreateFundingTxesResult, WalletError> {
         let mut funding_txes = Vec::<Transaction>::new();
         let mut payment_output_positions = Vec::<u32>::new();
-        let mut total_miner_fee = 0;
+        let mut total_miner_fee = Amount::ZERO;
 
         let mut leftover_coinswap_amount = coinswap_amount;
         let mut destinations_iter = destinations.iter();
@@ -282,7 +282,7 @@ impl Wallet {
 
             leftover_coinswap_amount -= funding_tx.output[0].value;
 
-            total_miner_fee += fee_rate.to_sat();
+            total_miner_fee += fee_rate;
 
             funding_txes.push(funding_tx);
             payment_output_positions.push(0);
@@ -332,7 +332,7 @@ impl Wallet {
 
         leftover_coinswap_amount -= funding_tx.output[0].value;
 
-        total_miner_fee += fee_rate.to_sat();
+        total_miner_fee += fee_rate;
 
         funding_txes.push(funding_tx);
         payment_output_positions.push(0);
@@ -373,7 +373,7 @@ impl Wallet {
         let mut info = iter::once(self.get_utxo((first_txid, first_vout))?.unwrap());
         self.sign_transaction(&mut funding_tx, &mut info)?;
 
-        total_miner_fee += fee_rate.to_sat();
+        total_miner_fee += fee_rate;
 
         funding_txes.push(funding_tx);
         payment_output_positions.push(1);

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -303,8 +303,8 @@ impl Wallet {
                 // I don't know if this case is even possible?
                 if fee > total_input_value {
                     return Err(WalletError::InsufficientFund {
-                        available: total_input_value.to_sat(),
-                        required: fee.to_sat(),
+                        available: total_input_value,
+                        required: fee,
                     });
                 }
 
@@ -344,14 +344,14 @@ impl Wallet {
                             diff
                         } else {
                             return Err(WalletError::InsufficientFund {
-                                available: total_input_value.to_sat(),
-                                required: (total_output_value + fee_wchange).to_sat(),
+                                available: total_input_value,
+                                required: (total_output_value + fee_wchange),
                             });
                         }
                     } else {
                         return Err(WalletError::InsufficientFund {
-                            available: total_input_value.to_sat(),
-                            required: (total_output_value + fee_wchange).to_sat(),
+                            available: total_input_value,
+                            required: (total_output_value + fee_wchange),
                         });
                     };
 

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -247,7 +247,7 @@ impl Wallet {
                             txid: outgoing_swap_coin.contract_tx.compute_txid(),
                             vout: 0,
                         },
-                        sequence: Sequence(outgoing_swap_coin.get_timelock()? as u32),
+                        sequence: Sequence(outgoing_swap_coin.get_timelock()?.to_consensus_u32()),
                         witness: Witness::new(),
                         script_sig: ScriptBuf::new(),
                     });

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -5,8 +5,8 @@
 //! parsing mechanisms for transaction inputs and outputs.
 
 use bitcoin::{
-    absolute::LockTime, transaction::Version, Address, Amount, OutPoint, ScriptBuf, Sequence,
-    Transaction, TxIn, TxOut, Txid, Witness,
+    absolute::LockTime, transaction::Version, Address, Amount, FeeRate, OutPoint, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RawTx, RpcApi};
 
@@ -41,7 +41,7 @@ impl Wallet {
     ///   are held in a change address, if applicable.
     pub fn spend_from_wallet(
         &mut self,
-        feerate: f64,
+        feerate: FeeRate,
         destination: Destination,
         coins_to_spend: &[(ListUnspentResultEntry, UTXOSpendInfo)],
     ) -> Result<Transaction, WalletError> {
@@ -70,7 +70,7 @@ impl Wallet {
     /// Redeem a Fidelity Bond.
     /// This functions creates a spending transaction from the fidelity bond, signs and broadcasts it.
     /// Returns the txid of the spending tx, and mark the bond as spent.
-    pub fn redeem_fidelity(&mut self, idx: u32, feerate: f64) -> Result<Txid, WalletError> {
+    pub fn redeem_fidelity(&mut self, idx: u32, feerate: FeeRate) -> Result<Txid, WalletError> {
         let (bond, _, is_spent) = self
             .store
             .fidelity_bond
@@ -123,7 +123,7 @@ impl Wallet {
         &self,
         og_sc: &OutgoingSwapCoin,
         destination_address: &Address,
-        feerate: f64,
+        feerate: FeeRate,
     ) -> Result<Transaction, WalletError> {
         let all_utxo = self.list_live_timelock_contract_spend_info(None)?;
         for (utxo, spend_info) in all_utxo {
@@ -150,7 +150,7 @@ impl Wallet {
         &self,
         ic_sc: &IncomingSwapCoin,
         destination_address: &Address,
-        feerate: f64,
+        feerate: FeeRate,
     ) -> Result<Transaction, WalletError> {
         let all_utxo = self.list_live_hashlock_contract_spend_info(None)?;
         for (utxo, spend_info) in all_utxo {
@@ -178,7 +178,7 @@ impl Wallet {
         &self,
         coins: &Vec<(ListUnspentResultEntry, UTXOSpendInfo)>,
         destination: Destination,
-        feerate: f64,
+        feerate: FeeRate,
     ) -> Result<Transaction, WalletError> {
         // Set the Anti-Fee-Snipping locktime
         let current_height = self.rpc.get_block_count()?;
@@ -287,7 +287,9 @@ impl Wallet {
                 let base_size = tx.base_size();
                 let vsize = (base_size * 4 + total_witness_size).div_ceil(4);
 
-                let fee = Amount::from_sat((feerate * vsize as f64).ceil() as u64);
+                let fee = Amount::from_sat(
+                    (feerate.to_sat_per_vb_ceil() as f64 * vsize as f64).ceil() as u64,
+                );
 
                 #[cfg(feature = "integration-test")]
                 let fee =
@@ -333,7 +335,9 @@ impl Wallet {
                 let base_wchange = tx_wchange.base_size();
                 let vsize_wchange = (base_wchange * 4 + total_witness_size).div_ceil(4);
 
-                let fee_wchange = Amount::from_sat((feerate * vsize_wchange as f64).ceil() as u64);
+                let fee_wchange = Amount::from_sat(
+                    (feerate.to_sat_per_vb_ceil() as f64 * vsize_wchange as f64).ceil() as u64,
+                );
 
                 #[cfg(feature = "integration-test")]
                 let fee_wchange = Amount::from_sat(1000);

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -2,7 +2,7 @@
 //!
 //! Wallet data is currently written in unencrypted CBOR files which are not directly human readable.
 
-use bitcoin::{bip32::Xpriv, Network, OutPoint, ScriptBuf};
+use bitcoin::{bip32::Xpriv, Amount, Network, OutPoint, ScriptBuf};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -27,7 +27,7 @@ pub(crate) struct WalletStore {
     /// The external index for the wallet.
     pub(super) external_index: u32,
     /// The maximum size for an offer in the wallet.
-    pub(crate) offer_maxsize: u64,
+    pub(crate) offer_maxsize: Amount,
     /// Map of multisig redeemscript to incoming swapcoins.
     pub(super) incoming_swapcoins: HashMap<ScriptBuf, IncomingSwapCoin>,
     /// Map of multisig redeemscript to outgoing swapcoins.
@@ -55,7 +55,7 @@ impl WalletStore {
             network,
             master_key,
             external_index: 0,
-            offer_maxsize: 0,
+            offer_maxsize: Amount::ZERO,
             incoming_swapcoins: HashMap::new(),
             outgoing_swapcoins: HashMap::new(),
             prevout_to_contract_map: HashMap::new(),

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -10,6 +10,7 @@
 
 use bitcoin::{
     ecdsa::Signature,
+    relative::LockTime as RelativeLockTime,
     secp256k1::{self, Secp256k1, SecretKey},
     sighash::{EcdsaSighashType, SighashCache},
     Amount, PublicKey, Script, ScriptBuf, Transaction, TxIn,
@@ -107,7 +108,7 @@ pub(crate) trait SwapCoin {
     /// Get the timelock public key.
     fn get_timelock_pubkey(&self) -> Result<PublicKey, WalletError>;
     /// Get the timelock value.
-    fn get_timelock(&self) -> Result<u16, WalletError>;
+    fn get_timelock(&self) -> Result<RelativeLockTime, WalletError>;
     /// Get the hash value.
     fn get_hashvalue(&self) -> Result<Hash160, WalletError>;
     /// Get the funding amount.
@@ -200,7 +201,7 @@ macro_rules! impl_swapcoin_getters {
             )?)
         }
 
-        fn get_timelock(&self) -> Result<u16, WalletError> {
+        fn get_timelock(&self) -> Result<RelativeLockTime, WalletError> {
             Ok(read_contract_locktime(&self.contract_redeemscript)?)
         }
 


### PR DESCRIPTION
****resolves** #262** 

-  `feerate` is left untouched as acquainted, except `DEFAULT_TX_FEE_RATE` and functions internally calling `spend_coins` which seems to handle feerate.
```rust
                let base_size = tx.base_size();
                let vsize = (base_size * 4 + total_witness_size).div_ceil(4);

                let fee = Amount::from_sat(
                    (feerate.to_sat_per_vb_ceil() as f64 * vsize as f64).ceil() as u64,
                );

```
- unsure about types of `fidelity_timelock` and `get_fidelity_expity`. except those `AbsoluteHeight` is used.
- any missed primitives (like `TEST_CURRENT_HEIGHT`) can be included in the required change commit.