### PR TITLE
Add derive macro for applying builder pattern on struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+coinswap_derive/target
 *.swp
 /docs/fidelity_bonds.md
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ flate2 = {version = "1.0.35", optional = true}
 tar = {version = "0.4.43", optional = true}
 minreq = { version = "2.12.0", features = ["https"] , optional = true}
 rust-coinselect = "0.1.2"
+coinswap-derive = { path = "coinswap_derive" }
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/coinswap_derive/Cargo.toml
+++ b/coinswap_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coinswap-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dev-dependencies]
+trybuild = { version = "1.0.104", features = ["diff"] }
+
+[dependencies]
+proc-macro2 = "1.0.95"
+quote = "1.0.40"
+syn = "2.0.101"

--- a/coinswap_derive/src/lib.rs
+++ b/coinswap_derive/src/lib.rs
@@ -1,0 +1,112 @@
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::quote;
+use syn::{
+    parse_macro_input, AngleBracketedGenericArguments, Data, DeriveInput, Fields, GenericArgument,
+    Path, PathArguments, PathSegment, Type, TypePath,
+};
+
+/// checks if type is optional
+// if type is optional return `Some(type)` else return `None`
+#[rustfmt::skip]
+fn ty_optional(ty: &Type) -> Option<&Ident> {
+    if let Type::Path(TypePath { path: Path { segments, .. }, ..}) = ty {
+        for PathSegment {ident, arguments} in segments {
+            if ident != "Option" { return None; }
+            if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. } ) = arguments {
+                for arg in args {
+                    if let GenericArgument::Type(Type::Path(TypePath { path: Path { segments, .. }, .. })) = arg {
+                        // TODO: build the entire path (e.x.,std::string::String)?
+                        return Some(&segments[segments.len() - 1].ident);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn create_methods(fields: &Fields) -> Vec<proc_macro2::TokenStream> {
+    fields
+        .into_iter()
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            if let Some(ident_ty) = ty_optional(ty) {
+                return quote! {
+                    pub(crate) fn #ident(&mut self, #ident: #ident_ty) -> &mut Self {
+                        // TODO: can we do better?
+                        self.#ident = Some(Some(#ident));
+                        self
+                    }
+                };
+            }
+            quote! {
+                pub(crate) fn #ident(&mut self, #ident: #ty) -> &mut Self {
+                    self.#ident = Some(#ident);
+                    self
+                }
+            }
+        })
+        .collect()
+}
+
+/// Derive macro generating boilerplate code involved in implementing the builder pattern.
+#[proc_macro_derive(ConfigBuilder)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let fields = if let Data::Struct(maker_config) = &input.data {
+        &maker_config.fields
+    } else {
+        unimplemented!()
+    };
+
+    let ident = input.ident;
+
+    let builder_ident = Ident::new(&format!("{}Builder", ident), ident.span());
+
+    let builder_methods = create_methods(fields);
+
+    let builder_fields = fields.into_iter().map(|f| {
+        let ident = &f.ident;
+        let ty = &f.ty;
+        quote! { #ident: std::option::Option<#ty> }
+    });
+
+    // fields inside final config struct.
+    let fields = fields.into_iter().map(|f| {
+        let ident = &f.ident;
+        let error = format!("{} is not set.", ident.clone().unwrap().to_string());
+        let ty = &f.ty;
+        if ty_optional(ty).is_some() {
+            quote! { #ident: self.#ident.clone().and_then(|value| value) }
+        } else {
+            quote! { #ident: self.#ident.clone().expect(#error) }
+        }
+    });
+
+    quote! {
+        // TODO: derive all macros that are derived on the original struct dynamically?
+        #[derive(Default)]
+        pub struct #builder_ident {
+            #(#builder_fields, )*
+        }
+        impl #builder_ident {
+            pub(crate) fn build(&mut self) -> std::io::Result<#ident> {
+                std::result::Result::Ok(
+                    #ident {
+                        #(#fields, )*
+                    }
+                )
+            }
+            #(#builder_methods)*
+        }
+        impl #ident {
+            pub(crate) fn builder() -> #builder_ident {
+                #builder_ident::default()
+            }
+        }
+    }
+    .into()
+}

--- a/coinswap_derive/tests/optional.rs
+++ b/coinswap_derive/tests/optional.rs
@@ -1,0 +1,39 @@
+use coinswap_derive::ConfigBuilder;
+
+#[derive(ConfigBuilder)]
+pub struct Config {
+    pub rpc_port: u16,
+    pub min_swap_amount: u64,
+    pub network_port: u16,
+    pub control_port: u16,
+    pub socks_port: u16,
+    pub tor_auth_password: String,
+    pub directory_server_address: Option<String>,
+}
+
+fn main() {
+    let config = Config::builder()
+        .rpc_port(6103)
+        .min_swap_amount(10_000)
+        .network_port(6102)
+        .control_port(9051)
+        .socks_port(9050)
+        .tor_auth_password("password".to_string())
+        .build()
+        .unwrap();
+    assert!(config.directory_server_address.is_none());
+
+    let config = Config::builder()
+        .rpc_port(6103)
+        .min_swap_amount(10_000)
+        .network_port(6102)
+        .control_port(9051)
+        .socks_port(9050)
+        .tor_auth_password("password".to_string())
+        .directory_server_address(
+            "kizqnaslcb2r3mbk2vm77bdff3madcvddntmaaz2htmkyuw7sgh4ddqd.onion:8080".to_string(),
+        )
+        .build()
+        .unwrap();
+    assert!(config.directory_server_address.is_some());
+}

--- a/coinswap_derive/tests/trybuild.rs
+++ b/coinswap_derive/tests/trybuild.rs
@@ -1,0 +1,5 @@
+#[test]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/optional.rs");
+}


### PR DESCRIPTION
This PR is a work in progress and introduces a derive macro to implement the builder pattern on structs. Some more work needs to be done so I am marking this as a draft.

## Implemented
- A basic derive macro that applies builder pattern to a struct.
- Optional builder methods.

## Todo
- Better error handling.
- field attributes like `#[builder(short = "...")]`.
- More tests.
- Refactor codebase to use the builder pattern.

The code isn't very clean right now, I'll definitely work on improving it.