### PR TITLE
trailing data handling

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -270,7 +270,7 @@ impl Taker {
             let empty_book = OfferBook::default();
             let file = std::fs::File::create(&offerbook_path)?;
             let writer = BufWriter::new(file);
-            serde_cbor::to_writer(writer, &empty_book)?;
+            serde_json::to_writer_pretty(writer, &empty_book)?;
             empty_book
         };
 

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -146,29 +146,8 @@ impl OfferBook {
 
     /// Reads from a path (errors if path doesn't exist).
     pub fn read_from_disk(path: &Path) -> Result<Self, TakerError> {
-        //let wallet_file = File::open(path)?;
-        let mut reader = std::fs::read_to_string(path)?;
-        let book = match serde_json::from_str(&reader) {
-            Ok(book) => book,
-            Err(e) => {
-                let err_string = format!("{e:?}");
-                // TODO: Investigate why files end up with trailing data.
-                // Check if this still happens for json file.
-                if err_string.contains("code: TrailingData") {
-                    // loop until all trailing bytes are removed.
-                    loop {
-                        reader.pop();
-                        match serde_json::from_slice::<Self>(reader.as_bytes()) {
-                            Ok(book) => break book,
-                            Err(_) => continue,
-                        }
-                    }
-                } else {
-                    return Err(e.into());
-                }
-            }
-        };
-        Ok(book)
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
     }
 }
 

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -90,32 +90,8 @@ impl WalletStore {
 
     /// Reads from a path (errors if path doesn't exist).
     pub(crate) fn read_from_disk(path: &Path) -> Result<Self, WalletError> {
-        //let wallet_file = File::open(path)?;
-        let mut reader = read(path)?;
-        let store = match serde_cbor::from_slice::<Self>(&reader) {
-            Ok(store) => store,
-            Err(e) => {
-                let err_string = format!("{e:?}");
-                if err_string.contains("code: TrailingData") {
-                    // TODO: Investigate why files end up with trailing data.
-                    // add a log for the length of trailing data.
-                    // run the apps many times and see what the average length if for this data is.
-                    // Log the trailing data.
-                    log::info!("Wallet file has trailing data, trying to restore");
-                    loop {
-                        // pop the last byte and try again.
-                        reader.pop();
-                        match serde_cbor::from_slice::<Self>(&reader) {
-                            Ok(store) => break store,
-                            Err(_) => continue,
-                        }
-                    }
-                } else {
-                    return Err(e.into());
-                }
-            }
-        };
-        Ok(store)
+        let reader = read(path)?;
+        Ok(serde_cbor::from_slice(&reader)?)
     }
 }
 


### PR DESCRIPTION
Fixes trailing data parsing errors : 
   - OfferBook was writing CBOR, changing it to JSON fixes the trailing data 
   - Tested the wallet files multiple times with custom log, got `CBOR parsing successful - no trailing data` with `wallet file size: 1157 bytes` , so we could remove the error handling