### PR TITLE
Include Redemption tracking in `FidelityBonds`

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -369,7 +369,7 @@ impl Maker {
                 .store
                 .fidelity_bond
                 .iter()
-                .filter_map(|(i, (bond, _))| {
+                .filter_map(|(i, bond)| {
                     if bond.conf_height.is_none() && bond.cert_expiry.is_none() {
                         let conf_height = wallet_read
                             .wait_for_fidelity_tx_confirmation(bond.outpoint.txid)

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -183,7 +183,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
 
     if let Some(i) = highest_index {
         let wallet_read = maker.get_wallet().read()?;
-        let (bond, _) = wallet_read.store.fidelity_bond.get(&i).unwrap();
+        let bond = wallet_read.store.fidelity_bond.get(&i).unwrap();
 
         let current_height = wallet_read
             .rpc

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -559,7 +559,7 @@ impl Wallet {
 
     /// Checks if a UTXO belongs to fidelity bonds, and then returns corresponding UTXOSpendInfo
     fn check_if_fidelity(&self, utxo: &ListUnspentResultEntry) -> Option<UTXOSpendInfo> {
-        self.store.fidelity_bond.iter().find_map(|(i, (bond, _))| {
+        self.store.fidelity_bond.iter().find_map(|(i, bond)| {
             if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
                 Some(UTXOSpendInfo::FidelityBondCoin {
                     index: *i,
@@ -1480,7 +1480,7 @@ impl Wallet {
             self.store
                 .fidelity_bond
                 .values()
-                .map(|(bond, _)| {
+                .map(|bond| {
                     let descriptor_without_checksum = format!("raw({:x})", bond.script_pub_key());
                     Ok(format!(
                         "{}#{}",

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -37,7 +37,7 @@ pub(crate) struct WalletStore {
     /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
     /// Map for all the fidelity bond information. (index, (Bond, redeemed)).
-    pub(crate) fidelity_bond: HashMap<u32, (FidelityBond, bool)>,
+    pub(crate) fidelity_bond: HashMap<u32, FidelityBond>,
     pub(super) last_synced_height: Option<u64>,
 
     pub(super) wallet_birthday: Option<u64>,

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -93,18 +93,18 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, 0);
 
-        let (bond, _) = wallet_read
+        let bond = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
         let bond_value = wallet_read.calculate_bond_value(bond).unwrap();
         assert_eq!(bond_value, Amount::from_sat(10814));
 
-        let (bond, redeemed) = wallet_read
+        let bond = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
-
+        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(5000000));
         assert!(!redeemed);
 
@@ -144,7 +144,8 @@ fn test_fidelity() {
         //let bond_value = wallet_read.calculate_bond_value(index).unwrap();
         // assert_eq!(bond_value, Amount::from_sat(1474));
 
-        let (bond, redeemed) = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        let bond = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(8000000));
         assert!(!redeemed);
 


### PR DESCRIPTION
closes #464 
Stores `redeem_tx: Option<Txid>` inside Bond to track fidelity fund spends for better UTXO management.