### PR TITLE
Make coinswap watch UTXO

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -233,6 +233,9 @@ pub struct Maker {
     data_dir: PathBuf,
     /// Thread pool for managing all spawned threads
     pub(crate) thread_pool: Arc<ThreadPool>,
+    #[cfg(feature = "tracker")]
+    /// Indexer address to poll for UTXO
+    pub(crate) tracker: RwLock<Option<String>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -325,6 +328,8 @@ impl Maker {
             is_setup_complete: AtomicBool::new(false),
             data_dir,
             thread_pool: Arc::new(ThreadPool::new(network_port)),
+            #[cfg(feature = "tracker")]
+            tracker: RwLock::new(None),
         })
     }
 


### PR DESCRIPTION
- Split TrackerRequest and TrackerResponse into TrackerClientToServer…
- Added structured Ping, Watch, Watch Response and Address variants with documented fields.
- Introduced `tracker` field in Maker to track tracker address.