### PR TITLE
move is_spent boolean into FidelityBond struct (builds on #472)

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -358,7 +358,7 @@ impl Maker {
                 .store
                 .fidelity_bond
                 .iter()
-                .filter_map(|(i, (bond, _))| {
+                .filter_map(|(i, bond)| {
                     if bond.conf_height.is_none() && bond.cert_expiry.is_none() {
                         let conf_height = wallet_read
                             .wait_for_fidelity_tx_confirmation(bond.outpoint.txid)

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -179,7 +179,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
 
     if let Some(i) = highest_index {
         let wallet_read = maker.get_wallet().read()?;
-        let (bond, _) = wallet_read.store.fidelity_bond.get(&i).unwrap();
+        let bond = wallet_read.store.fidelity_bond.get(&i).unwrap();
 
         let current_height = wallet_read
             .rpc

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -555,7 +555,7 @@ impl Wallet {
 
     /// Checks if a UTXO belongs to fidelity bonds, and then returns corresponding UTXOSpendInfo
     fn check_if_fidelity(&self, utxo: &ListUnspentResultEntry) -> Option<UTXOSpendInfo> {
-        self.store.fidelity_bond.iter().find_map(|(i, (bond, _))| {
+        self.store.fidelity_bond.iter().find_map(|(i, bond)| {
             if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
                 Some(UTXOSpendInfo::FidelityBondCoin {
                     index: *i,
@@ -1456,7 +1456,7 @@ impl Wallet {
             self.store
                 .fidelity_bond
                 .values()
-                .map(|(bond, _)| {
+                .map(|bond| {
                     let descriptor_without_checksum = format!("raw({:x})", bond.script_pub_key());
                     Ok(format!(
                         "{}#{}",

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -125,6 +125,8 @@ pub struct FidelityBond {
     pub(crate) conf_height: Option<u32>,
     // Cert expiry denoted in multiple of difficulty adjustment period (2016 blocks)
     pub(crate) cert_expiry: Option<u32>,
+    // Txid of Transaction which redeemed the bond
+    pub redeem_tx: Option<Txid>,
 }
 
 impl FidelityBond {
@@ -164,7 +166,7 @@ impl FidelityBond {
 // Wallet APIs related to fidelity bonds.
 impl Wallet {
     /// Get a reference to the fidelity bond store
-    pub fn get_fidelity_bonds(&self) -> &HashMap<u32, (FidelityBond, bool)> {
+    pub fn get_fidelity_bonds(&self) -> &HashMap<u32, FidelityBond> {
         &self.store.fidelity_bond
     }
 
@@ -174,15 +176,16 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
-            .map(|(index, (bond, redeemed))| {
+            .map(|(index, bond)| {
+                let redeemed = bond.redeem_tx.is_some();
                 let mut bond_info = serde_json::json!({
                         "index": index,
                         "outpoint": bond.outpoint.to_string(),
                         "amount": bond.amount.to_sat(),
-                        "status": if *redeemed {"Redeemed"} else {"Live"}
+                        "status": if redeemed {"Redeemed"} else {"Live"}
                 });
 
-                if !*redeemed {
+                if !redeemed {
                     let bond_value = self
                         .calculate_bond_value(bond)
                         .expect("Bond value calculation must not fail for valid bonds.");
@@ -202,7 +205,8 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
-            .filter_map(|(i, (bond, expired))| {
+            .filter_map(|(i, bond)| {
+                let expired = bond.redeem_tx.is_some();
                 if !expired {
                     match self.calculate_bond_value(bond) {
                         Ok(v) => {
@@ -239,7 +243,7 @@ impl Wallet {
 
     /// Derives the fidelity redeemscript from bond values at a given index.
     pub(crate) fn get_fidelity_reedemscript(&self, index: u32) -> Result<ScriptBuf, WalletError> {
-        let (bond, _) = self
+        let bond = self
             .store
             .fidelity_bond
             .get(&index)
@@ -350,8 +354,9 @@ impl Wallet {
                 // `Conf_height` & `cert_expiry` are considered None as they can't be known before the confirmation.
                 conf_height: None,
                 cert_expiry: None,
+                redeem_tx: None,
             };
-            self.store.fidelity_bond.insert(index, (bond, false));
+            self.store.fidelity_bond.insert(index, bond);
             self.save_to_disk()?;
         }
 
@@ -393,7 +398,7 @@ impl Wallet {
         conf_height: u32,
     ) -> Result<(), WalletError> {
         let cert_expiry = FidelityBond::get_fidelity_expiry(conf_height);
-        let (bond, _) = self
+        let bond = self
             .store
             .fidelity_bond
             .get_mut(&index)
@@ -415,7 +420,8 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
-            .filter_map(|(&i, (bond, redeemed))| {
+            .filter_map(|(&i, bond)| {
+                let redeemed = bond.redeem_tx.is_some();
                 if !redeemed && curr_height > bond.lock_time.to_consensus_u32() {
                     Some(i)
                 } else {
@@ -437,13 +443,13 @@ impl Wallet {
         maker_addr: &str,
     ) -> Result<FidelityProof, WalletError> {
         // Generate a fidelity bond proof from the fidelity data.
-        let (bond, redeemed) = self
+        let bond = self
             .store
             .fidelity_bond
             .get(&index)
             .ok_or(FidelityError::BondDoesNotExist)?;
-
-        if *redeemed {
+        let redeemed = bond.redeem_tx.is_some();
+        if redeemed {
             return Err(FidelityError::BondAlreadyRedeemed.into());
         }
 

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -5,8 +5,8 @@
 //! parsing mechanisms for transaction inputs and outputs.
 
 use bitcoin::{
-    absolute::LockTime, transaction::Version, Address, Amount, OutPoint, ScriptBuf, Sequence,
-    Transaction, TxIn, TxOut, Witness,
+    absolute::LockTime, hashes::Hash, transaction::Version, Address, Amount, OutPoint, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RawTx, RpcApi};
 
@@ -71,13 +71,13 @@ impl Wallet {
     /// This function creates a spending transaction from the fidelity bond, signs and broadcasts it.
     /// Returns the txid of the spending tx, and mark the bond as spent.
     pub fn redeem_fidelity(&mut self, idx: u32, feerate: f64) -> Result<(), WalletError> {
-        let (bond, redeemed) = self
+        let bond = self
             .store
             .fidelity_bond
             .get(&idx)
             .ok_or(FidelityError::BondDoesNotExist)?;
-
-        if *redeemed {
+        let redeemed = bond.redeem_tx.is_some();
+        if redeemed {
             log::info!("Fidelity bond already spent.");
             return Ok(());
         }
@@ -104,12 +104,13 @@ impl Wallet {
                 // As a temporary fix, we mark the bond as redeemed and exit gracefully.
                 log::info!("Fidelity bond already spent.");
 
-                let (_, redeemed) = self
+                let bond = self
                     .store
                     .fidelity_bond
                     .get_mut(&idx)
                     .ok_or(FidelityError::BondDoesNotExist)?;
-                *redeemed = true;
+                let dummy_txid = Txid::from_slice(&[0u8; 32]).unwrap();
+                bond.redeem_tx = Some(dummy_txid);
 
                 return Ok(());
             }
@@ -137,13 +138,13 @@ impl Wallet {
 
         // mark is_spent
         {
-            let (_, redeemed) = self
+            let bond = self
                 .store
                 .fidelity_bond
                 .get_mut(&idx)
                 .ok_or(FidelityError::BondDoesNotExist)?;
 
-            *redeemed = true;
+            bond.redeem_tx = Some(txid);
         }
 
         Ok(())
@@ -247,13 +248,13 @@ impl Wallet {
                     total_input_value += utxo_data.amount;
                 }
                 UTXOSpendInfo::FidelityBondCoin { index, input_value } => {
-                    let (bond, redeemed) = self
+                    let bond = self
                         .store
                         .fidelity_bond
                         .get(index)
                         .ok_or(FidelityError::BondDoesNotExist)?;
-
-                    if *redeemed {
+                    let redeemed = bond.redeem_tx.is_some();
+                    if redeemed {
                         return Err(FidelityError::BondAlreadyRedeemed.into());
                     }
 

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -36,7 +36,7 @@ pub(crate) struct WalletStore {
     pub(super) outgoing_swapcoins: HashMap<ScriptBuf, OutgoingSwapCoin>,
     /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
-    /// Map for all the fidelity bond information. (index, (Bond, redeemed)).
+    /// Map for all the fidelity bond information.
     pub(crate) fidelity_bond: HashMap<u32, FidelityBond>,
     pub(super) last_synced_height: Option<u64>,
 

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -37,7 +37,7 @@ pub(crate) struct WalletStore {
     /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
     /// Map for all the fidelity bond information. (index, (Bond, redeemed)).
-    pub(crate) fidelity_bond: HashMap<u32, (FidelityBond, bool)>,
+    pub(crate) fidelity_bond: HashMap<u32, FidelityBond>,
     pub(super) last_synced_height: Option<u64>,
 
     pub(super) wallet_birthday: Option<u64>,

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -115,18 +115,18 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, 0);
 
-        let (bond, _) = wallet_read
+        let bond = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
         let bond_value = wallet_read.calculate_bond_value(bond).unwrap();
         assert_eq!(bond_value, Amount::from_sat(10814));
 
-        let (bond, redeemed) = wallet_read
+        let bond = wallet_read
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
-
+        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(5000000));
         assert!(!redeemed);
 
@@ -164,7 +164,12 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, index);
 
-        let (bond, redeemed) = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        // TODO: Figure out why this sporadically fails.
+        //let bond_value = wallet_read.calculate_bond_value(index).unwrap();
+        // assert_eq!(bond_value, Amount::from_sat(1474));
+
+        let bond = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(8000000));
         assert!(!redeemed);
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -126,10 +126,8 @@ fn test_fidelity() {
             .get_fidelity_bonds()
             .get(&highest_bond_index)
             .unwrap();
-        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(5000000));
-        assert!(!redeemed);
-
+        assert!(!bond.is_spent());
         // Log the bond details for debugging
         log::info!(
             "📊 First bond created - Amount: {}, Value: {}, Maturity Height: {}",
@@ -164,14 +162,9 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, index);
 
-        // TODO: Figure out why this sporadically fails.
-        //let bond_value = wallet_read.calculate_bond_value(index).unwrap();
-        // assert_eq!(bond_value, Amount::from_sat(1474));
-
         let bond = wallet_read.get_fidelity_bonds().get(&index).unwrap();
-        let redeemed = bond.redeem_tx.is_some();
         assert_eq!(bond.amount, Amount::from_sat(8000000));
-        assert!(!redeemed);
+        (assert!(!bond.is_spent()));
 
         bond.lock_time.to_consensus_u32()
     };


### PR DESCRIPTION
Move redemption tracking from (FidelityBond, bool) tuple to FidelityBond.is_spent field