### PR TITLE
Fix bitcoin download URL to use official public link

### DIFF
--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -2,12 +2,11 @@
 //!
 //! It includes functions for handshaking, requesting contract signatures, sending proofs of funding, and downloading maker offers.
 //! It also defines structs for contract transactions and contract information.
-//! Notable types include [ContractTransaction], [ContractsInfo], [ThisMakerInfo], and [NextMakerInfo].
+//! Notable types include [ThisMakerInfo], and [NextMakerInfo].
 //! It also handles downloading maker offers with retry mechanisms and implements the necessary message structures
 //! for communication between taker and maker.
 
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 use std::{net::TcpStream, thread::sleep, time::Duration};
 
@@ -44,21 +43,6 @@ use crate::taker::api::{
 };
 
 use crate::wallet::SwapCoin;
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub(crate) struct ContractTransaction {
-    pub(crate) tx: Transaction,
-    pub(crate) redeemscript: ScriptBuf,
-    pub(crate) hashlock_spend_without_preimage: Option<Transaction>,
-    pub(crate) timelock_spend: Option<Transaction>,
-    pub(crate) timelock_spend_broadcasted: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub(crate) struct ContractsInfo {
-    pub(crate) contract_txes: Vec<ContractTransaction>,
-    pub(crate) wallet_label: String,
-}
 
 /// Make a handshake with a maker.
 /// Ensures that the Maker is alive and responding.

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -145,8 +145,11 @@ pub(crate) fn init_bitcoind(datadir: &std::path::Path) -> BitcoinD {
         let tarball_bytes = match env::var("BITCOIND_TARBALL_FILE") {
             Ok(path) => read_tarball_from_file(&path),
             Err(_) => {
-                let download_endpoint = env::var("BITCOIND_DOWNLOAD_ENDPOINT")
-                    .unwrap_or_else(|_| "http://172.81.178.3/bitcoin-binaries".to_owned());
+                let download_endpoint =
+                    env::var("BITCOIND_DOWNLOAD_ENDPOINT").unwrap_or_else(|_| {
+                        format!("https://bitcoincore.org/bin/bitcoin-core-{BITCOIN_VERSION}")
+                            .to_owned()
+                    });
                 let url = format!("{download_endpoint}/{download_filename}");
                 download_bitcoind_tarball(&url, 5)
             }


### PR DESCRIPTION
The fallback link to downloading bitcoin binaries via `http://172.81.178.3/bitcoin-binaries` was failing. This was causing tests to go on for hours while re-attempting to fetch the link *only* in [github workflows](https://github.com/citadel-tech/coinswap/actions/runs/16401366500/job/46341307138). Couldn't reproduce this locally.