### PR TITLE
Wallet encryption mechanism using PBKDF2 + AES-GCM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ flate2 = {version = "1.0.35", optional = true}
 tar = {version = "0.4.43", optional = true}
 minreq = { version = "2.12.0", features = ["https"] }
 rust-coinselect = "0.1.2"
+pbkdf2 = { version = "0.12", features = ["simple"] }
+aes-gcm = "0.10.3"
+sha2 = "0.10.9"
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -274,17 +274,7 @@ impl Maker {
 
         rpc_config.wallet_name = wallet_file_name;
 
-        let mut wallet = if wallet_path.exists() {
-            // wallet already exists, load the wallet
-            let wallet = Wallet::load(&wallet_path, &rpc_config)?;
-            log::info!("Wallet file at {wallet_path:?} successfully loaded.");
-            wallet
-        } else {
-            // wallet doesn't exist at the given path, create a new one
-            let wallet = Wallet::init(&wallet_path, &rpc_config)?;
-            log::info!("New Wallet created at : {wallet_path:?}");
-            wallet
-        };
+        let mut wallet = Wallet::load_or_init_wallet(&wallet_path, &rpc_config)?;
 
         // If the config file doesn't exist, the default config will be loaded.
         let mut config = MakerConfig::new(Some(&data_dir.join("config.toml")))?;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -216,17 +216,7 @@ impl Taker {
         let mut rpc_config = rpc_config.unwrap_or_default();
         rpc_config.wallet_name = wallet_file_name;
 
-        let mut wallet = if wallet_path.exists() {
-            // wallet already exists , load the wallet
-            let wallet = Wallet::load(&wallet_path, &rpc_config)?;
-            log::info!("Wallet file at {wallet_path:?} successfully loaded.");
-            wallet
-        } else {
-            // wallet doesn't exists at the given path , create a new one
-            let wallet = Wallet::init(&wallet_path, &rpc_config)?;
-            log::info!("New Wallet created at : {wallet_path:?}");
-            wallet
-        };
+        let mut wallet = Wallet::load_or_init_wallet(&wallet_path, &rpc_config)?;
 
         // If config file doesn't exist, default config will be loaded.
         let mut config = TakerConfig::new(Some(&data_dir.join("config.toml")))?;

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -7,6 +7,11 @@ use std::{convert::TryFrom, fmt::Display, path::PathBuf, str::FromStr};
 
 use std::collections::HashMap;
 
+use aes_gcm::{
+    aead::{AeadCore, OsRng},
+    Aes256Gcm,
+};
+
 use bip39::Mnemonic;
 use bitcoin::{
     bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
@@ -17,11 +22,14 @@ use bitcoin::{
     Address, Amount, OutPoint, PublicKey, Script, ScriptBuf, Transaction, Txid, VarInt, Weight,
 };
 use bitcoind::bitcoincore_rpc::{bitcoincore_rpc_json::ListUnspentResultEntry, Client, RpcApi};
+use pbkdf2::pbkdf2_hmac_array;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::path::Path;
 
 use crate::{
     protocol::contract,
+    utill,
     utill::{
         compute_checksum, generate_keypair, get_hd_path_from_descriptor,
         redeemscript_to_scriptpubkey,
@@ -47,12 +55,44 @@ use super::{
 
 const HARDENDED_DERIVATION: &str = "m/84'/1'/0'";
 
+/// Salt used for key derivation from a user-provided passphrase.
+const PBKDF2_SALT: &[u8; 8] = b"coinswap";
+/// Number of PBKDF2 iterations to strengthen passphrase-derived keys.
+///
+/// In production, this is set to **600,000 iterations**, following
+/// modern password security guidance from the
+/// [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+///
+/// During testing or integration tests, the iteration count is reduced to 1
+/// for performance.
+const PBKDF2_ITERATIONS: u32 = if cfg!(feature = "integration-test") || cfg!(test) {
+    1
+} else {
+    600_000
+};
+
+/// Holds derived cryptographic key material used for encrypting and decrypting wallet data.
+#[derive(Debug, Clone)]
+pub struct KeyMaterial {
+    /// A 256-bit key derived from the user’s passphrase via PBKDF2.
+    /// This key is used with AES-GCM for encryption/decryption.
+    pub key: [u8; 32],
+    /// Nonce used for AES-GCM encryption, generated when a new wallet is created.
+    /// When loading an existing wallet, this is initially `None`.
+    /// It is populated after reading the stored nonce from disk.
+    pub nonce: Option<Vec<u8>>,
+}
+
 /// Represents a Bitcoin wallet with associated functionality and data.
 #[derive(Debug)]
 pub struct Wallet {
     pub(crate) rpc: Client,
     wallet_file_path: PathBuf,
     pub(crate) store: WalletStore,
+    /// Optional encryption material derived from the user’s passphrase.
+    /// If present, wallet data will be encrypted/decrypted using AES-GCM.
+    /// The original passphrase is never stored—only the derived key is kept in memory.
+    store_enc_material: Option<KeyMaterial>,
 }
 
 /// Specify the keychain derivation path from [`HARDENDED_DERIVATION`]
@@ -210,7 +250,11 @@ impl Wallet {
     ///
     /// The path should include the full path for a wallet file.
     /// If the wallet file doesn't exist it will create a new wallet file.
-    pub fn init(path: &Path, rpc_config: &RPCConfig) -> Result<Self, WalletError> {
+    pub fn init(
+        path: &Path,
+        rpc_config: &RPCConfig,
+        store_enc_material: Option<KeyMaterial>,
+    ) -> Result<Self, WalletError> {
         let rpc = Client::try_from(rpc_config)?;
         let network = rpc.get_blockchain_info()?.chain;
 
@@ -238,13 +282,20 @@ impl Wallet {
             rpc,
             wallet_file_path: path.to_path_buf(),
             store,
+            store_enc_material,
         })
     }
 
     /// Load wallet data from file and connect to a core RPC.
     /// The core rpc wallet name, and wallet_id field in the file should match.
-    pub(crate) fn load(path: &Path, rpc_config: &RPCConfig) -> Result<Wallet, WalletError> {
-        let store = WalletStore::read_from_disk(path)?;
+    /// If encryption material is provided, decrypt the wallet store using it.
+    pub(crate) fn load(
+        path: &Path,
+        rpc_config: &RPCConfig,
+        store_enc_material: &Option<KeyMaterial>,
+    ) -> Result<Wallet, WalletError> {
+        let (store, nonce) = WalletStore::read_from_disk(path, store_enc_material)?;
+
         if rpc_config.wallet_name != store.file_name {
             return Err(WalletError::General(format!(
                 "Wallet name of database file and core mismatch, expected {}, found {}",
@@ -271,11 +322,83 @@ impl Wallet {
             store.outgoing_swapcoins.len()
         );
 
+        // The input `store_enc_material` has a key but no nonce before reading from disk.
+        // After reading, combine the key with the stored nonce to create a complete KeyMaterial
+        // used for subsequent encryption/decryption operations.
+        let updated_enc_material = match (store_enc_material, nonce) {
+            (Some(material), Some(nonce)) => Some(KeyMaterial {
+                key: material.key,
+                nonce: Some(nonce),
+            }),
+            _ => None,
+        };
+
         Ok(Self {
             rpc,
             wallet_file_path: path.to_path_buf(),
             store,
+            store_enc_material: updated_enc_material,
         })
+    }
+
+    /// Loads an existing wallet from the given path or initializes a new one if none exists.
+    ///
+    /// Prompts the user for an encryption passphrase (unless running tests),
+    /// derives encryption key material if a passphrase is provided,
+    /// and either loads or creates the wallet accordingly.
+    pub(crate) fn load_or_init_wallet(
+        path: &Path,
+        rpc_config: &RPCConfig,
+    ) -> Result<Wallet, WalletError> {
+        // For tests or integration tests, use a fixed password. Otherwise prompt user.
+        let wallet_enc_password = if cfg!(feature = "integration-test") || cfg!(test) {
+            "integration-test".to_string()
+        } else {
+            utill::prompt_password(
+                "Enter wallet encryption passphrase (empty for no encryption): ",
+            )?
+        };
+
+        // If user entered empty password, no encryption key material is created.
+        let key = if wallet_enc_password.is_empty() {
+            None
+        } else {
+            // Derive a 256-bit encryption key from the passphrase using PBKDF2.
+            let derived_key = pbkdf2_hmac_array::<Sha256, 32>(
+                wallet_enc_password.as_bytes(),
+                PBKDF2_SALT,
+                PBKDF2_ITERATIONS,
+            );
+            // Generate a nonce only if creating a new wallet, else defer nonce reading.
+            let nonce = if path.exists() {
+                //Will be filled after loading, by the Wallet::load method
+                None
+            } else {
+                // Generate a fresh nonce for encrypting a new wallet.
+                let generated_nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+                Some(generated_nonce.as_slice().to_vec())
+            };
+
+            Some(KeyMaterial {
+                key: derived_key,
+                nonce,
+            })
+        };
+
+        let wallet = if path.exists() {
+            // wallet already exists, load the wallet
+            let wallet = Wallet::load(path, rpc_config, &key)?;
+            log::info!("Wallet file at {path:?} successfully loaded.");
+            wallet
+        } else {
+            // wallet doesn't exists at the given path, create a new one
+            let wallet = Wallet::init(path, rpc_config, key)?;
+
+            log::info!("New Wallet created at : {path:?}");
+            wallet
+        };
+
+        Ok(wallet)
     }
 
     /// Update external index and saves to disk.
@@ -289,7 +412,8 @@ impl Wallet {
 
     /// Update the existing file. Error if path does not exist.
     pub(crate) fn save_to_disk(&self) -> Result<(), WalletError> {
-        self.store.write_to_disk(&self.wallet_file_path)
+        self.store
+            .write_to_disk(&self.wallet_file_path, &self.store_enc_material)
     }
 
     /// Finds an incoming swap coin with the specified multisig redeem script.

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -2,6 +2,12 @@
 //!
 //! Wallet data is currently written in unencrypted CBOR files which are not directly human readable.
 
+use super::{api::KeyMaterial, error::WalletError, fidelity::FidelityBond};
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm,
+    Key, // Or `Aes128Gcm`
+};
 use bitcoin::{bip32::Xpriv, Network, OutPoint, ScriptBuf};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -11,11 +17,29 @@ use std::{
     path::Path,
 };
 
-use super::{error::WalletError, fidelity::FidelityBond};
-
 use super::swapcoin::{IncomingSwapCoin, OutgoingSwapCoin};
-use crate::wallet::UTXOSpendInfo;
+use crate::{utill, wallet::UTXOSpendInfo};
 use bitcoind::bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry;
+
+/// Wrapper struct for storing an encrypted wallet on disk.
+///
+/// The standard `WalletStore` is first serialized to CBOR, then encrypted using
+/// [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode).
+///
+/// The resulting ciphertext is stored in `encrypted_wallet_store`, and the AES-GCM
+/// nonce used for encryption is stored in `nonce`.
+///
+/// Note: The term “IV” (Initialization Vector) used in AES-GCM — including in the linked Wikipedia page —
+/// refers to the same value as the nonce. They are conceptually the same in this context.
+///
+/// This wrapper itself is then serialized to CBOR and written to disk.
+#[derive(Serialize, Deserialize, Debug)]
+struct EncryptedWalletStore {
+    /// Nonce used for AES-GCM encryption (must match during decryption).
+    nonce: Vec<u8>,
+    /// AES-GCM-encrypted CBOR-serialized `WalletStore` data.
+    encrypted_wallet_store: Vec<u8>,
+}
 
 /// Represents the internal data store for a Bitcoin wallet.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -82,35 +106,94 @@ impl WalletStore {
     }
 
     /// Load existing file, updates it, writes it back (errors if path doesn't exist).
-    pub(crate) fn write_to_disk(&self, path: &Path) -> Result<(), WalletError> {
+    pub(crate) fn write_to_disk(
+        &self,
+        path: &Path,
+        store_enc_material: &Option<KeyMaterial>,
+    ) -> Result<(), WalletError> {
         let wallet_file = fs::OpenOptions::new().write(true).open(path)?;
         let writer = BufWriter::new(wallet_file);
-        Ok(serde_cbor::to_writer(writer, &self)?)
+
+        match store_enc_material {
+            Some(material) => {
+                // Encryption branch: encrypt the serialized wallet before writing.
+
+                // Serialize wallet data to bytes.
+                let packed_store = serde_cbor::ser::to_vec(&self)?;
+
+                // Extract nonce and key for AES-GCM.
+                let material_nonce = material.nonce.as_ref().unwrap();
+                let nonce = aes_gcm::Nonce::from_slice(material_nonce);
+                let key = Key::<Aes256Gcm>::from_slice(&material.key);
+
+                // Create AES-GCM cipher instance.
+                let cipher = Aes256Gcm::new(key);
+
+                // Encrypt the serialized wallet bytes.
+                let ciphertext = cipher.encrypt(nonce, packed_store.as_ref()).unwrap();
+
+                // Package encrypted data with nonce for storage.
+                let encrypted = EncryptedWalletStore {
+                    nonce: material_nonce.clone(),
+                    encrypted_wallet_store: ciphertext,
+                };
+
+                // Write encrypted wallet data to disk.
+                serde_cbor::to_writer(writer, &encrypted)?;
+            }
+            None => {
+                // No encryption: serialize and write the wallet directly.
+                serde_cbor::to_writer(writer, &self)?;
+            }
+        }
+        Ok(())
     }
 
     /// Reads from a path (errors if path doesn't exist).
-    pub(crate) fn read_from_disk(path: &Path) -> Result<Self, WalletError> {
-        let mut reader = read(path)?;
-        let store = match serde_cbor::from_slice::<Self>(&reader) {
-            Ok(store) => store,
-            Err(e) => {
-                let err_string = format!("{e:?}");
-                if err_string.contains("code: TrailingData") {
-                    // Defensive error handling - monitor logs to confirm wallet files stay clean.
-                    log::info!("Wallet file has trailing data, trying to restore");
-                    loop {
-                        reader.pop();
-                        match serde_cbor::from_slice::<Self>(&reader) {
-                            Ok(store) => break store,
-                            Err(_) => continue,
-                        }
-                    }
-                } else {
-                    return Err(e.into());
-                }
+    /// If `store_enc_material` is provided, attempts to decrypt the file using the
+    /// provided key. Returns the deserialized `WalletStore` and the nonce.
+    pub(crate) fn read_from_disk(
+        path: &Path,
+        store_enc_material: &Option<KeyMaterial>,
+    ) -> Result<(Self, Option<Vec<u8>>), WalletError> {
+        let reader = read(path)?;
+
+        match store_enc_material {
+            Some(material) => {
+                log::info!("Reading encrypted wallet");
+
+                // Deserialize the outer EncryptedWalletStore wrapper.
+                let encrypted_wallet: EncryptedWalletStore = utill::deserialize_from_cbor::<
+                    EncryptedWalletStore,
+                    WalletError,
+                >(reader.clone())?;
+
+                let nonce_vec = encrypted_wallet.nonce.clone();
+
+                // Reconstruct AES-GCM cipher from the provided key and stored nonce.
+                let key = Key::<Aes256Gcm>::from_slice(&material.key);
+                let cipher = Aes256Gcm::new(key);
+                let nonce = aes_gcm::Nonce::from_slice(&nonce_vec);
+
+                // Decrypt the inner WalletStore CBOR bytes.
+                let packed_wallet_store = cipher
+                    .decrypt(nonce, encrypted_wallet.encrypted_wallet_store.as_ref())
+                    .expect("Error decrypting wallet, wrong passphrase?");
+
+                // Deserialize the decrypted WalletStore and return it with the nonce.
+                Ok((
+                    utill::deserialize_from_cbor::<Self, WalletError>(packed_wallet_store)?,
+                    Some(nonce_vec.clone()),
+                ))
             }
-        };
-        Ok(store)
+            None => {
+                // If no encryption key is provided, deserialize the WalletStore directly.
+                Ok((
+                    utill::deserialize_from_cbor::<Self, WalletError>(reader)?,
+                    None,
+                ))
+            }
+        }
     }
 }
 
@@ -139,9 +222,11 @@ mod tests {
         )
         .unwrap();
 
-        original_wallet_store.write_to_disk(&file_path).unwrap();
+        original_wallet_store
+            .write_to_disk(&file_path, &None)
+            .unwrap();
 
-        let read_wallet = WalletStore::read_from_disk(&file_path).unwrap();
+        let (read_wallet, _nonce) = WalletStore::read_from_disk(&file_path, &None).unwrap();
         assert_eq!(original_wallet_store, read_wallet);
     }
 }


### PR DESCRIPTION
# Wallet encryption mechanism using PBKDF2 + AES-GCM

This PR introduces optional passphrase-based encryption for wallet storage using PBKDF2 key derivation and AES-GCM encryption.

When running either the maker or taker, users are prompted for a password. If an empty password is entered, the wallet behaves as before (unencrypted). Otherwise, the wallet is encrypted using the provided passphrase.

## Key Changes

### Encryption Support
- Introduced `KeyMaterial` struct for derived encryption key and nonce.
- Added `pbkdf2`, `aes-gcm`, and `sha2` crates for password-based encryption.
- New `prompt_password` function in `utill.rs` for securely reading passwords from the terminal.
  - This implementation requires unsafe Rust due to direct terminal handling.
  - Safe wrappers like [`rpassword`](https://docs.rs/rpassword) exist, but they have not been included to avoid adding another external dependencies.

### Wallet Logic Enhancements
- New `Wallet::load_or_init_wallet` function to handle passphrase prompting and decision logic between loading and initializing a wallet.
- Modified `Wallet::load` and `Wallet::init` to accept `KeyMaterial`.
- Added encryption-aware read/write logic to `WalletStore`.

### File Format Changes
- Encrypted wallets are stored as `EncryptedWalletStore` CBOR blobs when a passphrase is provided.
- Retains full support for decrypting and loading legacy unencrypted wallet files.
  - **Note:** In the future, it might be preferable to serialize the wallet in another format, such as JSON instead of CBOR. 
    - This would avoid the trailing data problem encountered with CBOR and improve human readability.
    - However, switching to another format would be a breaking change.

### Code Cleanup
- Removed duplicate wallet creation/loading logic from `maker/api.rs` and `taker/api.rs`.
- Unified logic under the new `load_or_init_wallet` method.

### Testing
- Updated tests in `wallet/storage.rs` to use the new encrypted wallet read/write APIs.
- All tests, including integration tests, run successfully.
- During test runs, wallets are always encrypted using `"integration-test"` as the passphrase.