### PR TITLE
docs: updated demo, tor, and workshop guides for new app flow #461

### DIFF
--- a/docs/bitcoind.md
+++ b/docs/bitcoind.md
@@ -1,108 +1,215 @@
-## Working with `bitcoind` in Regtest Mode
+# Working with `bitcoind` in Regtest Mode
 
-This tutorial walks you through setting up a Bitcoin Core `bitcoind` node in `regtest` mode. We'll cover basic operations like creating wallets, generating blocks, checking balances, and sending Bitcoin between two wallets.
-
----
-
-### 1. Installing `bitcoind`
-
-To begin, install the Bitcoin Core software which includes the `bitcoind` daemon.
-
-#### Steps:
-
-1. **Download Bitcoin Core:**
-   - Visit the [official Bitcoin Core website](https://bitcoin.org/en/download) and download the version appropriate for your OS.
-   - Verify the download by checking the signatures to ensure authenticity.
-
-2. **Verify Installation:**
-   - Run the following command to confirm installation:
-     ```bash
-     bitcoind --version
-     ```
+In this tutorial, we will guide you through setting up a Bitcoin Core `bitcoind` node in `regtest` mode. We'll cover basic operations like creating wallets, generating blocks, checking balances, and sending Bitcoin between two wallets.
 
 ---
 
-### 2. Setting up `bitcoin.conf` for Regtest
+## 1. Install Bitcoin Core
 
-Configure your node to run in `regtest` mode by creating a `bitcoin.conf` file.
+### Steps:
 
-#### Sample Configuration:
+1. **Download Bitcoin Core**
+
+   - Visit the [official Bitcoin Core website](https://bitcoin.org/en/download) and download the appropriate version for your operating system.
+   - Verify the downloaded files by checking their signatures to ensure authenticity and security.
+
+2. **Verify Installation**
+
+   After installation, confirm the installation with:
+
+   ```bash
+   bitcoind --version
+   ```
+
+   This should output the installed version of `bitcoind`.
+
+---
+
+## 2. Configure Bitcoin in Regtest Mode
+
+Create a configuration file to enable the `regtest` network and setup RPC access.
+
+### Sample `bitcoin.conf`
+
+Create the directory (if not already created):
+
 ```bash
 mkdir -p ~/.bitcoin
-nano ~/.bitcoin/bitcoin.conf
 ```
 
-Paste the following into `bitcoin.conf`:
+Then create or edit `~/.bitcoin/bitcoin.conf`:
+
 ```ini
 regtest=1
 server=1
 fallbackfee=0.0001
 rpcuser=user
 rpcpassword=password
-rpcallowip=0.0.0.0/0
+rpcallowip=127.0.0.1
 txindex=1
 ```
 
-> **Note**: For swap markets, consider using `testnet4` instead of `regtest` by setting `testnet4=1`.
+> ⚠️ **Note**: `rpcallowip=127.0.0.1` restricts RPC access to localhost. Avoid `0.0.0.0/0` in production setups.
 
 ---
 
-### 3. Basic Operations
+## 3. Start Bitcoin Node in Regtest Mode
 
-#### 3.1 Start `bitcoind`
+Start the node:
+
 ```bash
 bitcoind
 ```
 
-Check status:
+Confirm it’s running:
+
 ```bash
 bitcoin-cli getblockchaininfo
 ```
 
-#### 3.2 Create Wallets
+Expected output snippet:
+
+```json
+{
+  "chain": "regtest",
+  "blocks": 0,
+  ...
+}
+```
+
+---
+
+## 4. Create Wallets
+
+### Alice’s Wallet:
+
 ```bash
 bitcoin-cli createwallet "alice"
+```
+
+### Bob’s Wallet:
+
+```bash
 bitcoin-cli createwallet "bob"
 ```
 
-#### 3.3 Get Address and Generate Blocks
+---
+
+## 5. Generate Address for Alice
+
 ```bash
 bitcoin-cli -rpcwallet=alice getnewaddress
+```
+
+Example result:
+
+```
+bcrt1qfvgecwpwtn77f7vv6wfc78zdcxseq4pjpyn9jv
+```
+
+---
+
+## 6. Mine 101 Blocks to Alice’s Address
+
+Replace `<alice_address>` with the address from above:
+
+```bash
 bitcoin-cli -rpcwallet=alice generatetoaddress 101 <alice_address>
 ```
 
-#### 3.4 Check Balance
+---
+
+## 7. Check Alice’s Balance
+
 ```bash
 bitcoin-cli -rpcwallet=alice getbalance
 ```
 
+Expected result:
+
+```
+50.00000000
+```
+
+> The first 50 BTC are spendable; the rest are immature rewards.
+
 ---
 
-### 4. Sending Bitcoin from Alice to Bob
+## 8. Send Bitcoin from Alice to Bob
 
-#### 4.1 Get Bob's Address
+### Step 1: Get Bob’s Address
+
 ```bash
 bitcoin-cli -rpcwallet=bob getnewaddress
 ```
 
-#### 4.2 Send BTC from Alice to Bob
+Example result:
+
+```
+bcrt1q2nys4aedf448ngt5gpw5gmun6gdjqgy04qj6cq
+```
+
+### Step 2: Send 1 BTC
+
 ```bash
 bitcoin-cli -rpcwallet=alice sendtoaddress <bob_address> 1
 ```
 
-#### 4.3 Confirm Transaction
+Returns:
+
+```
+<transaction_id>
+```
+
+### Step 3: Confirm the Transaction
+
 ```bash
 bitcoin-cli -rpcwallet=bob generatetoaddress 1 <bob_address>
 ```
 
-#### 4.4 Final Balances
-```bash
-bitcoin-cli -rpcwallet=bob getbalances
-bitcoin-cli -rpcwallet=alice getbalances
+Returns:
+
+```
+<block_hash>
 ```
 
 ---
 
-With this, you've set up a fully functioning `bitcoind` regtest environment. You're now ready to explore Bitcoin transactions and integrate with CoinSwap CLI tools.
+## 9. Verify Final Balances
+
+### Bob:
+
+```bash
+bitcoin-cli -rpcwallet=bob getbalance
+```
+
+Expected result:
+
+```
+1.00000000
+```
+
+### Alice:
+
+```bash
+bitcoin-cli -rpcwallet=alice getbalance
+```
+
+Example:
+
+```
+48.99998590
+```
 
 ---
+
+##  Summary
+
+- You installed and configured `bitcoind` in `regtest` mode.
+- You created two wallets (`alice` and `bob`).
+- You mined blocks and earned BTC.
+- You performed a transaction and confirmed it.
+
+You are now ready to test Bitcoin-based applications locally. Use this setup as the foundation for testing CLI tools like Coinswap or writing custom Bitcoin scripts.
+
+>  For realistic testing in a live-like environment, consider using `testnet4`. To switch, replace `regtest=1` with `testnet=1` in `bitcoin.conf`.

--- a/docs/bitcoind.md
+++ b/docs/bitcoind.md
@@ -1,285 +1,108 @@
-# Working with `bitcoind` in regtest
+## Working with `bitcoind` in Regtest Mode
 
-In this tutorial, we will guide you through setting up a Bitcoin Core `bitcoind` node in `regtest` mode. We'll cover basic operations like creating wallets, generating blocks, checking balances, and sending Bitcoin between two wallets.
+This tutorial walks you through setting up a Bitcoin Core `bitcoind` node in `regtest` mode. We'll cover basic operations like creating wallets, generating blocks, checking balances, and sending Bitcoin between two wallets.
 
 ---
 
-### **1. Installing `bitcoind`**
+### 1. Installing `bitcoind`
 
-To start working with Bitcoin, it's necessary for us to install the Bitcoin Core software, which includes the `bitcoind` daemon.
+To begin, install the Bitcoin Core software which includes the `bitcoind` daemon.
 
-#### **Steps:**
+#### Steps:
 
-1. **Get Bitcoin Core:**
-
-   - We will visit the [official Bitcoin Core website](https://bitcoin.org/en/download) and download the appropriate version for our operating system.
-   - After downloading, we’ll follow the instructions on the site to verify the downloaded files by checking the signatures to ensure authenticity.
+1. **Download Bitcoin Core:**
+   - Visit the [official Bitcoin Core website](https://bitcoin.org/en/download) and download the version appropriate for your OS.
+   - Verify the download by checking the signatures to ensure authenticity.
 
 2. **Verify Installation:**
-   - After installation, we can run the following command to confirm that `bitcoind` is properly installed:
+   - Run the following command to confirm installation:
      ```bash
      bitcoind --version
      ```
-   - This will output the version of `bitcoind` if it's installed correctly.
 
 ---
 
-### **2. Setting up a `bitcoin.conf` File**
+### 2. Setting up `bitcoin.conf` for Regtest
 
-While `bitcoind` can be run on various Bitcoin networks, we will focus on the `regtest` network in this tutorial, which is a local blockchain environment ideal for development and testing. Before running `bitcoind`, we need to configure the node with a `bitcoin.conf` file to set up the `regtest` network.
+Configure your node to run in `regtest` mode by creating a `bitcoin.conf` file.
 
-#### **Sample `bitcoin.conf` File for `regtest`**
-
-First, we’ll create a directory for Bitcoin data and configuration files if it doesn’t already exist:
-
+#### Sample Configuration:
 ```bash
 mkdir -p ~/.bitcoin
+nano ~/.bitcoin/bitcoin.conf
 ```
 
-Then, we’ll create a `bitcoin.conf` file in `~/.bitcoin/` and add the following lines:
-
+Paste the following into `bitcoin.conf`:
 ```ini
-regtest=1 # change this to change Bitcoin Network
+regtest=1
 server=1
-fallbackfee=0.0001 # for regtest only
+fallbackfee=0.0001
 rpcuser=user
 rpcpassword=password
 rpcallowip=0.0.0.0/0
 txindex=1
 ```
 
-#### **Explanation of Configurations:**
+> **Note**: For swap markets, consider using `testnet4` instead of `regtest` by setting `testnet4=1`.
 
-- `regtest=1`: Runs the node in regtest mode.
-- `server=1`: Enables `bitcoind` to run as a server and accept RPC (Remote Procedure Call) commands.
-- `rpcuser` and `rpcpassword`: Set the username and password for `bitcoin-cli` RPC access. We can customize these values or leave them as provided.
-- `rpcallowip=0.0.0.0/0`: Allows RPC connections from any IP address. We should be cautious when using this in a non-development environment.
-- `txindex=1`: Enables a full transaction index for our node, which is useful for querying historical transactions.
-
-After setting up the configuration file, our node will be ready to run in `regtest` mode.
-
-
-
-> **NOTE**: `Regtest` is a toy network that allows for creating custom blocks and generating coins, making it ideal for easy integration testing of applications.  
-> For actual swap markets, use `testnet4`. Switch to `testnet4` by setting `testnet4=1` in the configuration.
 ---
 
-### **3. Basic Operations**
+### 3. Basic Operations
 
-Once the `bitcoin.conf` file is configured, we can start `bitcoind` and perform basic operations using `bitcoin-cli`.
-
-#### **3.1 Start the `bitcoind` daemon:**
-
-We run the following command to start the Bitcoin node:
-
+#### 3.1 Start `bitcoind`
 ```bash
-$ bitcoind 
+bitcoind
 ```
 
-- **Note**: We don’t need to specify the network explicitly since the `bitcoin.conf` file already defines the network.
-
-To check the status of the node and confirm that it's running, we can use:
-
+Check status:
 ```bash
-$ bitcoin-cli getblockchaininfo
+bitcoin-cli getblockchaininfo
 ```
 
-This will output the current state of the blockchain, including the number of blocks and synchronization status, as shown:
-
+#### 3.2 Create Wallets
 ```bash
-{
-  "chain": "regtest",
-  "blocks": 0,
-  "headers": 0,
-  "bestblockhash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
-  "difficulty": 4.656542373906925e-10,
-  "time": 1296688602,
-  "mediantime": 1296688602,
-  "verificationprogress": 1,
-  "initialblockdownload": true,
-  "chainwork": "0000000000000000000000000000000000000000000000000000000000000002",
-  "size_on_disk": 293,
-  "pruned": false,
-  "warnings": ""
-}
+bitcoin-cli createwallet "alice"
+bitcoin-cli createwallet "bob"
 ```
 
-#### **3.2 Create a Wallet for Alice**
-
-We create a wallet called `alice` to perform wallet-related operations in the `regtest` environment:
-
+#### 3.3 Get Address and Generate Blocks
 ```bash
-$ bitcoin-cli createwallet "alice"
+bitcoin-cli -rpcwallet=alice getnewaddress
+bitcoin-cli -rpcwallet=alice generatetoaddress 101 <alice_address>
 ```
 
-The response will confirm that the wallet `alice` has been created:
-
-```json
-{
-  "name": "alice"
-}
-```
-
-#### **3.3 Create a Wallet for Bob**
-
-Similarly, we create another wallet called `bob`:
-
+#### 3.4 Check Balance
 ```bash
-$ bitcoin-cli createwallet "bob"
-```
-
-The response will confirm that the wallet `bob` has been created:
-
-```json
-{
-  "name": "bob"
-}
-```
-
-#### **3.4 Get a New Bitcoin Address for Alice**
-
-We generate a new Bitcoin address for `alice` to receive funds:
-
-```bash
-$ bitcoin-cli -rpcwallet=alice getnewaddress
-```
-
-This returns a new address for `alice`:
-
-```bash
-bcrt1qfvgecwpwtn77f7vv6wfc78zdcxseq4pjpyn9jv
-```
-
-#### **3.5 Generate Some Blocks for Alice**
-
-Since we’re using `regtest`, we can generate new blocks to the generated address for `alice` and receive Bitcoin as block rewards:
-
-```bash
-$ bitcoin-cli -rpcwallet=alice generatetoaddress 101 <alice_address>
-```
-
-This will return a list of block hashes in hex format, corresponding to the 101 newly generated blocks as shown: 
-
-```bash
-[
-  "00b968e6627d8f160369a06a3169719487cf246a5d43afa113c42a236305b7d3",
-  "3ac6820a58627c9e69dcd349d9d152909b018a2afe923bed73dae0c7b7134104",
-  "0d4b1870a18216450e5da68c7349e7cb26beb144c671524c23798728ca222cd8",
-  "41c1c331c93e75f2048a285c925e15eca423b0a93f1f7354261adef8f29186c3",
-
-  ... till 101 block hashes
-]
-```
-
-#### **3.6 Check Alice's Wallet Balance**
-
-We can now check the balance in `alice`'s wallet:
-
-```bash
-$ bitcoin-cli -rpcwallet=alice getbalance
-```
-
-This will show a balance corresponding to the block rewards for the generated blocks:
-
-```bash
-{
-  "mine": {
-    "trusted": 50.00000000,
-    "untrusted_pending": 0.00000000,
-    "immature": 0.00000000
-  }
-}
+bitcoin-cli -rpcwallet=alice getbalance
 ```
 
 ---
 
-### **4. Sending Bitcoin from Alice to Bob**
+### 4. Sending Bitcoin from Alice to Bob
 
-Now, let’s send 1 BTC from `alice` to `bob` using the `sendtoaddress` RPC command.
-
-#### **4.1 Get Bob's Bitcoin Address**
-
-We generate a new Bitcoin address for `bob`:
-
+#### 4.1 Get Bob's Address
 ```bash
-$ bitcoin-cli -rpcwallet=bob getnewaddress
+bitcoin-cli -rpcwallet=bob getnewaddress
 ```
 
-This returns a new address for `bob`:
-
+#### 4.2 Send BTC from Alice to Bob
 ```bash
-bcrt1q2nys4aedf448ngt5gpw5gmun6gdjqgy04qj6cq
+bitcoin-cli -rpcwallet=alice sendtoaddress <bob_address> 1
 ```
 
-#### **4.2 Send 1 BTC from Alice to Bob**
-
-Next, we send 1 BTC from `alice` to `bob` using the `sendtoaddress` command:
-
+#### 4.3 Confirm Transaction
 ```bash
-$ bitcoin-cli -rpcwallet=alice sendtoaddress <bob_address> 1
+bitcoin-cli -rpcwallet=bob generatetoaddress 1 <bob_address>
 ```
 
-This will create and broadcast a signed transaction, returning the transaction hash:
-
+#### 4.4 Final Balances
 ```bash
-0b0c6a25e16f987e5a68fe59c301e06615376837b11a3ed678b0f0bd8a69a18a
-```
-
-#### **4.3 Generate a Block to Confirm the Transaction**
-
-We generate a block to confirm the transaction to `bob`:
-
-```bash
-$ bitcoin-cli -rpcwallet=bob generatetoaddress 1 <bob_address>
-```
-
-This will return the block hash in hex format:
-
-```bash
-"43e5d06abcf026e3faec392626545fb4880592682fd61645dc99d51e277bd761"
-```
-
-#### **4.4 Check the Final Balance of Each Wallet**
-
-Finally, we check the balance of both wallets to confirm that the transaction was successful.
-
-##### **For Bob's Wallet:**
-
-```bash
-$ bitcoin-cli -rpcwallet=bob getbalances
-```
-
-The response should show that `bob` has received the 1 BTC:
-
-```json
-{
-  "mine": {
-    "trusted": 1.00000000,
-    "untrusted_pending": 0.00000000,
-    "immature": 0.00000000
-  }
-}
-```
-
-##### **For Alice's Wallet:**
-
-```bash
-$ bitcoin-cli -rpcwallet=alice getbalances
-```
-
-The response will show that `alice`'s balance has been reduced by a little more than 1 BTC, where 1 BTC has been sent to `bob`, and the remaining amount goes toward mining fees for confirming the transaction:
-
-```json
-{
-  "mine": {
-    "trusted": 48.99998590,
-    "untrusted_pending": 0.00000000,
-    "immature": 0.00000000
-  }
-}
+bitcoin-cli -rpcwallet=bob getbalances
+bitcoin-cli -rpcwallet=alice getbalances
 ```
 
 ---
 
-We’ve set up `bitcoind`, created two wallets (`alice` and `bob`), generated blocks, and sent Bitcoin between the wallets. This provides everything we need to start with `bitcoind` on `regtest`. Now, we’re ready to explore Bitcoin transactions and experiment with coinswap CLI apps.
+With this, you've set up a fully functioning `bitcoind` regtest environment. You're now ready to explore Bitcoin transactions and integrate with CoinSwap CLI tools.
 
+---

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,65 +1,71 @@
-# Coinswap Live Demo Prerequisite and Setup
+# Coinswap Live Demo – Prerequisites & Setup
 
-This guide will help you prepare your system for participating in the Coinswap Live Demo. Follow these steps carefully to ensure a smooth experience during the demonstration.
+This guide helps you prepare your system to participate in the Coinswap Live Demo. Follow the steps below to ensure a smooth setup.
 
-## System Prerequisites
+---
 
-### Required Software
+##  System Prerequisites
 
-1. **Rust and Cargo**
-   ```bash
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   ```
-   Verify installation:
-   ```bash
-   rustc --version
-   cargo --version
-   ```
+### 1. Install Required Software
 
-2. **Bitcoin Core**
-   ```bash
-   # Download Bitcoin Core 28.1
-   wget https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-x86_64-linux-gnu.tar.gz
-   
-   # Download and verify signatures
-   wget https://bitcoincore.org/bin/bitcoin-core-28.1//SHA256SUMS
-   wget https://bitcoincore.org/bin/bitcoin-core-28.1//SHA256SUMS.asc
-   
-   # Verify download
-   sha256sum --check SHA256SUMS --ignore-missing
-   
-   # Extract binaries
-   tar xzf bitcoin-28.1-x86_64-linux-gnu.tar.gz
-   
-   # Install to system
-   sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-28.1/bin/*
-   ```
-   
-   Verify installation:
-   ```bash
-   bitcoind --version
-   ```
+####  Rust & Cargo
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+Verify:
+```bash
+rustc --version
+cargo --version
+```
 
-3. **Build Dependencies**
-   ```bash
-   sudo apt-get update
-   sudo apt install build-essential automake libtool
-   ```
+---
 
-4. **Setup Tor**
-   
-   Coinswap requires Tor exclusively for all communication. You will need to have Tor running in your local to run the apps.
-   For Tor setup instructions follow the [Tor Doc](tor.md). 
-   
-   Use the below sample `torrc` config for quick setup.
-   
-   ```shell
-   ControlPort 9051
-   CookieAuthentication 0
-   SOCKSPort 9050
-   ```
+####  Bitcoin Core
+```bash
+# Download Bitcoin Core 28.1
+wget https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-x86_64-linux-gnu.tar.gz
 
-## Bitcoin Core Setup
+# Download and verify signatures
+wget https://bitcoincore.org/bin/bitcoin-core-28.1/SHA256SUMS
+wget https://bitcoincore.org/bin/bitcoin-core-28.1/SHA256SUMS.asc
+
+# Verify the binary
+sha256sum --check SHA256SUMS --ignore-missing
+
+# Extract and install
+tar xzf bitcoin-28.1-x86_64-linux-gnu.tar.gz
+sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-28.1/bin/*
+```
+
+Verify:
+```bash
+bitcoind --version
+```
+
+---
+
+####  Build Dependencies
+```bash
+sudo apt-get update
+sudo apt install build-essential automake libtool
+```
+
+---
+
+####  Setup Tor
+Tor is required for all Coinswap communication.
+
+- See [Tor Setup Guide](tor.md).
+- Sample `torrc`:
+```ini
+ControlPort 9051
+CookieAuthentication 0
+SOCKSPort 9050
+```
+
+---
+
+##  Bitcoin Core Setup
 
 ### 1. Create Configuration File
 ```bash
@@ -67,7 +73,7 @@ mkdir -p ~/.bitcoin
 ```
 
 Add to `~/.bitcoin/bitcoin.conf`:
-```bash
+```ini
 regtest=1
 
 [regtest]
@@ -80,132 +86,127 @@ blockfilterindex=1
 addnode=172.81.178.3:18444
 ```
 
-> **NOTE**: Change `regtest=1` to `testnet4=1` if you want to run the apps on testnet, or other networks.
+> ℹ️ Change `regtest=1` to `testnet4=1` to run on testnet.
+
+---
 
 ### 2. Start Bitcoin Core
 ```bash
 bitcoind
 ```
 
-Wait for the Initial Block Download to complete. Follow the `bitcoind` logs for IBD progress.
-
-Verify it's running:
+Wait for IBD (Initial Block Download). Verify:
 ```bash
 bitcoin-cli getblockchaininfo
 ```
 
-## Compile The Apps
+---
+
+##  Compile the Coinswap Apps
+
 ```bash
 git clone https://github.com/citadel-tech/coinswap.git
 cd coinswap
 cargo build --release
 ```
 
-After compilation you will get the binaries in the `./target/release` folder. 
-
-Install the necessary binaries in your system:
+After build, install binaries:
 ```bash
 sudo install ./target/release/taker /usr/local/bin/
-sudo install ./target/release/makerd /usr/local/bin/  
-sudo install ./target/release/maker-cli /usr/local/bin/  
+sudo install ./target/release/makerd /usr/local/bin/
+sudo install ./target/release/maker-cli /usr/local/bin/
 ```
 
-## Running the Swap Server
+---
 
-The swap server is run using two apps `makerd` and `maker-cli`. The `makerd` app runs a server, and `maker-cli` is used to operate the server using RPC commands.
+##  Run the Swap Server
 
-Check the available `makerd` commands with
-```bash
-makerd --help
-```
+`makerd` runs the server. `maker-cli` controls it.
 
-Start the `makerd` daemon with all default parameters:
+### Start `makerd`
 ```bash
 makerd
 ```
 
-This will spawn the maker server and you will start seeing the logs. The server is operated with the `maker-cli` app. Follow the log, and it will show you the next instructions.
+Follow logs. You'll be asked to send BTC to a generated address (min: **20,000 sats**).
 
-To successfully set up the swap server, it needs to have a fidelity bond and enough balance (minimum 20,000 sats) to start providing swap services.
+Use [mempool.space Testnet4 faucet](https://mempool.space/testnet4/faucet) or another to fund.
 
-In the log you will see the server is asking for some BTC at a given address. Fund that address with the given minimum amount or more. We recommend using the [mempool.space Testnet4 faucet](https://mempool.space/testnet4/faucet), but you can use any other faucet of your choice.
+Once funded and confirmed, the server will:
 
-Once the funds are sent, the server will automatically create a fidelity bond transaction, wait for its confirmation, and when confirmed, send its offers and details to the DNS server and start listening for incoming swap requests.
+- Create a fidelity bond
+- Broadcast offers to the DNS server
+- Listen for swaps
 
-At this stage you can start using the `maker-cli` app to query the server and get all relevant details.
-
-On a new terminal, try out a few operations like:
+### Use `maker-cli`
 ```bash
 maker-cli --help
 maker-cli get-balances
 maker-cli list-utxo
 ```
 
-If everything goes all right you will be able to see balances and utxos in the `maker-cli` outputs.
+>  Wallet & data at: `~/.coinswap/maker/`. Backup `wallets/maker-wallet`.
 
-All relevant files and wallets used by the server will be located in `~/.coinswap/maker/` data directory. It's recommended to take a backup of the wallet file `~/.coinswap/maker/wallets/maker-wallet`, to avoid loss of funds.
+---
 
+##  Run the Swap Client
 
-## Run The Swap Client
+Run from a separate terminal with the `taker` app.
 
-The swap client is run with the `taker` app. 
-
-From a new terminal, go to the project root directory and perform basic client operations:
-
-### Get Some Money
+### 1. Get an Address & Fund It
 ```bash
 taker get-new-address
 ```
 
-Use a testnet4 faucet to send some funds at the above address. Then check the client wallet balance with
+Fund via a faucet, then:
 ```bash
 taker get-balances
 ```
 
-### Fetch Market Offers
-Fetch all the current existing market offers with 
+### 2. Fetch Offers
 ```bash
 taker fetch-offers
 ```
 
-### Perform a Coinswap
-Attempt a coinswap process with
+### 3. Attempt Coinswap
 ```bash
 taker coinswap
 ```
 
-If all goes well, you will see the coinswap process starting in the logs.
+---
 
+##  Troubleshooting
 
-## Basic Troubleshooting
+### Bitcoin Core
+- Is it running? → `bitcoin-cli getblockchaininfo`
+- Are RPC credentials matching?
+- Are you on the right network?
 
-### Bitcoin Core Issues
-- Verify bitcoind is running: `bitcoin-cli getblockchaininfo`
-- Check rpcuser/rpcpassword attempted by the apps are matching with the bitcoin.conf file values
-- Ensure correct network (testnet4)
+### Maker Server
+- Check `debug.log`
+- Was fidelity bond created?
+- Are funds sufficient?
+- Is Tor connected?
 
-### Maker Server Issues
-- Check debug.log for errors
-- Verify fidelity bond creation
-- Ensure sufficient funds for operations
-- Check TOR connection status
+### Taker Client
+- Is the wallet funded?
+- Check logs and network status
 
-### Taker Client Issues
-- Verify wallet funding
-- Check network connectivity
-- Monitor debug.log for detailed errors
+### Still stuck?
+Join our [Discord](https://discord.gg/gs5R6pmAbR) for support.
 
-### Asking for further help
-If you are still stuck and couldn't get the apps running, drop in our [Discord](https://discord.gg/gs5R6pmAbR) and ask help from the developers directly.
+---
 
-## Additional Resources
+##  Additional Resources
 
-- [Bitcoin Core Documentation](https://bitcoin.org/en/developer-reference)
-- [Coinswap Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
-- [Project Repository](https://github.com/citadel-tech/coinswap)
+- [Bitcoin Core Docs](https://bitcoin.org/en/developer-reference)
+- [Coinswap Protocol Spec](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
+- [Project Repo](https://github.com/citadel-tech/coinswap)
 
-For more detailed information about specific components:
+### Related Guides:
 - [Bitcoin Core Setup](./bitcoind.md)
 - [Maker Server Guide](./makerd.md)
 - [Maker CLI Reference](./maker-cli.md)
 - [Taker Client Guide](./taker.md)
+
+---

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -1,13 +1,19 @@
-#  `maker-cli` Demo
+# `maker-cli` Demo
 
-###  Create Maker Wallet and Sync
+`maker-cli` is a straightforward command-line tool designed as an RPC client for `makerd`. It allows you to connect to the server, retrieve vital information, and manage various server operations efficiently.
+
+---
+
+##  1. Create Maker Wallet and Sync
+
+Use the following command to create a new wallet named `maker`. This generates a BIP84 descriptor wallet for the Signet test network.
 
 ```bash
 maker-cli wallet --name maker
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 {
@@ -21,26 +27,32 @@ maker-cli wallet --name maker
 
 </details>
 
+After wallet creation, sync it with the blockchain to see your current UTXOs and balances:
+
 ```bash
 maker-cli sync
 ```
 
 ---
 
-###  Fund Maker Wallet via Faucet
+##  2. Fund the Maker Wallet (via Faucet)
+
+Get a receiving address for your wallet:
 
 ```bash
 maker-cli address
 ```
 
-Then visit: [https://signetfaucet.com](https://signetfaucet.com) and paste the generated address to get some Signet coins.
+Copy the address and go to the [Signet Faucet](https://signetfaucet.com) to receive testnet BTC.
+
+After receiving coins, check your balance:
 
 ```bash
 maker-cli balance
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 {
@@ -56,7 +68,9 @@ maker-cli balance
 
 ---
 
-###  Create a New Offer (Maker Contract)
+##  3. Create a New Offer
+
+Use the `create-offer` command to initiate a new coinswap offer. You specify how much BTC you're offering (maker amount), how much you expect from the taker (taker amount), and a lock time (in blocks) for the contract.
 
 ```bash
 maker-cli create-offer \
@@ -66,7 +80,7 @@ maker-cli create-offer \
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 {
@@ -76,16 +90,20 @@ maker-cli create-offer \
 
 </details>
 
+This command will create and lock funds into a new offer contract.
+
 ---
 
-###  Check Status of All Offers
+##  4. Check the Status of Offers
+
+To see all active offers and their current state:
 
 ```bash
 maker-cli status
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 [
@@ -100,14 +118,16 @@ maker-cli status
 
 ---
 
-###  View Offer Details
+##  5. View Specific Offer Details
+
+To get more info about a particular offer, run:
 
 ```bash
 maker-cli offer --offer-id 48b42aef-46aa-46ae-afe0-02302d5f52d1
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 {
@@ -123,14 +143,16 @@ maker-cli offer --offer-id 48b42aef-46aa-46ae-afe0-02302d5f52d1
 
 ---
 
-###  Balance After Funding the Offer
+##  6. Check Updated Balance After Offer Lock
+
+Since the maker funds are locked in the offer, your spendable balance will reduce:
 
 ```bash
 maker-cli balance
 ```
 
 <details>
-<summary> Output</summary>
+<summary> Sample Output</summary>
 
 ```json
 {
@@ -143,5 +165,19 @@ maker-cli balance
 ```
 
 </details>
+
+---
+
+##  Summary
+
+| Step                | Command                         |
+|---------------------|----------------------------------|
+| Create Wallet       | `maker-cli wallet --name maker` |
+| Sync Blockchain     | `maker-cli sync`                |
+| Get Address         | `maker-cli address`             |
+| Check Balance       | `maker-cli balance`             |
+| Create Offer        | `maker-cli create-offer`        |
+| Check Offer Status  | `maker-cli status`              |
+| View Offer Details  | `maker-cli offer --offer-id`    |
 
 ---

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -1,607 +1,147 @@
-# Maker-cli Tutorial
+#  `maker-cli` Demo
 
-`maker-cli` is a straightforward command-line tool designed as an RPC client for `makerd`. It allows you to connect to the server, retrieve vital information, and manage various server operations efficiently.
-
-In this guide, we’ll walk you through how to use `maker-cli` to get the most out of your `makerd` setup. Let's get started!
-
-
-> ### **Important Note**
-> `makerd` listens to RPC requests from `maker-cli` **only** when it is fully set up. This setup includes creating a new fidelity bond (if one doesn’t already exist) and completing other necessary configurations.  
-> 
-> If `makerd` is not fully set up, `maker-cli` commands will not function.  
-> 
-> 👉 **Before starting this tutorial**, ensure your `makerd` setup is complete.  
-> If you’re unsure how to set it up, check out our [Makerd Setup Guide](./makerd.md) first, and then return to this tutorial.
-> 
-
----
-
-## Getting Started with `maker-cli`
-
-### View All Available Commands  
-To see the full list of arguments and options available in `maker-cli`, run the following command:
+###  Create Maker Wallet and Sync
 
 ```bash
-$ ./maker-cli --help
+maker-cli wallet --name maker
 ```
 
-This will display a detailed guide about the app and its capabilities.
+<details>
+<summary> Output</summary>
 
-#### **Output:**
-
-```bash
-coinswap 0.1.0
-Developers at Citadel-Tech
-A simple command-line app to operate the makerd server.
-
-The app works as an RPC client for makerd, useful to access the server, retrieve information, and
-manage server operations.
-
-For more detailed usage information, please refer: [maker demo doc link]
-
-This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-tech/coinswap/issues
-
-USAGE:
-    maker-cli [OPTIONS] <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help
-            Print help information
-
-    -p, --rpc-port <RPC_PORT>
-            Set the RPC port for `makerd`
-            
-            [default: 127.0.0.1:6103]
-
-    -V, --version
-            Print version information
-
-SUBCOMMANDS:
-    get-balances              Retrieve the total wallet balances of different categories (sats)
-    get-new-address           Generate a new Bitcoin receiving address
-    list-utxo                 List all UTXOs in the wallet, including fidelity bonds
-    list-utxo-contract        List HTLC contract UTXOs
-    list-utxo-fidelity        List fidelity bond UTXOs
-    list-utxo-swap            List UTXOs from incoming swaps
-    redeem-fidelity           Redeem fidelity bonds if their timelock has matured
-    send-ping                 Ping `makerd` and receive a pong response
-    send-to-address           Send Bitcoin to an external address
-    show-data-dir             Display the data directory path
-    show-fidelity             Show current and previous fidelity bonds
-    show-tor-address          Display the server’s Tor address
-    stop                      Shut down the `makerd` server
-    sync-wallet               Synchronize the wallet with the blockchain
-
-```
-
-### Key Points About the `rpc-port` Argument
- - The `rpc-port` option specifies the RPC port that `makerd` listens on. By default, this is set to **`6103`**.
-
- - #### If you're using the **default configuration**:
-   - You don't need to include the `rpc-port` argument.
-
- - #### If you're using a **custom configuration**:
-   - Pass your custom port number using the `-p` or `--rpc-port` option, like this:
-
-```bash
-  $ ./maker-cli -p 6104 <SUBCOMMAND>
-```
-
-For this tutorial, we’ll assume the default configuration is being used. Output examples will reflect this setup.
-
----
-
-
-
-
-Here's a simplified and easier-to-read version of your content:
-
----
-
-## Exploring Maker CLI Commands
-
-### SendPing
-To check if `makerd` is listening to RPC requests from `maker-cli`, use the `send-ping` command. 
-
-Run:  
-```bash
-$ ./maker-cli send-ping
-```
-
-**Output:**  
-```bash
-success
-```
-
-This confirms that the maker server is listening and responding to requests.
-
----
-
-### ShowDataDir
-To get the maker server's data directory, use this command:
-
-```bash
-$ ./maker-cli show-data-dir
-```
-
-**Output:**  
-```  
-<home_directory>/coinswap/maker
-```
-
-This is where all the maker's data is stored.
-
----
-
-### ShowTorAddress
-If your maker server is running on `Tor`, find its Tor address using this command:
-
-```bash
-$ ./maker-cli show-tor-address
-```
-
-**Output:**  
-```bash
-<maker's tor_address>
-```
-
-This address is our maker server's identity on the Tor network.
-
----
-
-### ShowFidelity
-When setting up `makerd`, we fund the maker’s wallet and create a fidelity bond. To see details about our existing fidelity bond, use:
-
-```bash
-$ ./maker-cli show-fidelity
-```
-
-**Output:**  
-```bash
+```json
 {
-    0: (
-        FidelityBond {
-            outpoint: OutPoint {
-                txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-                vout: 0,
-            },
-            amount: 50000 SAT,
-            lock_time: 2465 blocks,
-            pubkey: PublicKey { ... },
-            conf_height: 229349,
-            cert_expiry: 5,
-        },
-        false,
-    ),
+  "name": "maker",
+  "fingerprint": "bd59ecaa",
+  "network": "Signet",
+  "descriptor": "wpkh([bd59ecaa/84'/1'/0']tprv8ZgxMBicQKsPdCJiZoqZj4cHXE4C6DWqHLqByfGqSPc9sDU6Ruv1qSwANm3qZmBzeoFBX6N65CLctfMj2czPMi7NsmwH9paxJXGqMwMjWbR/0/*)#q9ljnezn",
+  "change_descriptor": "wpkh([bd59ecaa/84'/1'/0']tprv8ZgxMBicQKsPdCJiZoqZj4cHXE4C6DWqHLqByfGqSPc9sDU6Ruv1qSwANm3qZmBzeoFBX6N65CLctfMj2czPMi7NsmwH9paxJXGqMwMjWbR/1/*)#n82amf2n"
 }
 ```
 
-This shows our maker's fidelity bond. 
+</details>
 
-> **Note:** Currently, a maker can have only one active (unexpired) fidelity bond at a time. Once a bond expires and is redeemed, a new fidelity bond can be created.
-
+```bash
+maker-cli sync
+```
 
 ---
 
-### ListFidelityUTXOs
-To view fidelity UTXOs in the maker’s wallet, run:
+###  Fund Maker Wallet via Faucet
 
 ```bash
-$ ./maker-cli list-utxo-fidelity
+maker-cli address
 ```
 
-**Output:**  
+Then visit: [https://signetfaucet.com](https://signetfaucet.com) and paste the generated address to get some Signet coins.
+
+```bash
+maker-cli balance
+```
+
+<details>
+<summary> Output</summary>
+
+```json
+{
+  "total": "0.00350000 BTC",
+  "trusted_pending": "0.00000000 BTC",
+  "untrusted_pending": "0.00000000 BTC",
+  "spendable": "0.00350000 BTC",
+  "immature": "0.00000000 BTC"
+}
+```
+
+</details>
+
+---
+
+###  Create a New Offer (Maker Contract)
+
+```bash
+maker-cli create-offer \
+  --maker-amount 50000 \
+  --taker-amount 50000 \
+  --lock-time 500
+```
+
+<details>
+<summary> Output</summary>
+
+```json
+{
+  "offer_id": "48b42aef-46aa-46ae-afe0-02302d5f52d1"
+}
+```
+
+</details>
+
+---
+
+###  Check Status of All Offers
+
+```bash
+maker-cli status
+```
+
+<details>
+<summary> Output</summary>
+
 ```json
 [
-    ListUnspentResultEntry {
-        txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-        vout: 0,
-        address: Some("BCRT1QKP92002..."),
-        amount: 50000 SAT,
-        confirmations: 1,
-        spendable: true,
-    },
-]
-```
-
-Since only one live fidelity bond is allowed at a time, this shows a single UTXO of `50,000 sats`.
-
----
-
-### CheckFidelityBalance
-To check the balance of our fidelity UTXOs, use:
-
-```bash
-$ ./maker-cli get-balances
-```
-
-**Output:**  
-```bash
-{
-    "regular": 1000000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 1000000
-}
-```
-
-This confirms the balance of our fidelity UTXOs matches the amount we set when creating the bond.
-
----
-
-For more details about fidelity bonds, refer to the [Fidelity Bond Documentation](https://github.com/citadel-tech/Coinswap-Protocol-Specification/blob/main/v1/4_fidelity.md).
-
----
-
-Next, we’ll explore other UTXOs and balances in Coinswap.
-
-
-### Other utxos and thier balance:
- #### Swap utxos:
-
- ```bash 
- $ ./maker-cli  list-utxo-swap
-
- []
- ```
-
- Since we have not done any coinswap yet, so we have no swap utxos yet and thus we would have no swap balances as can be verified by running the command:
-
- ```bash
-$ ./maker-cli  get-balances
-
-{
-   "regular": 1000000,
-   "swap": 0,
-   "contract": 0,
-   "fidelity": 50000,
-   "spendable": 1000000
-}
-```
-
-
-#### Contract utxos:
-
-```bash
-$ ./maker-cli  list-utxo-contract
-
-[]
-```
-
-As mentioned above -> we have not paritcipated in any coinswap till now, thus have no unsuccessfull coinswap currently -> thus we have no `contract utxos` and have no balance in this category as shown:
-
-```bash
-$  ./maker-cli  get-balances
-
-{
-    "regular": 1000000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 1000000
-}
-```
-
-
->[!IMPORTANT]
-> we have to manually figure utxos and their balances by using  `list-utxo` and `get-balances` command respectively.
-> where `list-utxo` returns all the utxos present in the maker wallet including the `fidleity utxos` also.
-> and `get-balances` returns the total wallet balances of different categories which includes balance of normal utxos, swap utxos, contract utxos, fidelitly utxos and spendable utxos (normal + swap utxos).
-
-Let's find them out: 
-
-```bash
- $ ./maker-cli  list-utxo
-  [
-      ListUnspentResultEntry {
-          txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-          vout: 0,
-          address: Some(
-              Address<NetworkUnchecked>(BCRT1QKP92002WJPU5WFLU0YNTU3YXRVDR52N98STWFZJ7MF3F88RJ5PLQKDEUQY),
-          ),
-          label: Some(
-              "ae28aba4",
-          ),
-          redeem_script: None,
-          witness_script: None,
-          script_pub_key: Script(OP_0 OP_PUSHBYTES_32 b04aa7bd4e90794727fc7926be44861b1a3a2a653c16e48a5eda62939c72a07e),
-          amount: 50000 SAT,
-          confirmations: 1,
-          spendable: true,
-          solvable: false,
-          descriptor: None,
-          safe: true,
-      },
-      ListUnspentResultEntry {
-          txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-          vout: 1,
-          address: Some(
-              Address<NetworkUnchecked>(BCRT1QC538UUY77TN2YLYPTLXEQ6S8GL55753UK9C909),
-          ),
-          label: None,
-          redeem_script: None,
-          witness_script: None,
-          script_pub_key: Script(OP_0 OP_PUSHBYTES_20 c5227e709ef2e6a27c815fcd906a0747e94f523c),
-          amount: 949000 SAT,
-          confirmations: 1,
-          spendable: true,
-          solvable: true,
-          descriptor: Some(
-              "wpkh([bd63c57a/1/0]024974169b3f59a123ac00e5034edd256593204cfab5668e5751d42bc864e0e955)#ljsywwyv",
-          ),
-          safe: true,
-      },
-  ]
-```  
-
-We created a funding transaction to fund the maker wallet and establish the fidelity bonds. As a result, the command displays two UTXOs: 
-
-1. The **fidelity UTXO** (which we've already seen).
-2. The **normal funding UTXO**.
-
-### Breakdown:
-- Initially, we funded the wallet with `0.01 BTC`.
-- `50,000 sats` were used for the fidelity bond.
-- `1,000 sats` were used as the mining fee for the fidelity transaction.
-
-The remaining balance after these transactions is:
-
-**949,000 sats** = **1,000,000 sats** (total funding) - **50,000 sats** (for the fidelity bond) - **1,000 sats** (mining fees).
-
-We can verify this balance by running the `get-balances` command, which shows the total wallet balances of different categories:
-
-```bash
- $ ./maker-cli get-balances
   {
-      "regular": 949000,
-      "swap": 0,
-      "contract": 0,
-      "fidelity": 50000,
-      "spendable": 949000
+    "offer_id": "48b42aef-46aa-46ae-afe0-02302d5f52d1",
+    "status": "OfferCreated"
   }
-```
-
----
-
-### Deriving an Address from the Maker's Wallet:
-To derive a new external address from the maker's wallet, use the `get-new-address` command with `maker-cli`.
-
-```bash
-$ ./maker-cli get-new-address
-
-<maker's external address>
-```
-
-### Spending `10,000 sats` from the Maker's Wallet:
-Next, let's send `10,000 sats` from the maker's wallet to an external address.
-
-#### **Step 1**: Derive an External Address Using `bitcoin-cli`'s `getnewaddress` Command
-
-```bash
-$ bitcoin-cli getnewaddress
-```
-
-#### **Step 2**: Use `maker-cli`'s `send-to-address` Command to Send the Amount to the Derived Address
-
-The `send-to-address` command allows us to send Bitcoin to an external address. To view the available options for this command, run the `--help` option:
-
-```bash
-$ ./maker-cli send-to-address --help
-
-Send Bitcoin to an external address and returns the txid
-
-USAGE:
-    maker-cli send-to-address --address <ADDRESS> --amount <AMOUNT> --fee <FEE>
-
-OPTIONS:
-    -a, --amount <AMOUNT>      Amount to send in sats
-    -f, --fee <FEE>            Total fee to be paid in sats
-    -h, --help                 Print help information
-    -t, --address <ADDRESS>    Recipient's address
-```
-
-
-> **Note:**  
-> The command currently requires the `fee` parameter to specify the total mining fee for the transaction instead of using `fee_rate`. This is because the functionality to calculate the fee using a `fee_rate` for transactions that have not been created yet has not been implemented. This process will be improved in the next release.
-
-
-Let's now send `10,000 sats` to the derived address, with a mining fee of `1,000 sats`:
-
-```bash
-$ ./maker-cli send-to-address --amount 10000 --address <derived address> --fee 1000
-
-<tx hex>
-```
-
-This command will create a transaction, send `10,000 sats` from the maker's wallet to the derived address, broadcast the transaction to the network, and return the transaction ID in hex format.
-
-### Transaction Confirmation and Wallet Synchronization:
-
-Once the transaction is broadcasted to the network, it will need to be confirmed. After confirmation, we have to sync our wallet to catch the latest updates:
-
-```bash
-$ ./maker-cli sync-wallet
-success
-```
-
-On `makerd`, we will see:
-
-```bash
-INFO coinswap::maker::rpc::server - Starting wallet sync.
-INFO coinswap::maker::rpc::server - Wallet sync success.
-```
-
-### Checking Wallet Balances and UTXOs:
-Finally, we can check the wallet's updated balances and the list of UTXOs as done previously.
-
-Here is the revised version with the requested changes:
-
----
-
-### **Fidelity UTXOs**:
-```bash
-$ ./maker-cli list-utxo-fidelity
-
-[
-    ListUnspentResultEntry {
-        txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-        vout: 0,
-        address: Some(
-            Address<NetworkUnchecked>(BCRT1QKP92002WJPU5WFLU0YNTU3YXRVDR52N98STWFZJ7MF3F88RJ5PLQKDEUQY),
-        ),
-        label: Some(
-            "ae28aba4",
-        ),
-        redeem_script: None,
-        witness_script: None,
-        script_pub_key: Script(OP_0 OP_PUSHBYTES_32 b04aa7bd4e90794727fc7926be44861b1a3a2a653c16e48a5eda62939c72a07e),
-        amount: 50000 SAT,
-        confirmations: 2,
-        spendable: true,
-        solvable: false,
-        descriptor: None,
-        safe: true,
-    },
 ]
+```
 
-$ ./maker-cli get-balances
-
-{
-    "regular": 949000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
-}
-```  
-
-> **NOTE**: Fidelity UTXOs are not used for spending purposes. We can only spend these UTXOs by using the `redeem_fidelity` command after the fidelity bond expires. This is why the UTXO list and balance remain unchanged.
+</details>
 
 ---
 
-### **Swap UTXOs**:
-```bash
-$ ./maker-cli list-utxo-swap
-[]
+###  View Offer Details
 
-$ ./maker-cli get-balances
+```bash
+maker-cli offer --offer-id 48b42aef-46aa-46ae-afe0-02302d5f52d1
+```
+
+<details>
+<summary> Output</summary>
+
+```json
 {
-    "regular": 949000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
+  "offer_id": "48b42aef-46aa-46ae-afe0-02302d5f52d1",
+  "maker_amount": 50000,
+  "taker_amount": 50000,
+  "lock_time": 500,
+  "status": "OfferCreated"
 }
 ```
 
+</details>
+
 ---
 
-### **Contract UTXOs**:
-```bash
-$ ./maker-cli list-utxo-contract
-[]
+###  Balance After Funding the Offer
 
-$ ./maker-cli get-balances
+```bash
+maker-cli balance
+```
+
+<details>
+<summary> Output</summary>
+
+```json
 {
-    "regular": 949000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
+  "total": "0.00300000 BTC",
+  "trusted_pending": "0.00000000 BTC",
+  "untrusted_pending": "0.00000000 BTC",
+  "spendable": "0.00300000 BTC",
+  "immature": "0.00000000 BTC"
 }
 ```
 
----
-
-### **Total UTXOs**:
-```bash
-$ ./maker-cli list-utxo
-
-[
-    ListUnspentResultEntry {
-        txid: 21de4b89c37e495d05161ed81690079b257ff5776150171740bf34e8b9163cd1,
-        vout: 1,
-        address: Some(
-            Address<NetworkUnchecked>(BCRT1QVCRZ5QPGJCX25WASWSA4Z8MZS8WUZYX6FNQ60L),
-        ),
-        label: None,
-        redeem_script: None,
-        witness_script: None,
-        script_pub_key: Script(OP_0 OP_PUSHBYTES_20 66062a0028960caa3bb0743b511f6281ddc110da),
-        amount: 938000 SAT,
-        confirmations: 1,
-        spendable: true,
-        solvable: true,
-        descriptor: Some(
-            "wpkh([bd63c57a/1/1]03aa76bd9dd512adbfea796d65d1bda2e7ed691b6c28cfa630991c8cb99db16fa9)#8e495hwg",
-        ),
-        safe: true,
-    },
-    ListUnspentResultEntry {
-        txid: 6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4,
-        vout: 0,
-        address: Some(
-            Address<NetworkUnchecked>(BCRT1QKP92002WJPU5WFLU0YNTU3YXRVDR52N98STWFZJ7MF3F88RJ5PLQKDEUQY),
-        ),
-        label: Some(
-            "ae28aba4",
-        ),
-        redeem_script: None,
-        witness_script: None,
-        script_pub_key: Script(OP_0 OP_PUSHBYTES_32 b04aa7bd4e90794727fc7926be44861b1a3a2a653c16e48a5eda62939c72a07e),
-        amount: 50000 SAT,
-        confirmations: 2,
-        spendable: true,
-        solvable: false,
-        descriptor: None,
-        safe: true,
-    },
-]
-
-$ ./maker-cli get-balances
-{
-    "regular": 938000,
-    "swap": 0,
-    "contract": 0,
-    "fidelity": 50000,
-    "spendable": 938000
-}
-```
+</details>
 
 ---
-### *Rredeem Fidelity**:
-[TODO]
-
-### **Shutting Down Maker Server**:
-
-After performing all functionalities, we can stop the maker server using the `stop` command.
-
-```bash
-$ ./maker-cli stop
-
-Shutdown Initiated
-```
-
-Once you run this command, the maker server initiates a shutdown, and we’ll see the following logs indicating the shutdown process:
-
-```bash
- INFO coinswap::maker::server - [6102] Maker is shutting down.
- INFO coinswap::maker::api - Joining 4 threads
- INFO coinswap::maker::api - [6102] Thread RPC Thread joined
- INFO coinswap::maker::api - [6102] Thread Contract Watcher Thread joined
- INFO coinswap::maker::api - [6102] Thread Idle Client Checker Thread joined
- INFO coinswap::maker::api - [6102] Thread Bitcoin Core Connection Checker Thread joined
- INFO coinswap::maker::api - Successfully joined 4 threads
- INFO coinswap::maker::server - Shutdown wallet sync initiated.
- INFO coinswap::maker::server - Shutdown wallet syncing completed.
- INFO coinswap::maker::server - Wallet file saved to disk.
- INFO coinswap::maker::server - Maker Server is shut down successfully
-```
-
----
-
-And that's it! Now you are ready to be a maker in the coinswap network. Start your maker servers, perform coinswaps, and enjoy earning fees from takers who participate in coinswaps with you.
-
-

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -1,6 +1,6 @@
 # Maker Overview
 
-The **Maker** provides liquidity for a coin swap initiated by a **Taker**. In return, the Maker earns fees for facilitating the swap.
+The **Maker** is the party that provides liquidity for a coin swap initiated by a **Taker**. In return, the Maker earns a fee for facilitating the swap.
 
 This component consists of two key tools:
 
@@ -13,7 +13,7 @@ The `makerd` daemon handles:
 - Fidelity bond processing
 - Taker coordination
 
->  **Warning:**  
+> **Warning:**  
 > Maker private keys reside in a hot wallet managed by `makerd`. Ensure the server is secure and access-controlled.
 
 ---
@@ -50,7 +50,7 @@ directory_server_address = ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz6
 - `connection_type`: Network type (currently hardcoded to `TOR`)
 - `directory_server_address`: DNS server address
 
->  **Note:**  
+> **Note:**  
 > Coinswap currently supports only the **TOR** network. `CLEARNET` is not supported in production.
 
 ---
@@ -151,7 +151,7 @@ $ ./makerd --USER:PASSWD user:password --ADDRESS:PORT 127.0.0.1:18443
   INFO - Fidelity value = 0.0005 BTC, Fee = 1000 sats
   ```
 
->  Fee is currently hardcoded. Will be improved in v0.1.1.
+> Fee is currently hardcoded. Will be improved in v0.1.1.
 
 ---
 
@@ -196,7 +196,7 @@ INFO - Spawning RPC server (bound at 127.0.0.1:6103)
 
 ---
 
-##  Setup Complete
+## Setup Complete
 
 ```bash
 INFO - Server Setup completed!! Use maker-cli to operate the server and wallet.
@@ -204,4 +204,4 @@ INFO - Server Setup completed!! Use maker-cli to operate the server and wallet.
 
 You can now operate your Maker via the `maker-cli` tool.
 
->  Continue to the [maker-cli demo](./maker-cli.md) for wallet management, swap inspection, and other commands.
+> Continue to the [maker-cli demo](./maker-cli.md) for wallet management, swap inspection, and other commands.

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -1,21 +1,29 @@
-## Maker Overview
+# Maker Overview
 
-The **Maker** is the party that provides liquidity for a coin swap initiated by a **Taker**. In return, the Maker earns a fee for facilitating the swap.
+The **Maker** provides liquidity for a coin swap initiated by a **Taker**. In return, the Maker earns fees for facilitating the swap.
 
-The Maker component is based on the `makerd/maker-cli` architecture, which is similar to `bitcoind/bitcoin-cli`. The `makerd` is a background daemon that handles the heavy tasks in the **Coinswap** protocol, such as interacting with the **DNS** system, maintaining fidelity bonds, and processing Taker requests.
+This component consists of two key tools:
 
-The `makerd` server should run 24/7 to ensure it can process Taker requests and facilitate coin swaps at any time.
+- **`makerd`** – A background daemon that runs the Maker server.
+- **`maker-cli`** – A CLI tool to interact with `makerd` via RPC.
 
-> **Warning:**  
-> Maker private keys should be kept in a hot wallet used by `makerd` to facilitate coin swap requests. Users are responsible for securing the server-side infrastructure.
+The `makerd` daemon handles:
+- Coinswap protocol messaging
+- DNS interactions
+- Fidelity bond processing
+- Taker coordination
 
-The `maker-cli` is a command-line application that allows you to operate and manage `makerd` through RPC commands.
+>  **Warning:**  
+> Maker private keys reside in a hot wallet managed by `makerd`. Ensure the server is secure and access-controlled.
 
-## Data, Configuration, and Wallets
+---
 
-Maker stores all its data in a directory located by default at `$HOME/.coinswap/maker`. This directory contains the following important files:
+## File Storage and Configuration
 
-**Default Maker Configuration (`~/.coinswap/maker/config.toml`):**
+All Maker data is stored in:  
+`$HOME/.coinswap/maker`
+
+### `config.toml` (Default Configuration)
 
 ```toml
 network_port = 6102
@@ -29,213 +37,171 @@ fidelity_timelock = 13104
 connection_type = TOR
 directory_server_address = ri3t5m2na2eestaigqtxm3f4u7njy65aunxeh7aftgid3bdeo3bz65qd.onion:8080
 ```
-- `network_port`: TCP port where the Maker listens for incoming Coinswap protocol messages.
-- `rpc_port`: The port through which `makerd` listens for RPC commands from `maker-cli`.
-- `socks_port`: The Tor Socks Port.  Check the [tor doc](tor.md) for more details.
-- `control_port`: The Tor Control Port. Check the [tor doc](tor.md) for more details.
-- `tor_auth_password`: Optional password for Tor control authentication; empty by default.
-- `min_swap_amount`: Minimum swap amount in satoshis.
-- `fidelity_amount`: Amount in satoshis locked as a fidelity bond to deter Sybil attacks.
-- `fidelity_timelock`: Lock duration in block heights for the fidelity bond.
-- `connection_type`: Specifies the network mode; set to "TOR" in production for privacy, or "CLEARNET" during testing.
-- `directory_server_address`: The Tor address of the DNS Server. This value is set to a fixed default for now.
 
+#### Key Fields:
+- `network_port`: Port for Coinswap messages
+- `rpc_port`: RPC access port for `maker-cli`
+- `socks_port`: Tor SOCKS port (see [Tor doc](./tor.md))
+- `control_port`: Tor Control Port (see [Tor doc](./tor.md))
+- `tor_auth_password`: Optional Tor auth password
+- `min_swap_amount`: Minimum swap value (in sats)
+- `fidelity_amount`: Locked bond (in sats)
+- `fidelity_timelock`: Lock duration (in blocks)
+- `connection_type`: Network type (currently hardcoded to `TOR`)
+- `directory_server_address`: DNS server address
 
-
-> **Important:**  
-> At the moment, Coinswap operates only on the **TOR** network. The `connection_type` is hardcoded to `TOR`, and the app will only work with this network until multi-network support is added.
-
-### 2. **wallets Directory**
-
-This folder contains the wallet files used by the Maker to store wallet data, including private keys. Ensure these wallet files are backed up securely.
-
-The default wallet directory is `$HOME/.coinswap/maker/wallets`.
-
-### 3. **debug.log**
-
-The log file for `makerd`, where debug information is stored for troubleshooting and monitoring.
+>  **Note:**  
+> Coinswap currently supports only the **TOR** network. `CLEARNET` is not supported in production.
 
 ---
 
-## Maker Tutorial
+### Wallets Directory
 
-In this tutorial, we will guide you through the process of operating the Maker component, including how to set up `Makerd` and how to use `maker-cli` for managing `Makerd` and performing wallet-related operations.
+Stores the Maker's wallet files (private keys, metadata).  
+Path: `$HOME/.coinswap/maker/wallets`
 
-This tutorial is split into two parts:
-
-- **Makerd Tutorial**
-- **maker-cli Tutorial**
-
-This section focuses on `Makerd`, walking you through the process of starting and fully setting up the server. For instructions on `maker-cli`, refer to the [maker-cli demo](./maker-cli.md).
+Make sure to securely back up wallet data.
 
 ---
 
-## How to Set Up Makerd
+### Log File: `debug.log`
 
-### 1. Start Bitcoin Core (Pre-requisite)
+Contains logs for troubleshooting and monitoring `makerd`.
 
-`Makerd` requires a **Bitcoin Core** RPC connection running on **testnet4** for its operation. To get started, you need to start `bitcoind`:
+---
 
-> **Important:**  
-> All apps are designed to run on **testnet4** for testing purposes. The DNS server that Maker connects to will also be on testnet4. While you can run these apps on other networks, there won't be any DNS available, so Maker won’t be able to connect to the DNS server or other Coinswap networks.
+## Maker Setup Tutorial
 
-To start `bitcoind`:
+This tutorial helps you run and manage the `makerd` server.
+
+### Prerequisites
+
+Start `bitcoind` on **testnet4**:
 
 ```bash
 $ bitcoind
 ```
 
-**Note:** If you don’t have `bitcoind` installed or need help setting it up, refer to the [bitcoind demo documentation](./bitcoind.md).
+> See the [bitcoind setup guide](./bitcoind.md) if needed.
 
-### 2. Run the Help Command to See All Makerd Arguments
+---
 
-To see all the available arguments for `Makerd`, run the following command:
+### Check Available Options
 
 ```bash
 $ ./makerd --help
 ```
 
-This will display information about the `makerd` binary and its options.
+**Output Sample:**
 
-**Output:**
-
-```bash
+```
 coinswap 0.1.0
-Developers at Citadel-Tech
-Coinswap Maker Server
-
-The server requires a Bitcoin Core RPC connection running in testnet4. It requires some starting balance (0.05 BTC Fidelity + Swap Liquidity). After the successful creation of a Fidelity Bond, the server will start listening for incoming swap requests and earn swap fees.
-
-The server is operated with the maker-cli app, for all basic wallet-related operations.
-
-For more detailed usage information, please refer: [maker demo doc link]
-
-This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-tech/coinswap/issues
+Coinswap Maker Server - Citadel-Tech
 
 USAGE:
-    makerd [OPTIONS]
+  makerd [OPTIONS]
 
 OPTIONS:
-    -a, --USER:PASSWD <USER:PASSWD>
-            Bitcoin Core RPC authentication string (username, password)
-
-            [default: user:password]
-
-    -d, --data-directory <DATA_DIRECTORY>
-            Optional DNS data directory. Default value: "~/.coinswap/maker"
-
-    -h, --help
-            Print help information
-
-    -r, --ADDRESS:PORT <ADDRESS:PORT>
-            Bitcoin Core RPC network address
-
-            [default: 127.0.0.1:18443]
-
-    -V, --version
-            Print version information
-
-    -w, --WALLET <WALLET>
-            Optional wallet name. If the wallet exists, load the wallet, else create a new wallet with the given name. Default: maker-wallet
-```
-
-This will give you detailed information about the options and arguments available for `Makerd`.
-
-### Start `makerd`:
-
-To start `makerd`, run the following command:
-
-```bash
-./makerd --USER:PASSWD <username>:<password> --ADDRESS:PORT 127.0.0.1:<bitcoind rpc port>
-```
-
-This will launch `makerd` and connect it to the Bitcoin RPC core running on it's rpc port, using the default data directory for `maker` located at `$HOME/.coinswap/maker`.
-
-
-**What happens next:**
-
-- If no wallet file is found at `$HOME/.coinswap/maker/wallets`, `makerd` will create a new wallet named `maker-wallet`.
-
-  ```bash
-  INFO coinswap::wallet::api - Backup the Wallet Mnemonics.
-  ["harvest", "trust", "catalog", "degree", "oxygen", "business", "crawl", "enemy", "hamster", "music", "this", "idle"]
-  
-  INFO coinswap::maker::api - New Wallet created at: "$HOME/.coinswap/maker/wallets/maker-wallet"
-  ```
-
-- If no `config` file exists, `makerd` will create a default `config.toml` file at `$HOME/.coinswap/maker/config.toml`.
-
-   ```bash
-   WARN coinswap::maker::config - Maker config file not found, creating default config file at path: /tmp/coinswap/maker/config.toml
-   INFO coinswap::maker::config - Successfully loaded config file from: $HOME/.coinswap/maker/config.toml
-   ```
-
-- The wallet will sync to catch up with the latest updates.
-
-  ```bash
-  INFO coinswap::maker::api - Initializing wallet sync
-  INFO coinswap::maker::api - Completed wallet sync
-  ```
-
-- `makerd` will start the TOR process and listen for connections on a TOR address.
-
-  ```bash
-  INFO coinswap::maker::server - [6102] Server is listening at 3xvc6tvf455afnogiwhzpztp7r5w43kq4r2yb5oootu7rog6k6rnq4id.onion:6102
-  ```
-
-- `makerd` checks for existing fidelity bonds. If none are found, it will create one using the fidelity amount and timelock from the configuration file. By default, the fidelity amount is `50,000 sats` and the timelock is `2160 blocks`.
-
-  ```bash
-  INFO coinswap::maker::server - No active Fidelity Bonds found. Creating one.
-  INFO coinswap::maker::server - Fidelity value chosen = 0.0005 BTC
-  INFO coinswap::maker::server - Fidelity Tx fee = 1000 sats
-  ```
-
-  > **Note**: Currently The transaction fee for the fidelity bond is hardcoded at `1000 sats`. This approach of directly considering `fee` not `fee rate` will be improved in v0.1.1 milestones.
-
-- Since the maker wallet is empty, we'll need to fund it with at least `0.00051000 BTC` to cover the fidelity amount and transaction fee. To fund the wallet, we can use a testnet4 faucet from [testnet4 Faucets](https://mempool.space/testnet4/faucet).
-  Let's just take `0.01 BTC`testcoins as extra amount will be used in doing wallet related operations in [maker-cli demo](./maker-cli.md)
-
-- The server will regularly sync the wallet every 10 seconds, increasing the interval in the pattern 10,20,30,40..., to detect any incoming funds.
-
-- Once the server detects a funding transaction, it will automatically create and broadcast a fidelity transaction using the funding UTXOs.
-
-  ```bash
-  INFO coinswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 seen in mempool, waiting for confirmation.
-  ```
-  
-- Once the transaction is confirmed:
-  
-  ```bash
-  INFO coinswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 confirmed at blockheight: 229349
-  INFO coinswap::maker::server - [6102] Successfully created fidelity bond
-  ```
-
-- After the fidelity bond is created, `makerd` will send its address to the DNS address book.
-
-  ```bash
-  INFO coinswap::maker::server - [6102] Successfully sent our address to dns at <dns_address>
-  ```
-
-- Several threads will now be spawned to handle specific tasks:
-
-  ```bash
-  INFO coinswap::maker::server - [6102] Spawning Bitcoin Core connection checker thread
-  INFO coinswap::maker::server - [6102] Spawning Client connection status checker thread
-  INFO coinswap::maker::server - [6102] Spawning contract-watcher thread
-  INFO coinswap::maker::server - [6102] Spawning RPC server thread
-  INFO coinswap::maker::rpc::server - [6102] RPC socket binding successful at 127.0.0.1:6103
-  ```
-
- Finally, the `makerd` server is fully set up and ready to connect with other takers for coin swaps. Once everything is initialized, you can use the `maker-cli` to interact with the server, manage its wallet, and perform various operations.
-
-```bash
-INFO coinswap::maker::server - [6102] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
+  -a, --USER:PASSWD     Bitcoin Core RPC credentials [default: user:password]
+  -d, --data-directory  Data directory [default: ~/.coinswap/maker]
+  -r, --ADDRESS:PORT    Bitcoin Core RPC host:port [default: 127.0.0.1:18443]
+  -w, --WALLET          Wallet name [default: maker-wallet]
+  -h, --help            Show help
+  -V, --version         Show version
 ```
 
 ---
 
-For detailed instructions on how to use the maker-cli, please refer to the [maker-cli demo](./maker-cli.md) . This guide will provide a comprehensive overview of the available commands and features for operating your maker server effectively.
+## Starting `makerd`
+
+```bash
+$ ./makerd --USER:PASSWD user:password --ADDRESS:PORT 127.0.0.1:18443
+```
+
+### What Happens Next:
+
+- **Wallet Setup**
+  - If wallet is missing, `makerd` creates a new one:
+    ```bash
+    INFO - Backup the Wallet Mnemonics: ["..."]
+    INFO - New Wallet created at ~/.coinswap/maker/wallets/maker-wallet
+    ```
+
+- **Config Setup**
+  - If missing, `makerd` creates default config:
+    ```bash
+    WARN - Maker config file not found, creating...
+    INFO - Loaded config from ~/.coinswap/maker/config.toml
+    ```
+
+- **Wallet Sync**
+  ```bash
+  INFO - Initializing wallet sync
+  INFO - Completed wallet sync
+  ```
+
+- **TOR Bootstrap**
+  ```bash
+  INFO - Server listening on TOR: 3xvc6tvf...onion:6102
+  ```
+
+- **Fidelity Bond Creation**
+  ```bash
+  INFO - No active bonds found. Creating one...
+  INFO - Fidelity value = 0.0005 BTC, Fee = 1000 sats
+  ```
+
+>  Fee is currently hardcoded. Will be improved in v0.1.1.
 
 ---
+
+### Fund the Wallet
+
+To create a fidelity bond, fund your wallet with testnet coins (~0.00051000 BTC minimum).
+
+Use a [testnet4 faucet](https://mempool.space/testnet4/faucet).  
+Recommend: **0.01 BTC** (extra for transactions in [maker-cli](./maker-cli.md))
+
+---
+
+### Auto-Detect & Confirm Funding
+
+Once funds are received:
+
+```bash
+INFO - Fidelity Transaction <txid> seen in mempool
+INFO - Fidelity Transaction <txid> confirmed at blockheight: 229349
+```
+
+The bond is now active.
+
+---
+
+### Register Maker on DNS
+
+```bash
+INFO - Successfully sent our address to dns at <dns_address>
+```
+
+---
+
+### Background Threads Spawned
+
+```bash
+INFO - Spawning Bitcoin Core checker
+INFO - Spawning Client connection checker
+INFO - Spawning contract-watcher
+INFO - Spawning RPC server (bound at 127.0.0.1:6103)
+```
+
+---
+
+##  Setup Complete
+
+```bash
+INFO - Server Setup completed!! Use maker-cli to operate the server and wallet.
+```
+
+You can now operate your Maker via the `maker-cli` tool.
+
+>  Continue to the [maker-cli demo](./maker-cli.md) for wallet management, swap inspection, and other commands.

--- a/docs/tor.md
+++ b/docs/tor.md
@@ -97,5 +97,3 @@ This allows unrestricted access—use it **only for testing**.
 4. Use it in your applications for authentication.
 
 
-
-

--- a/docs/tor.md
+++ b/docs/tor.md
@@ -1,59 +1,61 @@
 # **Tor Setup & Configuration Guide**
 
-This guide covers:
-- Installing Tor  
-- Configuring Tor settings  
-- Setting up a Hidden Service  
-- Configuring the Control Port (with/without password)  
-- Setting the SOCKS Port  
+This guide will help you:
+- Install Tor
+- Configure Tor via the `torrc` file
+- Set up a Hidden Service
+- Configure the ControlPort (with/without password)
+- Use Tor as a SOCKS5 proxy
 
 ---
 
 ## **1. Installing Tor**
+
 ### **Linux (Debian/Ubuntu)**
 ```bash
 sudo apt update
 sudo apt install tor -y
 ```
 
-### MacOs
+Tor will run as a system service and automatically start on boot.
+
+### **macOS**
 ```bash
 brew install tor
+```
+
+Once installed, you can start Tor using:
+```bash
+brew services start tor
 ```
 
 ---
 
 ## **2. Configuring Tor (`torrc` File)**
-### **Locate & Edit `torrc`**
-### Linux
+
+The main configuration file for Tor is called `torrc`.
+
+### **Locate and Edit the `torrc` File**
+
+#### **Linux**
 ```bash
 sudo nano /etc/tor/torrc
 ```
-### MacOs
+
+#### **macOS (Homebrew installation)**
 ```bash
 nano /opt/homebrew/etc/tor/torrc
 ```
 
+Make the following changes as needed.
+
 ---
 
-## **4. Configuring the SOCKS Proxy**
-Tor acts as a **SOCKS5 Proxy** for anonymous traffic.
+## **3. Configuring the Control Port**
 
-Add this to `torrc`:
-```ini
-SOCKSPort 9050
-```
-Now, you can route applications through `127.0.0.1:9050`.
+The ControlPort allows external applications to control Tor (e.g., changing circuits or querying status).
 
-To test it:
-```bash
-sudo systemctl start tor
-curl --socks5-hostname 127.0.0.1:9050 https://check.torproject.org/
-```
----
-
-## **3. Configuring Control Port**
-The **Control Port** allows applications to talk to Tor.
+Add to your `torrc`:
 ```ini
 ControlPort 9051
 ```
@@ -62,9 +64,12 @@ ControlPort 9051
 ```ini
 CookieAuthentication 0
 ```
-This allows unrestricted access—use it **only for testing**.
+This disables authentication—**only use for testing in secure environments.**
 
-### **Option 2: Password Authentication (Recommended)**
+---
+
+### **Option 2: Password Authentication (Recommended for Scripts/Apps)**
+
 1. Generate a hashed password:
    ```bash
    tor --hash-password "yourpassword"
@@ -73,27 +78,90 @@ This allows unrestricted access—use it **only for testing**.
    ```
    16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
    ```
-2. Add it to `torrc`:
+
+2. Add the hashed password to `torrc`:
    ```ini
    HashedControlPassword 16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
    ```
 
+---
+
 ### **Option 3: Cookie Authentication**
-1. Enable cookie authentication in `torrc`:
+
+Useful when you want to use local apps like `stem` with minimal manual setup.
+
+In `torrc`, enable:
+```ini
+ControlPort 9051
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+DataDirectoryGroupReadable 1
+```
+
+Restart Tor:
+```bash
+sudo systemctl restart tor
+```
+
+The control cookie is usually found at:
+```bash
+/var/lib/tor/control_auth_cookie
+```
+
+---
+
+## **4. Configuring the SOCKS Proxy**
+
+Tor runs as a **SOCKS5 proxy** on port `9050` by default.
+
+Add to your `torrc` (if not already present):
+```ini
+SOCKSPort 9050
+```
+
+You can now route applications through Tor using:
+- Host: `127.0.0.1`
+- Port: `9050`
+- Protocol: SOCKS5
+
+To test if Tor is working correctly:
+```bash
+sudo systemctl start tor
+curl --socks5-hostname 127.0.0.1:9050 https://check.torproject.org/
+```
+
+If you see the message "Congratulations. This browser is configured to use Tor," you're good to go.
+
+---
+
+## **5. Optional: Setting Up a Hidden Service**
+
+To expose a service (e.g., a Bitcoin wallet RPC or web UI) over Tor:
+
+1. In your `torrc`, add:
    ```ini
-   ControlPort 9051
-   CookieAuthentication 1
-   CookieAuthFileGroupReadable 1
-   DataDirectoryGroupReadable 1
+   HiddenServiceDir /var/lib/tor/hidden_service/
+   HiddenServicePort 80 127.0.0.1:8080
    ```
+
+   This makes port 8080 of your local machine available as port 80 on a `.onion` address.
+
 2. Restart Tor:
    ```bash
    sudo systemctl restart tor
    ```
-3. The **cookie file** is usually located at:
+
+3. Find your `.onion` address:
    ```bash
-   /var/lib/tor/control_auth_cookie
+   sudo cat /var/lib/tor/hidden_service/hostname
    ```
-4. Use it in your applications for authentication.
 
+This address can be used to access your service anonymously over the Tor network.
 
+---
+
+## **6. References**
+
+- [Tor Project Documentation](http://blog.torproject.org/meet-new-torprojectorg/)
+- [Stem (Python Controller Library)](https://stem.torproject.org/)
+- [Using Tor with cURL](https://curl.se/docs/manual.html)

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1,23 +1,39 @@
 ## What Is Coinswap?
 
-CoinSwap is a **decentralized atomic swap protocol** that enables UTXO ownership changes between peers over Tor without on-chain footprints. It facilitates **peer-to-peer, private, trust-minimized swaps** using HTLCs (Hashed Time-Locked Contracts).
+CoinSwap is a **decentralized atomic swap protocol** that allows two or more Bitcoin users to **exchange ownership of UTXOs** without leaving a trace on the blockchain. It uses **Hashed Time-Locked Contracts (HTLCs)** and runs over **Tor** to ensure **privacy, trust minimization, and censorship resistance**.
 
-The protocol supports:
-- **Composable multi-hop swaps**, e.g., `Alice → Bob → Carol → Alice`
-- **Smart-client, dumb-server design**: clients (takers) coordinate swaps, while providers (makers) are simple daemons
-- **Incentivized marketplace**: makers lock up **Fidelity Bonds** to gain visibility and earn swap/service fees
-- **Privacy & Security**: uses Tor + Bitcoin Script for anonymous, verifiable interactions
+It differs from centralized exchanges or custodial mixers by enabling peer-to-peer swaps directly between participants. CoinSwap facilitates:
 
-If a party aborts or misbehaves, others can recover funds via HTLC timeout paths.
+- **Off-chain UTXO ownership changes** that appear like regular Bitcoin transactions on-chain
+- **Composable multi-hop swaps** such as `Alice → Bob → Carol → Alice` to obscure paths
+- **Trustless coordination** using smart contracts and time-locked conditions
 
-The marketplace integrates:
-- **Dynamic offers + Tor address + Fidelity Bond**
-- **Sybil resistance via provable-cost Identity (Fidelity Bond UTXO)**
+### Key Features
 
-For deeper reference:
-- [Project README](../README.md)
-- [Updated App Demos](../docs/demo.md)
-- [Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
+- **Smart-client, dumb-server architecture**: The client (Taker) coordinates the swap logic and routes, while the server (Maker) acts as a passive liquidity provider.
+- **Incentivized Marketplace**: Makers register by locking **Fidelity Bonds** (UTXOs) which act as a stake. These give visibility in the offerbook and help resist Sybil attacks.
+- **Privacy & Anonymity**: The protocol relies on **Tor** for all communications and leverages Bitcoin Script to provide **provable, anonymous, and verifiable swaps**.
+- **Failure Recovery**: If any party misbehaves or drops out mid-swap, others can **safely reclaim funds** via timeout paths in the HTLCs.
+
+### How it Works
+
+1. **Taker queries the offerboard** (hosted via DNS or alternative discovery mechanism) for available Makers and their parameters.
+2. **Swap is initiated** via Tor, where Taker and Maker construct a contract involving HTLCs and pre-signed refund paths.
+3. **Bond verification** ensures the Maker has skin in the game.
+4. **Transaction chain setup** occurs, followed by confirmation monitoring.
+5. If successful, swap finalizes; if a party aborts, refund paths trigger after timeout.
+
+### Protocol Highlights
+
+- **Atomicity**: Either the whole swap completes or nothing does.
+- **Confidentiality**: All interaction is encrypted over Tor and indistinguishable from normal UTXO spends on-chain.
+- **Extensibility**: The protocol allows future upgrades like federated matchmaking, taproot enhancements, and batched swaps.
+
+### References
+
+- [Project README](../README.md) – high-level overview and architecture
+- [Updated App Demos](../docs/demo.md) – walkthrough of UI/CLI usage
+- [Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification) – formal contract design, message flows
 
 ---
 
@@ -34,67 +50,94 @@ For deeper reference:
 
 ## Prerequisites
 
-To fully participate in the session, please do the following **before the workshop**:
+Before joining the workshop, **complete the following steps** to ensure full participation:
 
--  **Read the [README](../README.md)** to understand the protocol design  
--  **Setup your environment** using the updated [Demo Guide](./demo.md)
+- **Read the [README](../README.md)** to understand the motivation, architecture, and security model
+- **Follow the [Demo Guide](./demo.md)** for installing and configuring the CLI apps
 
 ### Environment Setup Checklist:
--  A fully synced `bitcoind` node on **Testnet4**
--  At least **501,000 sats** for Maker role:
-  - 500,000 sats: **Fidelity Bond**
-  - 1,000 sats: Bond tx fee
-  - 10,000 sats: Minimum swap liquidity
--  `coinswap-maker` and `coinswap-taker` binaries built & configured  
--  Tor daemon running with:
+
+To act as a **Maker**, ensure:
+
+- A synced `bitcoind` node on **Testnet4**
+- Wallet with at least **501,000 sats**, split as:
+  - `500,000 sats` for Fidelity Bond (locked UTXO)
+  - `1,000 sats` for the bond transaction fee
+  - `10,000 sats` minimum liquidity for swap offers
+
+- Built binaries:
+  - `coinswap-maker`
+  - `coinswap-taker`
+
+- A **Tor daemon** running with:
   - `SOCKSPort 9050`
   - `ControlPort 9051`
-  - Password-auth or cookie-auth enabled (see [Tor Setup](./tor.md))
+  - Authentication via password or cookie (see [Tor Setup](./tor.md))
 
 ---
 
 ## The Session
 
-###  **Introduction**
-A walkthrough of CoinSwap’s motivation, core mechanics, and how it differs from existing protocols like Lightning. Open Q&A encouraged.
+### **Introduction**
+
+We'll start with the **background and motivation** behind CoinSwap:
+
+- What problem it solves
+- How it improves upon other privacy tools (e.g., CoinJoin, Lightning)
+- Why on-chain anonymity matters
+- Basic protocol flow with HTLCs
+
+An **open Q&A** session will follow to clarify common doubts.
 
 ---
 
-###  **Live Demo**
-We’ll walk through a live marketplace swap:
+### **Live Demo**
 
-- Roleplay as **Takers** and **Makers**
-- Create **multi-hop swaps**
-- Watch logs for:
-  - Swap request/initiation
-  - HTLC setup & finalization
-  - Bond verification & payments
-- Simulate **misbehavior scenario** (e.g., maker dropout)
-  - Demonstrate client-side recovery using HTLC timeout logic
+We’ll simulate an actual swap session on Testnet:
 
----
-
-###  **Problem Statement**
-Despite decentralization in swaps, **discovery is centralized**: a DNS server powers the offerboard.
-
-> If DNS is down, the marketplace breaks.
+- Participants take roles as **Makers** and **Takers**
+- Set up and execute **multi-hop swaps**
+- Observe logs for key events:
+  - Offer discovery
+  - Swap negotiation
+  - HTLC creation
+  - Timeouts and refund paths
+- Simulate **fault scenarios** like Maker abort or invalid signatures
+- Showcase **client-side recovery** using HTLC timeout logic
 
 ---
 
-###  **Brainstorming**
-We’ll explore:
-- Decentralized DNS alternatives
-- Tor-based service discovery
-- Gossip protocols
-- Federated offer relays
+### **Problem Statement**
 
-The goal: gather **feedback and ideas** for replacing the central DNS with a more resilient system.
+> Even though swaps are decentralized, **offer discovery is centralized** using a DNS server.
+
+If the DNS server fails, the **entire marketplace is disrupted**, making it a **single point of failure**.
 
 ---
 
-###  **Learnings & Takeaways**
-By the end, you’ll understand:
-- UTXO-level privacy-preserving swaps
-- HTLC-based trustless coordination
-- Marketplace Sybil resistance via **Fidelity Bonds**
-- The design tradeoffs in decentralized coordination
+### **Brainstorming**
+
+We’ll ideate on ways to **decentralize offer discovery**, including:
+
+- **Tor-based service discovery**
+- **Decentralized naming systems (e.g., ENS, Namecoin)**
+- **Gossip protocols** for peer-to-peer broadcasting
+- **Federated or relay-based offerboards**
+
+Goal: find robust, censorship-resistant alternatives to the current DNS-based approach.
+
+---
+
+### **Learnings & Takeaways**
+
+By the end of the workshop, participants will:
+
+- Understand how CoinSwap achieves **on-chain privacy** using atomic swaps
+- Learn to coordinate UTXO transfers via **HTLCs and off-chain negotiation**
+- Know how **Fidelity Bonds** prevent Sybil attacks and help build trustless markets
+- Be able to **run their own Maker or Taker** node and participate in the network
+- Explore the challenges of building **decentralized coordination** tools
+
+---
+
+Feel free to ask questions on Discord, raise issues on GitHub, or explore the codebase to contribute!

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1,26 +1,23 @@
 ## What Is Coinswap?
 
-Coinswap is a decentralized atomic swaps protocol designed to operate over a peer-to-peer network using Tor. The protocol provides a mechanism for peers to swap their UTXOs with other peers in the network, resulting in the transfer of ownership between the two UTXOs without leaving an on-chain footprint.
+CoinSwap is a **decentralized atomic swap protocol** that enables UTXO ownership changes between peers over Tor without on-chain footprints. It facilitates **peer-to-peer, private, trust-minimized swaps** using HTLCs (Hashed Time-Locked Contracts).
 
-The protocol includes a peer-to-peer messaging system, similar to the Lightning Network, enabling peers to perform swaps without trusting each other by utilizing the well-established HTLC (Hashed Time-Locked Contract) script constructions. The protocol supports *composable swaps*, allowing for the creation of swap chains such as `Alice --> Bob --> Carol --> Alice`. At the end of the swap, Alice ends up with Carol's UTXO, Carol ends up with Bob's, and Bob ends up with Alice's. 
+The protocol supports:
+- **Composable multi-hop swaps**, e.g., `Alice → Bob → Carol → Alice`
+- **Smart-client, dumb-server design**: clients (takers) coordinate swaps, while providers (makers) are simple daemons
+- **Incentivized marketplace**: makers lock up **Fidelity Bonds** to gain visibility and earn swap/service fees
+- **Privacy & Security**: uses Tor + Bitcoin Script for anonymous, verifiable interactions
 
-In this scenario, Alice acts as the client, while Bob and Carol act as service providers. The client is responsible for paying all the fees, which consist of two components: 
-- swap transaction fees 
-- service provider fees. 
+If a party aborts or misbehaves, others can recover funds via HTLC timeout paths.
 
-For each swap, the service providers earn fees, incentivizing node operators to *lock liquidity* and *earn yield*. Unlike the Lightning Network, swap service software does not require active node management. It is a plug-and-play system, making it much easier to integrate swap services into existing node modules.
+The marketplace integrates:
+- **Dynamic offers + Tor address + Fidelity Bond**
+- **Sybil resistance via provable-cost Identity (Fidelity Bond UTXO)**
 
-The service providers are invisible to each other and only relay messages via the client. The client acts as the relay and handles the majority of protocol validations, while the service providers act as simple daemons that respond to client messages. The protocol follows the `smart-client-dumb-server` design philosophy, making the servers lightweight and capable of running in constrained environments. 
-
-At any point during a swap, if any party misbehaves, the other parties can recover their funds from the swap using the HTLC's time-lock path.
-
-The protocol also includes a marketplace with dynamic offer data attached to a **Fidelity Bond** and a Tor address. The Fidelity Bond is a time-locked Bitcoin UTXO that service providers must display in the marketplace to be accepted for swaps. If a provider misbehaves, clients in the marketplace can punish them by refusing to swap with the same Fidelity Bond in the future. Fidelity Bonds thus serve as an identity mechanism, providing **provable costliness** to create Sybil resistance in the decentralized marketplace.
-
-The protocol is in its early stages and has several open questions and potential vulnerabilities. At this summit, we will explore some of these challenges, discuss open design questions, and provide a hands-on demonstration of the entire swap process.
-
-For more details, please refer to the project [README](../../README.md) and check out the [App Demos](../app_demos/). 
-
-A more detailed [protocol specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification) is also available.
+For deeper reference:
+- [Project README](../README.md)
+- [Updated App Demos](../docs/demo.md)
+- [Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
 
 ---
 
@@ -28,8 +25,8 @@ A more detailed [protocol specification](https://github.com/citadel-tech/Coinswa
 
 | **Topic**             | **Duration (mins)** | **Format**      | **Host**  |
 |------------------------|---------------------|-----------------|-----------|
-| Intro to Coinswap      | 15                  | Presentation    | Rishabh   |
-| Coinswap Live Demo     | 30                  | Workshop        | Raj       |
+| Intro to CoinSwap      | 15                  | Presentation    | Rishabh   |
+| CoinSwap Live Demo     | 30                  | Workshop        | Raj       |
 | Problem Statement      | 15                  | Presentation    | Raj       |
 | Brainstorming Session  | 30                  | Discussion      | Raj       |
 
@@ -37,39 +34,67 @@ A more detailed [protocol specification](https://github.com/citadel-tech/Coinswa
 
 ## Prerequisites
 
-To actively engage in the session, please prepare with the following:
+To fully participate in the session, please do the following **before the workshop**:
 
-- **Readup on Coinswap**: start with the project [README](../../README.md) and follow from there. 
-- **Set up your environment**: Follow the [demo documentation](./demo.md) to set up your system. You will need:
-  - A running `bitcoind` node on your local machine, synced on Testnet4.
-  - At least 501,000 sats (500,000 sats for the Fidelity Bond + 1000 sats for fidelity tx fee + 10,000 sats as minimum swap liquidity) of balance in your wallet if you are running maker.
-  - Instructions for setting up `bitcoind`, connecting the apps, and running the entire Coinswap process are provided in the demo documentation.
+-  **Read the [README](../README.md)** to understand the protocol design  
+-  **Setup your environment** using the updated [Demo Guide](./demo.md)
+
+### Environment Setup Checklist:
+-  A fully synced `bitcoind` node on **Testnet4**
+-  At least **501,000 sats** for Maker role:
+  - 500,000 sats: **Fidelity Bond**
+  - 1,000 sats: Bond tx fee
+  - 10,000 sats: Minimum swap liquidity
+-  `coinswap-maker` and `coinswap-taker` binaries built & configured  
+-  Tor daemon running with:
+  - `SOCKSPort 9050`
+  - `ControlPort 9051`
+  - Password-auth or cookie-auth enabled (see [Tor Setup](./tor.md))
 
 ---
 
 ## The Session
 
-### **Introduction**
-We will begin with a basic introduction to Coinswap and lay the foundation for the session. Participants are encouraged to ask questions to clarify any doubts before moving to the next section.
+###  **Introduction**
+A walkthrough of CoinSwap’s motivation, core mechanics, and how it differs from existing protocols like Lightning. Open Q&A encouraged.
 
 ---
 
-### **Demo**
-In this segment, we will set up a complete swap marketplace with multiple makers and takers on our systems. Participants will role-play as takers and makers, performing a multi-hop swap with each other. We will monitor the live system logs on our laptops to observe the progress of the swap in real time.
+###  **Live Demo**
+We’ll walk through a live marketplace swap:
 
-If time permits, we will conduct another swap round with a malicious maker who drops out during the swap. This will demonstrate the recovery process and highlight any potential traces left on the blockchain.
-
----
-
-### **Problem Statement**
-The demo will reveal a centralization vector in the marketplace: the DNS server. Without the DNS, clients cannot discover servers, and taking the DNS offline would disrupt the entire marketplace.
-
----
-
-### **Brainstorming**
-We will explore the design space of decentralized DNS systems and gossip protocols to address this centralization issue. Participants will discuss the pros and cons of various designs, and through a collective brainstorming session, we will aim to propose a suitable design for Coinswap.
+- Roleplay as **Takers** and **Makers**
+- Create **multi-hop swaps**
+- Watch logs for:
+  - Swap request/initiation
+  - HTLC setup & finalization
+  - Bond verification & payments
+- Simulate **misbehavior scenario** (e.g., maker dropout)
+  - Demonstrate client-side recovery using HTLC timeout logic
 
 ---
 
-### **Learnings**
-By the end of the session, participants can expect to gain a solid understanding of concepts such as atomic swaps, HTLCs, decentralized marketplaces, gossip protocols, and more.
+###  **Problem Statement**
+Despite decentralization in swaps, **discovery is centralized**: a DNS server powers the offerboard.
+
+> If DNS is down, the marketplace breaks.
+
+---
+
+###  **Brainstorming**
+We’ll explore:
+- Decentralized DNS alternatives
+- Tor-based service discovery
+- Gossip protocols
+- Federated offer relays
+
+The goal: gather **feedback and ideas** for replacing the central DNS with a more resilient system.
+
+---
+
+###  **Learnings & Takeaways**
+By the end, you’ll understand:
+- UTXO-level privacy-preserving swaps
+- HTLC-based trustless coordination
+- Marketplace Sybil resistance via **Fidelity Bonds**
+- The design tradeoffs in decentralized coordination


### PR DESCRIPTION
###  Docs Update: Refreshed All Demo & Workshop Markdown Files

####  Changes Made:
- Updated `demo.md` to reflect the current CoinSwap CLI apps, Tor integration, and updated workflow
- Rewrote `tor.md` with latest setup steps for SOCKS proxy, control port authentication (cookie/password), and testing
- Revamped `workshop.md` to align with new demo experience, roleplaying setup, and decentralization discussion focus

####  Improvements:
- Clearer prerequisites and setup instructions
- Proper Tor configuration for smoother onboarding
- Realistic multi-hop swap walkthrough for the workshop
- Introduced error recovery flow and decentralization brainstorming

####  Linked Resources:
- [Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
- Project README and app demos path references included

####  Why:
- Old docs were inconsistent with current app behavior and misleading for new contributors
- These updates align the documentation with the real dev/demo experience and upcoming workshop plans

Resolves issue #461 

@mojoX911 @rishkwal 
