### PR TITLE
Replace implicit wallet saving from wallet.sync() with explicit sync_and_save wrapper

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -309,9 +309,7 @@ impl Maker {
 
         config.write_to_file(&data_dir.join("config.toml"))?;
 
-        log::info!("Initializing wallet sync");
-        wallet.sync()?;
-        log::info!("Completed wallet sync");
+        wallet.sync_and_save()?;
 
         let network_port = config.network_port;
 
@@ -969,13 +967,10 @@ pub(crate) fn recover_from_swap(
                             outgoing_removed.contract_tx.compute_txid()
                         );
 
-                        log::info!("initializing Wallet Sync.");
                         {
                             let mut wallet_write = maker.wallet.write()?;
-                            wallet_write.sync()?;
-                            wallet_write.save_to_disk()?;
+                            wallet_write.sync_and_save()?;
                         }
-                        log::info!("Completed Wallet Sync.");
                     }
                 }
             }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -657,12 +657,8 @@ impl Maker {
         let mut conn_state = self.ongoing_swap_state.lock()?;
         *conn_state = HashMap::default();
 
-        log::info!("initializing Wallet Sync.");
-        {
-            let wallet_write = self.wallet.write()?;
-            wallet_write.save_to_disk()?;
-        }
-        log::info!("Completed Wallet Sync.");
+        self.wallet.write()?.sync_and_save()?;
+
         log::info!("Successfully Completed Coinswap");
         Ok(())
     }

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -125,10 +125,12 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
         }
         RpcMsgReq::SyncWallet => {
             log::info!("Initializing wallet sync");
-            if let Err(e) = maker.get_wallet().write()?.sync() {
+            let mut wallet = maker.get_wallet().write()?;
+            if let Err(e) = wallet.sync() {
                 RpcMsgResp::ServerError(format!("{e:?}"))
             } else {
                 log::info!("Completed wallet sync");
+                wallet.save_to_disk()?;
                 RpcMsgResp::Pong
             }
         }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -264,9 +264,7 @@ impl Taker {
             empty_book
         };
 
-        log::info!("Initializing wallet sync");
-        wallet.sync()?;
-        log::info!("Completed wallet sync");
+        wallet.sync_and_save()?;
 
         Ok(Self {
             wallet,
@@ -1322,7 +1320,7 @@ impl Taker {
                 o_ms_pubkey1
             };
 
-            self.wallet.sync()?;
+            self.wallet.sync_and_save()?;
 
             let mut incoming_swapcoin = IncomingSwapCoin::new(
                 maker_funded_multisig_privkey,
@@ -1890,7 +1888,7 @@ impl Taker {
         let mut outgoing_infos = Vec::new();
 
         // Broadcast the Outgoing Contracts
-        self.get_wallet_mut().sync()?;
+        self.get_wallet_mut().sync_and_save()?;
 
         for outgoing in outgoings {
             let contract_tx = outgoing.get_fully_signed_contract_tx()?;
@@ -1915,7 +1913,8 @@ impl Taker {
             let timelock = outgoing.get_timelock()?;
             let next_internal = &self.wallet.get_next_internal_addresses(1)?[0];
 
-            self.get_wallet_mut().sync()?;
+            let wallet = self.get_wallet_mut();
+            wallet.sync_and_save()?;
 
             let timelock_spend =
                 self.wallet
@@ -1927,9 +1926,7 @@ impl Taker {
         let mut timelock_boardcasted = Vec::new();
 
         // Save the wallet file here before going into the expensive loop.
-        self.wallet.sync()?;
-        self.wallet.save_to_disk()?;
-        log::info!("Wallet file synced and saved.");
+        self.wallet.sync_and_save()?;
 
         // Start the loop to keep checking for timelock maturity, and spend from the contract asap.
         loop {
@@ -1979,10 +1976,7 @@ impl Taker {
                                 "Removed Outgoing Swapcoin from Wallet, Contract Txid: {}",
                                 outgoing_removed.contract_tx.compute_txid()
                             );
-                            log::info!("Initializing Wallet sync and save");
-                            self.wallet.sync()?;
-                            self.wallet.save_to_disk()?;
-                            log::info!("Completed wallet sync and save");
+                            self.wallet.sync_and_save()?;
                         }
                     }
                 }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -365,15 +365,6 @@ impl Wallet {
         Ok(wallet)
     }
 
-    /// Update external index and saves to disk.
-    pub(crate) fn update_external_index(
-        &mut self,
-        new_external_index: u32,
-    ) -> Result<(), WalletError> {
-        self.store.external_index = new_external_index;
-        self.save_to_disk()
-    }
-
     /// Update the existing file. Error if path does not exist.
     pub(crate) fn save_to_disk(&self) -> Result<(), WalletError> {
         self.store
@@ -988,7 +979,7 @@ impl Wallet {
         Ok((max_index + 1) as u32)
     }
 
-    /// Gets the next external address from the HD keychain.
+    /// Gets the next external address from the HD keychain. Saves the wallet to disk
     pub fn get_next_external_address(&mut self) -> Result<Address, WalletError> {
         let descriptors = self.get_wallet_descriptors()?;
         let receive_branch_descriptor = descriptors
@@ -999,7 +990,8 @@ impl Wallet {
             Some([self.store.external_index, self.store.external_index]),
         )?[0]
             .clone();
-        self.update_external_index(self.store.external_index + 1)?;
+        self.store.external_index += 1;
+        self.save_to_disk()?;
         Ok(receive_address.assume_checked())
     }
 

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -412,7 +412,7 @@ impl Wallet {
         bond.cert_expiry = Some(cert_expiry);
         bond.conf_height = Some(conf_height);
 
-        self.sync()?;
+        self.sync_and_save()?;
 
         Ok(())
     }

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -129,12 +129,12 @@ fn test_stop_taker_after_setup() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -127,12 +127,12 @@ fn test_abort_case_2_move_on_with_other_makers() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 
@@ -221,7 +221,7 @@ fn test_abort_case_2_move_on_with_other_makers() {
     bitcoind.client.send_raw_transaction(&tx).unwrap();
     generate_blocks(bitcoind, 1);
 
-    taker_wallet_mut.sync().unwrap();
+    taker_wallet_mut.sync_and_save().unwrap();
 
     let balances = taker_wallet_mut.get_balances().unwrap();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -138,12 +138,12 @@ fn test_abort_case_2_recover_if_no_makers_found() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -127,12 +127,11 @@ fn maker_drops_after_sending_senders_sigs() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
-
+    taker_wallet.sync_and_save().unwrap();
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -132,12 +132,12 @@ fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -125,12 +125,11 @@ fn abort3_case2_close_at_contract_sigs_for_recvr() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
-
+    taker_wallet.sync_and_save().unwrap();
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -128,12 +128,12 @@ fn abort3_case3_close_at_hash_preimage_handover() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -62,7 +62,7 @@ fn test_fidelity() {
     // Add sync and verification before starting maker server
     {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
         let balances = wallet.get_balances().unwrap();
         log::info!(
             "📊 Initial wallet balance: {} sats",
@@ -238,7 +238,7 @@ fn test_fidelity() {
         let maker = maker.clone();
         move || {
             let mut maker_write_wallet = maker.get_wallet().write().unwrap();
-            maker_write_wallet.sync().unwrap();
+            maker_write_wallet.sync_and_save().unwrap();
         }
     });
 

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -121,12 +121,12 @@ fn malice1_taker_broadcast_contract_prematurely() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -123,12 +123,12 @@ fn malice2_maker_broadcast_contract_prematurely() {
 
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
     ///////////////
 

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -132,12 +132,12 @@ fn test_standard_coinswap() {
     // | **Maker6102**  | 465,384 - 438,642 - 3,000 = +21,858                               |
 
     let taker_wallet = taker.get_wallet_mut();
-    taker_wallet.sync().unwrap();
+    taker_wallet.sync_and_save().unwrap();
 
     // Synchronize each maker's wallet.
     for maker in makers.iter() {
         let mut wallet = maker.get_wallet().write().unwrap();
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
     }
 
     info!("📊 Verifying swap results");
@@ -172,7 +172,8 @@ fn test_standard_coinswap() {
     bitcoind.client.send_raw_transaction(&tx).unwrap();
     generate_blocks(bitcoind, 1);
 
-    taker_wallet_mut.sync().unwrap();
+    taker_wallet_mut.sync_and_save().unwrap();
+
     let balances = taker_wallet_mut.get_balances().unwrap();
 
     assert_in_range!(balances.swap.to_sat(), [441394], "Swap Balance Mismatch");

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -420,7 +420,7 @@ pub fn fund_and_verify_maker(
         assert_eq!(wallet.get_external_index(), &utxo_count);
 
         //
-        wallet.sync().unwrap();
+        wallet.sync_and_save().unwrap();
 
         let balances = wallet.get_balances().unwrap();
 


### PR DESCRIPTION
The `wallet.sync()` function used to indirectly write to disk by calling `update_external_index()`, which performed a `wallet.save_to_disk()`. This behavior was implicit and done before sync end, `refresh_offer_maxsize_cache()` was called before and therefore not persisted, leading to inconsistencies.

# Solution

This PR removes the implicit saving behavior from `update_external_index()` and introduces an explicit `sync_and_save()` wrapper function that:
1. Calls `sync()`
2. Then performs a `save_to_disk()`

All previous usages of `wallet.sync()` where saving was intended have been replaced with `wallet.sync_and_save()` to make saving behavior explicit and consistent.

# Additional Changes

- Removed the `save_to_disk()` call from `update_external_index()`
- Added a warning comment to `get_next_external_address()`, which remains the only function with indirect save behavior
- Applied `cargo fmt` to ensure consistent formatting

# Why it matters

This change improves code clarity, avoids unintentional wallet persistence, and ensures that wallet modifications are only saved when explicitly intended.