### PR TITLE
Fix Taker Private Key Handover Exploit

### DIFF
--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -300,6 +300,8 @@ pub(crate) enum MakerToTakerMessage {
     ReqContractSigsAsRecvrAndSender(ContractSigsAsRecvrAndSender),
     /// Send Contract Sigs **for** the Receiver side of the hop. The Maker sending this message is the Sender of the hop.
     RespContractSigsForRecvr(ContractSigsForRecvr),
+    ///Send Ack message to taker,after receiving hashpreimage
+    AckPreimageRecieved,
     /// Send the multisig private keys of the swap, declaring completion of the contract.
     RespPrivKeyHandover(PrivKeyHandover),
 }
@@ -315,6 +317,9 @@ impl Display for MakerToTakerMessage {
             }
             Self::RespContractSigsForRecvr(_) => {
                 write!(f, "RespContractSigsForRecvr")
+            }
+            Self::AckPreimageRecieved => {
+                write!(f, "AckPreimageReceived")
             }
             Self::RespPrivKeyHandover(_) => write!(f, "RespPrivKeyHandover"),
         }


### PR DESCRIPTION
This pr is a work in progress on issue #468 

Implemented
---
- AckPreimageReceived Message
- Refactored Taker::routines,Taker::api

Todo
---
- Fixing settle_one_coinswap() (Taker::api Module)
- Refactoring Maker::Handlers
- Necessary nits,Integration Testing 


Will improve the code as I progress.