### PR TITLE
Better panic message for subprocess errors in `test_maker`

### DIFF
--- a/tests/maker.rs
+++ b/tests/maker.rs
@@ -230,7 +230,12 @@ fn test_maker() {
 
     // Panic if test logic failed or panicked
     if let Err(err) = result {
-        panic!("Test panicked or failed: {:?}", err);
+        let message = err
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| err.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| format!("unknown type: {:?}", err));
+        panic!("Test panicked or failed: {}", message);
     }
 
     info!("🎉 All maker tests completed successfully");


### PR DESCRIPTION
This PR improves error reporting in the `test_maker` integration test by downcasting the panic payload returned by `std::panic::catch_unwind`.

## Why
When `makerd` panics or fails during the test, the captured error was always showing up as `{Any}` providing no useful information for debugging.

By attempting to downcast to `&str` or `String`, we can now surface the actual error message from the subprocess, making test failures much easier to diagnose.

## Changes
- Downcast `err` from `catch_unwind` to get a readable panic message if possible.
- Fallback to a generic message if the type is unknown.