### PR TITLE
add maker tor address to fidelity bond's OP_RETURN

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -204,10 +204,11 @@ fn main() -> Result<(), TakerError> {
                 .get_wallet_mut()
                 .coin_select(amount, feerate.unwrap_or(DEFAULT_TX_FEE_RATE))?;
 
-            let destination = Destination::Multi(vec![(
-                Address::from_str(&address).unwrap().assume_checked(),
-                amount,
-            )]);
+            let outputs = vec![(Address::from_str(&address)?.assume_checked(), amount)];
+            let destination = Destination::Multi {
+                outputs,
+                op_return_data: None,
+            };
 
             let tx = taker.get_wallet_mut().spend_from_wallet(
                 feerate.unwrap_or(DEFAULT_TX_FEE_RATE),

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -77,10 +77,14 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
             feerate,
         } => {
             let amount = Amount::from_sat(amount);
-            let destination = Destination::Multi(vec![(
+            let outputs = vec![(
                 Address::from_str(&address).unwrap().assume_checked(),
                 amount,
-            )]);
+            )];
+            let destination = Destination::Multi {
+                outputs,
+                op_return_data: None,
+            };
 
             let coins_to_send = maker.get_wallet().read()?.coin_select(amount, feerate)?;
             let tx = maker.get_wallet().write()?.spend_from_wallet(

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -240,11 +240,12 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
             // sync the wallet
             maker.get_wallet().write()?.sync_no_fail();
 
-            let fidelity_result =
-                maker
-                    .get_wallet()
-                    .write()?
-                    .create_fidelity(amount, locktime, DEFAULT_TX_FEE_RATE);
+            let fidelity_result = maker.get_wallet().write()?.create_fidelity(
+                amount,
+                locktime,
+                Some(maker_address.as_bytes()),
+                DEFAULT_TX_FEE_RATE,
+            );
 
             match fidelity_result {
                 // Wait for sufficient fund to create fidelity bond.

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -3,6 +3,7 @@ use crate::{
     error::NetError, market::directory::DirectoryServerError, protocol::error::ProtocolError,
     utill::TorError, wallet::WalletError,
 };
+use bitcoin::address::ParseError;
 
 /// Represents errors that can occur during Taker operations.
 ///
@@ -35,6 +36,8 @@ pub enum TakerError {
     MPSC(String),
     /// Tor error
     TorError(TorError),
+    /// Error relating to Bitcoin Address Parsing.
+    AddressParseError(ParseError),
 }
 
 impl From<TorError> for TakerError {
@@ -94,5 +97,11 @@ impl From<std::sync::mpsc::RecvError> for TakerError {
 impl<T> From<std::sync::mpsc::SendError<T>> for TakerError {
     fn from(value: std::sync::mpsc::SendError<T>) -> Self {
         Self::MPSC(value.to_string())
+    }
+}
+
+impl From<ParseError> for TakerError {
+    fn from(value: ParseError) -> Self {
+        Self::AddressParseError(value)
     }
 }

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -328,13 +328,17 @@ impl Wallet {
         &mut self,
         amount: Amount,
         locktime: LockTime,
+        maker_address: Option<&[u8]>,
         feerate: f64,
     ) -> Result<u32, WalletError> {
         let (index, fidelity_addr, fidelity_pubkey) = self.get_next_fidelity_address(locktime)?;
 
         let coins = self.coin_select(amount, feerate)?;
-
-        let destination = Destination::Multi(vec![(fidelity_addr, amount)]);
+        let outputs = vec![(fidelity_addr, amount)];
+        let destination = Destination::Multi {
+            outputs,
+            op_return_data: maker_address.map(|addr| addr.to_vec().into_boxed_slice()),
+        };
 
         let tx = self.spend_coins(&coins, destination, feerate)?;
 

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -173,8 +173,11 @@ impl Wallet {
                     .collect::<Vec<_>>();
 
                 // Create destination with output - currently, destination is an array with a single address, i.e only a single transaction.
-                let destination =
-                    Destination::Multi(vec![(address.clone(), Amount::from_sat(output_value))]);
+                let outputs = vec![(address.clone(), Amount::from_sat(output_value))];
+                let destination = Destination::Multi {
+                    outputs,
+                    op_return_data: None,
+                };
 
                 // Creates and Signs Transactions via the spend_coins API
                 let funding_tx =

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -131,6 +131,7 @@ fn test_fidelity() {
                 Amount::from_sat(8000000),
                 LockTime::from_height((bitcoind.client.get_block_count().unwrap() as u32) + 950)
                     .unwrap(),
+                None,
                 DEFAULT_TX_FEE_RATE,
             )
             .unwrap();


### PR DESCRIPTION
This PR adds the maker's onion address into an OP_RETURN output of the fidelity bond.