### PR TITLE
Issue450: fee rate negotiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ log4rs = "1.3.0"
 flate2 = {version = "1.0.35", optional = true}
 tar = {version = "0.4.43", optional = true}
 minreq = { version = "2.12.0", features = ["https"] , optional = true}
+bitcoincore-rpc = "0.19.0"
+reqwest = { version = "0.12.15", features = ["blocking", "json"] }
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -170,6 +170,7 @@ pub(crate) struct ConnectionState {
     pub(crate) incoming_swapcoins: Vec<IncomingSwapCoin>,
     pub(crate) outgoing_swapcoins: Vec<OutgoingSwapCoin>,
     pub(crate) pending_funding_txes: Vec<Transaction>,
+    pub(crate) negotiated_feerate: Option<u64>
 }
 
 pub(crate) struct ThreadPool {

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -185,6 +185,19 @@ pub(crate) struct PrivKeyHandover {
     pub(crate) multisig_privkeys: Vec<MultisigPrivkey>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct FeeNegotiationProposal {
+    /// Proposed fee in sat/vByte
+    pub proposed_fee_sat_per_vbyte: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum FeeNegotiationResponse {
+    Accept(u64),    // Maker accepts the proposed fee
+    Counter(u64),   // Maker counters with a new fee
+    Reject(String), // Maker rejects the proposal (with a reason)
+}
+
 /// All messages sent from Taker to Maker.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum TakerToMakerMessage {
@@ -205,6 +218,9 @@ pub(crate) enum TakerToMakerMessage {
     /// Respond by handing over the Private Keys of coinswap multisig. This denotes the completion of the whole swap.
     RespPrivKeyHandover(PrivKeyHandover),
     WaitingFundingConfirmation(String),
+    //fee rate negotiation proposal
+    FeeNegotiationProposal(FeeNegotiationProposal),
+
 }
 
 impl Display for TakerToMakerMessage {
@@ -221,6 +237,8 @@ impl Display for TakerToMakerMessage {
             Self::RespHashPreimage(_) => write!(f, "RespHashPreimage"),
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
             Self::WaitingFundingConfirmation(_) => write!(f, "WaitingFundingConfirmation"),
+            Self::FeeNegotiationProposal(_) => write!(f, "FeeNegotiationProposal"), 
+
         }
     }
 }
@@ -302,6 +320,9 @@ pub(crate) enum MakerToTakerMessage {
     RespContractSigsForRecvr(ContractSigsForRecvr),
     /// Send the multisig private keys of the swap, declaring completion of the contract.
     RespPrivKeyHandover(PrivKeyHandover),
+    //reponse to fee rate negotiation
+    FeeNegotiationResponse(FeeNegotiationResponse),
+
 }
 
 impl Display for MakerToTakerMessage {
@@ -317,6 +338,7 @@ impl Display for MakerToTakerMessage {
                 write!(f, "RespContractSigsForRecvr")
             }
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
+            Self::FeeNegotiationResponse(_) => write!(f, "FeeNegotiationResponse"),
         }
     }
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -185,10 +185,11 @@ pub(crate) struct PrivKeyHandover {
     pub(crate) multisig_privkeys: Vec<MultisigPrivkey>,
 }
 
+/// A message struct used for negotiating transaction fees between Taker and Maker.
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct FeeNegotiationProposal {
-    /// Proposed fee in sat/vByte
-    pub proposed_fee_sat_per_vbyte: u64,
+pub struct FeeNegotiationProposal {
+    /// The proposed fee rate in satoshis per virtual byte (sat/vB)
+    pub proposed_feerate: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -219,7 +220,7 @@ pub(crate) enum TakerToMakerMessage {
     RespPrivKeyHandover(PrivKeyHandover),
     WaitingFundingConfirmation(String),
     //fee rate negotiation proposal
-    FeeNegotiationProposal(FeeNegotiationProposal),
+    ReqFeeNegotiation(FeeNegotiationProposal), // Taker proposes a fee
 
 }
 
@@ -237,7 +238,7 @@ impl Display for TakerToMakerMessage {
             Self::RespHashPreimage(_) => write!(f, "RespHashPreimage"),
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
             Self::WaitingFundingConfirmation(_) => write!(f, "WaitingFundingConfirmation"),
-            Self::FeeNegotiationProposal(_) => write!(f, "FeeNegotiationProposal"), 
+            Self::ReqFeeNegotiation(_) => write!(f, "FeeNegotiationProposal"), 
 
         }
     }
@@ -321,8 +322,7 @@ pub(crate) enum MakerToTakerMessage {
     /// Send the multisig private keys of the swap, declaring completion of the contract.
     RespPrivKeyHandover(PrivKeyHandover),
     //reponse to fee rate negotiation
-    FeeNegotiationResponse(FeeNegotiationResponse),
-
+    RespFeeNegotiation(FeeNegotiationResponse),
 }
 
 impl Display for MakerToTakerMessage {
@@ -338,7 +338,7 @@ impl Display for MakerToTakerMessage {
                 write!(f, "RespContractSigsForRecvr")
             }
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
-            Self::FeeNegotiationResponse(_) => write!(f, "FeeNegotiationResponse"),
+            Self::RespFeeNegotiation(_) => write!(f, "FeeNegotiationResponse"),
         }
     }
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1044,6 +1044,12 @@ impl Taker {
                 this_maker_refund_locktime: maker_refund_locktime,
             };
 
+
+        let fee_rate = self
+         .ongoing_swap_state
+         .negotiated_feerate
+        .unwrap_or(MINER_FEE);
+
             let (contract_sigs_as_recvr_sender, next_swap_contract_redeemscripts) =
                 send_proof_of_funding_and_init_next_hop(
                     &mut socket,
@@ -1051,6 +1057,7 @@ impl Taker {
                     next_maker_info,
                     self.get_preimage_hash(),
                     self.ongoing_swap_state.id.clone(),
+                    fee_rate,
                 )?;
             log::info!(
                 "<=== ReqContractSigsAsRecvrAndSender | {}",

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -35,6 +35,8 @@ pub enum TakerError {
     MPSC(String),
     /// Tor error
     TorError(TorError),
+    /// A general error message.
+    General(String),
 }
 
 impl From<TorError> for TakerError {

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -8,7 +8,7 @@ pub mod api;
 mod config;
 pub mod error;
 pub(crate) mod offers;
-mod routines;
+pub mod routines;
 
 pub use self::api::TakerBehavior;
 pub use api::{SwapParams, Taker};


### PR DESCRIPTION
addresses #450 
changes made :
- **Dynamic fee‐rate negotiation added**  
  - Taker fetches a sats/vByte estimate from Bitcoin Core (6‑block target)  
  - Sends that value in a new `FeeNegotiationProposal` to the Maker  

- **Maker’s decision logic**  
  - Retrieves its own fee estimate via mempool.space  
  - **Accept** if proposal ≥ Maker’s estimate  
  - **Counter** if proposal ≥ 80% of Maker’s estimate  
  - **Reject** otherwise, aborting the swap  

- **State handling**  
  - Agreed‐upon rate is stored in `ongoing_swap_state.negotiated_feerate`  
  - Falls back to the legacy `MINER_FEE` only when no negotiation took place  


Testing is remaining. Would appreciate a review  .