### PR TITLE
P2p offloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 Cargo.lock
 .vscode
 .idea
+.ra-target
 bin
 /coverage/reports

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ default = []
 # The following feature set is in response to the issue described at https://github.com/rust-lang/rust/issues/45599
 # Only used for running the integration tests
 integration-test = ['dep:flate2','dep:tar']
+tracker = []

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -201,10 +201,11 @@ fn main() -> Result<(), TakerError> {
                 .get_wallet_mut()
                 .coin_select(amount, feerate.unwrap_or(DEFAULT_TX_FEE_RATE))?;
 
-            let destination = Destination::Multi(vec![(
-                Address::from_str(&address).unwrap().assume_checked(),
-                amount,
-            )]);
+            let outputs = vec![(Address::from_str(&address)?.assume_checked(), amount)];
+            let destination = Destination::Multi {
+                outputs,
+                op_return_data: None,
+            };
 
             let tx = taker.get_wallet_mut().spend_from_wallet(
                 feerate.unwrap_or(DEFAULT_TX_FEE_RATE),

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -77,10 +77,14 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
             feerate,
         } => {
             let amount = Amount::from_sat(amount);
-            let destination = Destination::Multi(vec![(
+            let outputs = vec![(
                 Address::from_str(&address).unwrap().assume_checked(),
                 amount,
-            )]);
+            )];
+            let destination = Destination::Multi {
+                outputs,
+                op_return_data: None,
+            };
 
             let coins_to_send = maker.get_wallet().read()?.coin_select(amount, feerate)?;
             let tx = maker.get_wallet().write()?.spend_from_wallet(

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -236,11 +236,12 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
             // sync the wallet
             maker.get_wallet().write()?.sync_no_fail();
 
-            let fidelity_result =
-                maker
-                    .get_wallet()
-                    .write()?
-                    .create_fidelity(amount, locktime, DEFAULT_TX_FEE_RATE);
+            let fidelity_result = maker.get_wallet().write()?.create_fidelity(
+                amount,
+                locktime,
+                Some(maker_address.as_bytes()),
+                DEFAULT_TX_FEE_RATE,
+            );
 
             match fidelity_result {
                 // Wait for sufficient funds to create fidelity bond.

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -373,8 +373,9 @@ pub enum DnsRequest {
 }
 
 /// Tracker response
+#[cfg(feature = "tracker")]
 #[derive(Serialize, Deserialize, Debug)]
-pub enum TrackerResponse {
+pub(crate) enum TrackerResponse {
     /// Address response
     Address {
         /// Address response
@@ -387,10 +388,10 @@ pub enum TrackerResponse {
 /// Enum representing DNS request message types.
 ///
 /// These requests and responses are structured using Serde for serialization and deserialization.
-
+#[cfg(feature = "tracker")]
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum TrackerRequest {
+pub(crate) enum TrackerRequest {
     /// A request sent by the maker to register itself with the DNS server and authenticate.
     Post {
         /// Metadata containing the maker's URL and fidelity proof.
@@ -408,9 +409,10 @@ pub enum TrackerRequest {
 /// unified message as maker server can receive any
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
-pub enum MessageToMaker {
+pub(crate) enum MessageToMaker {
     /// taker to maker variant
     TakerToMaker(TakerToMakerMessage),
+    #[cfg(feature = "tracker")]
     /// tracker request variant
-    TrackerRequest(TrackerRequest),
+    TrackerRequest(TrackerResponse),
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -372,7 +372,6 @@ pub enum DnsRequest {
     },
 }
 
-#[cfg(feature = "tracker")]
 /// Tracker response
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TrackerResponse {
@@ -388,7 +387,7 @@ pub enum TrackerResponse {
 /// Enum representing DNS request message types.
 ///
 /// These requests and responses are structured using Serde for serialization and deserialization.
-#[cfg(feature = "tracker")]
+
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum TrackerRequest {
@@ -404,4 +403,14 @@ pub enum TrackerRequest {
         /// address
         address: String,
     },
+}
+
+/// unified message as maker server can receive any
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload")]
+pub enum MessageToMaker {
+    /// taker to maker variant
+    TakerToMaker(TakerToMakerMessage),
+    /// tracker request variant
+    TrackerRequest(TrackerRequest),
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -371,3 +371,37 @@ pub enum DnsRequest {
         vout: u32,
     },
 }
+
+#[cfg(feature = "tracker")]
+/// Tracker response
+#[derive(Serialize, Deserialize, Debug)]
+pub enum TrackerResponse {
+    /// Address response
+    Address {
+        /// Address response
+        addresses: Vec<String>,
+    },
+    /// Ping response
+    Ping,
+}
+
+/// Enum representing DNS request message types.
+///
+/// These requests and responses are structured using Serde for serialization and deserialization.
+#[cfg(feature = "tracker")]
+#[derive(Serialize, Deserialize, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum TrackerRequest {
+    /// A request sent by the maker to register itself with the DNS server and authenticate.
+    Post {
+        /// Metadata containing the maker's URL and fidelity proof.
+        metadata: DnsMetadata,
+    },
+    /// A request sent by the taker to fetch all valid maker addresses from the DNS server.
+    Get,
+    /// To gauge server activity
+    Pong {
+        /// address
+        address: String,
+    },
+}

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -33,7 +33,7 @@ use bitcoin::{
 
 use super::{
     error::TakerError,
-    offers::{fetch_addresses_from_dns, fetch_offer_from_makers, MakerAddress, OfferAndAddress},
+    offers::{fetch_offer_from_makers, MakerAddress, OfferAndAddress},
     routines::*,
 };
 use crate::{
@@ -53,6 +53,12 @@ use crate::{
         WalletSwapCoin, WatchOnlySwapCoin,
     },
 };
+
+#[cfg(not(feature = "tracker"))]
+use crate::taker::offers::fetch_addresses_from_dns;
+
+#[cfg(feature = "tracker")]
+use crate::taker::offers::fetch_addresses_from_tracker;
 
 // Default values for Taker configurations
 pub(crate) const REFUND_LOCKTIME: u16 = 20;
@@ -2023,8 +2029,19 @@ impl Taker {
 
         log::info!("Fetching addresses from DNS: {dns_addr}");
 
+        #[cfg(not(feature = "tracker"))]
         let addresses_from_dns =
             match fetch_addresses_from_dns(socks_port, dns_addr, self.config.connection_type) {
+                Ok(dns_addrs) => dns_addrs,
+                Err(e) => {
+                    log::error!("Could not connect to DNS Server: {e:?}");
+                    return Err(e);
+                }
+            };
+
+        #[cfg(feature = "tracker")]
+        let addresses_from_dns =
+            match fetch_addresses_from_tracker(socks_port, dns_addr, self.config.connection_type) {
                 Ok(dns_addrs) => dns_addrs,
                 Err(e) => {
                     log::error!("Could not connect to DNS Server: {e:?}");

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -46,7 +46,7 @@ use crate::{
             TakerToMakerMessage,
         },
     },
-    taker::{config::TakerConfig, offers::OfferBook},
+    taker::{config::TakerConfig, offers::OfferBook, send_message_with_prefix},
     utill::*,
     wallet::{
         IncomingSwapCoin, OutgoingSwapCoin, RPCConfig, SwapCoin, Wallet, WalletError,
@@ -1154,7 +1154,7 @@ impl Taker {
             this_maker.address
         );
         let id = self.ongoing_swap_state.id.clone();
-        send_message(
+        send_message_with_prefix(
             &mut socket,
             &TakerToMakerMessage::RespContractSigsForRecvrAndSender(
                 ContractSigsForRecvrAndSender {
@@ -1728,7 +1728,7 @@ impl Taker {
             ret
         })?;
         log::info!("===> PrivateKeyHandover | {maker_address}");
-        send_message(
+        send_message_with_prefix(
             &mut socket,
             &TakerToMakerMessage::RespPrivKeyHandover(PrivKeyHandover {
                 multisig_privkeys: privkeys_reply,
@@ -2122,7 +2122,7 @@ impl Taker {
 
         socket.set_write_timeout(Some(reconnect_timeout))?;
 
-        send_message(&mut socket, &msg)?;
+        send_message_with_prefix(&mut socket, &msg)?;
         log::info!("===> {msg} | {maker_addr}");
 
         Ok(())

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -3,6 +3,7 @@ use crate::{
     error::NetError, market::directory::DirectoryServerError, protocol::error::ProtocolError,
     utill::TorError, wallet::WalletError,
 };
+use bitcoin::address::ParseError;
 
 /// Represents errors that can occur during Taker operations.
 ///
@@ -35,6 +36,8 @@ pub enum TakerError {
     MPSC(String),
     /// Tor error
     TorError(TorError),
+    /// Error relating to Bitcoin Address Parsing.
+    AddressParseError(ParseError),
 }
 
 impl From<TorError> for TakerError {
@@ -94,5 +97,11 @@ impl From<std::sync::mpsc::RecvError> for TakerError {
 impl<T> From<std::sync::mpsc::SendError<T>> for TakerError {
     fn from(value: std::sync::mpsc::SendError<T>) -> Self {
         Self::MPSC(value.to_string())
+    }
+}
+
+impl From<ParseError> for TakerError {
+    fn from(value: ParseError) -> Self {
+        Self::AddressParseError(value)
     }
 }

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -9,7 +9,33 @@ mod config;
 pub mod error;
 pub(crate) mod offers;
 mod routines;
+use std::io::Write;
+
+use std::{io::BufWriter, net::TcpStream};
+
+use crate::utill::send_message;
 
 pub use self::api::TakerBehavior;
 pub use api::{SwapParams, Taker};
 pub use config::TakerConfig;
+use error::TakerError;
+
+/// This method adds a prefix for
+/// maker to identify if its
+/// taker or not
+pub fn send_message_with_prefix(
+    socket_writer: &mut TcpStream,
+    message: &impl serde::Serialize,
+) -> Result<(), TakerError> {
+    let mut writer = BufWriter::new(socket_writer);
+    let mut msg_bytes = Vec::new();
+    msg_bytes.push(0x01);
+    msg_bytes.extend(serde_cbor::to_vec(message)?);
+    let msg_len = (msg_bytes.len() as u32).to_be_bytes();
+    let mut to_send = Vec::with_capacity(msg_bytes.len() + msg_len.len());
+    to_send.extend(msg_len);
+    to_send.extend(msg_bytes);
+    writer.write_all(&to_send)?;
+    writer.flush()?;
+    Ok(())
+}

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -13,8 +13,6 @@ use std::io::Write;
 
 use std::{io::BufWriter, net::TcpStream};
 
-use crate::utill::send_message;
-
 pub use self::api::TakerBehavior;
 pub use api::{SwapParams, Taker};
 pub use config::TakerConfig;

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -21,10 +21,15 @@ use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 
 use crate::{
-    error::NetError,
-    protocol::messages::{DnsRequest, Offer},
+    protocol::messages::Offer,
     utill::{read_message, send_message, ConnectionType, GLOBAL_PAUSE, NET_TIMEOUT},
 };
+
+#[cfg(not(feature = "tracker"))]
+use crate::protocol::messages::DnsRequest;
+
+#[cfg(not(feature = "tracker"))]
+use crate::error::NetError;
 
 #[cfg(feature = "tracker")]
 use crate::protocol::messages::{TrackerRequest, TrackerResponse};
@@ -50,6 +55,7 @@ struct OnionAddress {
 pub struct MakerAddress(OnionAddress);
 
 impl MakerAddress {
+    #[cfg(not(feature = "tracker"))]
     pub(crate) fn new(address: &str) -> Result<Self, TakerError> {
         if let Some((onion_addr, port)) = address.split_once(':') {
             Ok(Self(OnionAddress {

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -331,13 +331,17 @@ impl Wallet {
         &mut self,
         amount: Amount,
         locktime: LockTime,
+        maker_address: Option<&[u8]>,
         feerate: f64,
     ) -> Result<u32, WalletError> {
         let (index, fidelity_addr, fidelity_pubkey) = self.get_next_fidelity_address(locktime)?;
 
         let coins = self.coin_select(amount, feerate)?;
-
-        let destination = Destination::Multi(vec![(fidelity_addr, amount)]);
+        let outputs = vec![(fidelity_addr, amount)];
+        let destination = Destination::Multi {
+            outputs,
+            op_return_data: maker_address.map(|addr| addr.to_vec().into_boxed_slice()),
+        };
 
         let tx = self.spend_coins(&coins, destination, feerate)?;
 

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -242,8 +242,11 @@ impl Wallet {
                     .collect::<Vec<_>>();
 
                 // Create destination with output - currently, destination is an array with a single address, i.e only a single transaction.
-                let destination =
-                    Destination::Multi(vec![(address.clone(), Amount::from_sat(output_value))]);
+                let outputs = vec![(address.clone(), Amount::from_sat(output_value))];
+                let destination = Destination::Multi {
+                    outputs,
+                    op_return_data: None,
+                };
 
                 // Creates and Signs Transactions via the spend_coins API
                 let funding_tx =

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -163,7 +163,10 @@ impl Wallet {
 
             // Create destination with output
             let destination = if normie_flag {
-                Destination::Multi(vec![(destinations[0].clone(), coinswap_amount)])
+                Destination::Multi {
+                    outputs: vec![(destinations[0].clone(), coinswap_amount)],
+                    op_return_data: None,
+                }
             } else {
                 Destination::MultiDynamic(coinswap_amount, destinations)
             };

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -5,8 +5,8 @@
 //! parsing mechanisms for transaction inputs and outputs.
 
 use bitcoin::{
-    absolute::LockTime, transaction::Version, Address, Amount, OutPoint, ScriptBuf, Sequence,
-    Transaction, TxIn, TxOut, Witness,
+    absolute::LockTime, script::PushBytesBuf, transaction::Version, Address, Amount, OutPoint,
+    ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RawTx, RpcApi};
 
@@ -20,7 +20,12 @@ pub enum Destination {
     /// Sweep
     Sweep(Address),
     /// Multi
-    Multi(Vec<(Address, Amount)>),
+    Multi {
+        /// List of outputs (address, amounts)
+        outputs: Vec<(Address, Amount)>,
+        /// OP_RETURN data, used to create a OP_RETURN TxOut
+        op_return_data: Option<Box<[u8]>>,
+    },
     /// Send Dynamic Random Amounts to Multiple Addresses
     MultiDynamic(Amount, Vec<Address>),
 }
@@ -337,13 +342,30 @@ impl Wallet {
                 log::info!("Fee: {} sats", fee.to_sat());
                 tx.output[0].value = total_input_value - fee;
             }
-            Destination::Multi(addresses) => {
+            Destination::Multi {
+                outputs,
+                op_return_data,
+            } => {
                 let mut total_output_value = Amount::ZERO;
-                for (address, amount) in addresses {
+                for (address, amount) in outputs {
                     total_output_value += amount;
                     let txout = TxOut {
                         script_pubkey: address.script_pubkey(),
                         value: amount,
+                    };
+                    tx.output.push(txout);
+                }
+                if let Some(data) = op_return_data {
+                    let mut push_bytes = PushBytesBuf::new();
+                    push_bytes.extend_from_slice(&data).map_err(|_| {
+                        WalletError::General(
+                            "Failed to add OP_RETURN data to transaction output".to_owned(),
+                        )
+                    })?;
+                    let op_return_script = ScriptBuf::new_op_return(&push_bytes);
+                    let txout = TxOut {
+                        script_pubkey: op_return_script,
+                        value: Amount::ZERO,
                     };
                     tx.output.push(txout);
                 }

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -151,6 +151,7 @@ fn test_fidelity() {
                 Amount::from_sat(8000000),
                 LockTime::from_height((bitcoind.client.get_block_count().unwrap() as u32) + 950)
                     .unwrap(),
+                None,
                 DEFAULT_TX_FEE_RATE,
             )
             .unwrap();


### PR DESCRIPTION
This PR adds tracker integration to Coinswap. The integration is currently gated behind the tracker feature flag. Once DNS support is fully removed, the tracker will become the default. To use the tracker with Coinswap, enable the tracker feature when building both the tracker and Coinswap components.