### PR TITLE
PR for manual utxo selection

### DIFF
--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -404,6 +404,7 @@ impl Maker {
                 hashvalue,
                 message.refund_locktime,
                 message.contract_feerate,
+                None,
             )?
         };
 

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -86,7 +86,10 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
                 op_return_data: None,
             };
 
-            let coins_to_send = maker.get_wallet().read()?.coin_select(amount, feerate)?;
+            let coins_to_send = maker
+                .get_wallet()
+                .read()?
+                .coin_select(amount, feerate, None)?;
             let tx = maker.get_wallet().write()?.spend_from_wallet(
                 feerate,
                 destination,

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -81,7 +81,7 @@ pub(crate) const TCP_TIMEOUT_SECONDS: u64 = 300;
 /// SwapParams govern the criteria to find suitable set of makers from the offerbook.
 ///
 /// If no maker matches with a given SwapParam, that coinswap round will fail.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct SwapParams {
     /// Total Amount to Swap.
     pub send_amount: Amount,
@@ -89,6 +89,8 @@ pub struct SwapParams {
     pub maker_count: usize,
     /// How many splits
     pub tx_count: u32,
+    /// Manual UTXOs Outpoints
+    pub manual_utxo_outpoints: Option<Vec<OutPoint>>,
 }
 
 // Defines the Taker's position in the current ongoing swap.
@@ -303,7 +305,7 @@ impl Taker {
     ///
     /// If that fails too. Open an issue at [our github](https://github.com/citadel-tech/coinswap/issues)
     pub(crate) fn send_coinswap(&mut self, swap_params: SwapParams) -> Result<(), TakerError> {
-        self.ongoing_swap_state.swap_params = swap_params;
+        self.ongoing_swap_state.swap_params = swap_params.clone();
         // Check if we have enough balance.
         let available = self.wallet.get_balances()?.spendable;
         let estimated_fee = Amount::from_sat(calculate_fee_sats(200));
@@ -520,6 +522,10 @@ impl Taker {
                     self.get_preimage_hash(),
                     swap_locktime,
                     MIN_FEE_RATE,
+                    self.ongoing_swap_state
+                        .swap_params
+                        .manual_utxo_outpoints
+                        .clone(),
                 )?;
 
             let contract_reedemscripts = outgoing_swapcoins

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -336,7 +336,7 @@ impl Wallet {
     ) -> Result<u32, WalletError> {
         let (index, fidelity_addr, fidelity_pubkey) = self.get_next_fidelity_address(locktime)?;
 
-        let coins = self.coin_select(amount, feerate)?;
+        let coins = self.coin_select(amount, feerate, None)?;
         let outputs = vec![(fidelity_addr, amount)];
         let destination = Destination::Multi {
             outputs,

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -39,8 +39,14 @@ impl Wallet {
         coinswap_amount: Amount,
         destinations: &[Address],
         fee_rate: f64,
+        manually_selected_utxo: Option<Vec<OutPoint>>,
     ) -> Result<CreateFundingTxesResult, WalletError> {
-        let ret = self.create_funding_txes_random_amounts(coinswap_amount, destinations, fee_rate);
+        let ret = self.create_funding_txes_random_amounts(
+            coinswap_amount,
+            destinations,
+            fee_rate,
+            manually_selected_utxo,
+        );
         if ret.is_ok() {
             log::info!(target: "wallet", "created funding txes random amounts");
             return ret;
@@ -130,7 +136,8 @@ impl Wallet {
         normie_flag: bool,
         coinswap_amount: Amount,
         destinations: Vec<Address>,
-        fee_rate: Amount,
+        fee_rate: f64,
+        manually_selected_utxo: Option<Vec<OutPoint>>,
     ) -> Result<CreateFundingTxesResult, WalletError> {
         // Unlock all unspent UTXOs
         self.rpc.unlock_unspent_all()?;
@@ -145,7 +152,8 @@ impl Wallet {
 
         // Here, we are gonna use a closure to ensure proper cleanup on error (since we need a rollback)
         let result = (|| {
-            let selected_utxo = self.coin_select(coinswap_amount, fee_rate.to_btc())?;
+            let selected_utxo =
+                self.coin_select(coinswap_amount, fee_rate, manually_selected_utxo)?;
 
             let outpoints: Vec<OutPoint> = selected_utxo
                 .iter()
@@ -175,15 +183,14 @@ impl Wallet {
             };
 
             // Creates and Signs Transactions via the spend_coins API
-            let funding_tx =
-                self.spend_coins(&coins_to_spend, destination, fee_rate.to_sat() as f64)?;
+            let funding_tx = self.spend_coins(&coins_to_spend, destination, fee_rate)?;
 
             // Record this transaction in our results.
             let payment_pos = 0; // assuming the payment output position is 0
 
             funding_txes.push(funding_tx);
             payment_output_positions.push(payment_pos as u32);
-            total_miner_fee += fee_rate.to_sat();
+            total_miner_fee += fee_rate as u64;
 
             Ok(CreateFundingTxesResult {
                 funding_txes,
@@ -204,6 +211,7 @@ impl Wallet {
         coinswap_amount: Amount,
         destinations: &[Address],
         fee_rate: f64,
+        manually_selected_utxo: Option<Vec<OutPoint>>,
     ) -> Result<CreateFundingTxesResult, WalletError> {
         let output_values = Wallet::generate_amount_fractions(destinations.len(), coinswap_amount)?;
 
@@ -222,7 +230,8 @@ impl Wallet {
         let result = (|| {
             for (address, &output_value) in destinations.iter().zip(output_values.iter()) {
                 let remaining = Amount::from_sat(output_value);
-                let selected_utxo = self.coin_select(remaining, fee_rate)?;
+                let selected_utxo =
+                    self.coin_select(remaining, fee_rate, manually_selected_utxo.clone())?;
 
                 let outpoints: Vec<OutPoint> = selected_utxo
                     .iter()
@@ -474,7 +483,7 @@ impl Wallet {
         let fee = Amount::from_sat(calculate_fee_sats(150));
         let remaining = coinswap_amount;
 
-        let selected_utxo = self.coin_select(remaining + fee, MIN_FEE_RATE)?;
+        let selected_utxo = self.coin_select(remaining + fee, MIN_FEE_RATE, None)?;
 
         let total_input_amount = selected_utxo.iter().fold(Amount::ZERO, |acc, (unspet, _)| {
             acc.checked_add(unspet.amount)

--- a/src/wallet/split_utxos.rs
+++ b/src/wallet/split_utxos.rs
@@ -285,7 +285,7 @@ impl Wallet {
 
             // Delta_c finds the threshold, which is used for a second coinselection
             let delta_c = target - target_change;
-            let delta_inputs = match self.coin_select(Amount::from_sat(delta_c), fee_rate) {
+            let delta_inputs = match self.coin_select(Amount::from_sat(delta_c), fee_rate, None) {
                 Ok(inputs) => inputs,
                 Err(e) => {
                     log::info!("Error other than insufficient amount during second coin selection in dynamic splitting logic: {e:?}, backtracking and returning previous state");

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -107,6 +107,7 @@ fn test_stop_taker_after_setup() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -106,6 +106,7 @@ fn test_abort_case_2_move_on_with_other_makers() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -113,6 +113,7 @@ fn test_abort_case_2_recover_if_no_makers_found() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
 
     if let Err(e) = taker.do_coinswap(swap_params) {

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -106,6 +106,7 @@ fn maker_drops_after_sending_senders_sigs() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -111,6 +111,7 @@ fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -104,6 +104,7 @@ fn abort3_case2_close_at_contract_sigs_for_recvr() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -104,6 +104,7 @@ fn abort3_case3_close_at_hash_preimage_handover() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -397,7 +397,7 @@ fn test_fidelity_spending() {
         let tx_result = {
             let mut wallet = maker.get_wallet().write().unwrap();
             let selected_utxos = wallet
-                .coin_select(Amount::from_sat(REGULAR_TX_AMOUNT), MIN_FEE_RATE)
+                .coin_select(Amount::from_sat(REGULAR_TX_AMOUNT), MIN_FEE_RATE, None)
                 .unwrap();
 
             for (_utxo, spend_info) in &selected_utxos {

--- a/tests/funding_dynamic_splits.rs
+++ b/tests/funding_dynamic_splits.rs
@@ -84,7 +84,8 @@ fn test_create_funding_txn_with_varied_distributions() {
                 false,
                 target,
                 destinations.clone(),
-                Amount::from_sat(MIN_FEE_RATE as u64),
+                MIN_FEE_RATE,
+                None,
             )
             .unwrap();
 
@@ -148,7 +149,7 @@ fn test_create_funding_txn_with_varied_distributions() {
 
         // Assert Fee is less than 98% of the expected Fee Rate or equal to MIN_FEE_RATE.
         assert!(
-            actual_feerate > MIN_FEE_RATE * 0.98 || actual_fee == MIN_FEE_RATE as u64,
+            actual_feerate > MIN_FEE_RATE * 0.98 || actual_feerate == MIN_FEE_RATE,
             "Fee rate ({}) is not less than 98% of MIN_FEE_RATE ({}) or fee is not equal to MIN_FEE_RATE",
             actual_feerate,
             MIN_FEE_RATE

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -100,6 +100,7 @@ fn malice1_taker_broadcast_contract_prematurely() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -102,6 +102,7 @@ fn malice2_maker_broadcast_contract_prematurely() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/manual_utxos.rs
+++ b/tests/manual_utxos.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "integration-test")]
+use bitcoin::{Amount, OutPoint};
+use coinswap::utill::MIN_FEE_RATE;
+mod test_framework;
+use test_framework::*;
+
+/// This test checks that manual_utxo_outpoints are honored by coin_select.
+#[test]
+fn test_manual_utxo_selection() {
+    // Setup: create a wallet and fund it with several UTXOs
+    let (test_framework, _, makers, _directory_server_instance, _block_generation_handle) =
+        TestFramework::init(
+            [((6102, None), coinswap::maker::MakerBehavior::Normal)].into(),
+            vec![coinswap::taker::TakerBehavior::Normal],
+            coinswap::utill::ConnectionType::CLEARNET,
+        );
+
+    let bitcoind = &test_framework.bitcoind;
+    let maker = makers.first().unwrap();
+
+    // Fund 3 addresses with 0.1, 0.2, 0.3 BTC each
+    for amount in [0.1, 0.2, 0.3] {
+        let addr = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        send_to_address(bitcoind, &addr, Amount::from_btc(amount).unwrap());
+        generate_blocks(bitcoind, 1);
+    }
+
+    let utxo_outpoints = maker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .get_all_utxo()
+        .unwrap()
+        .iter()
+        .map(|utxo| OutPoint::new(utxo.txid, utxo.vout))
+        .collect::<Vec<_>>();
+
+    // Sync wallet to see all the UTXOs
+    {
+        let mut wallet = maker.get_wallet().write().unwrap();
+        wallet.sync_no_fail();
+    }
+
+    // Now test coin selection with manual_utxo_outpoints = [first two]
+    let wallet = maker.get_wallet().read().unwrap();
+    let manual = utxo_outpoints[..2].to_vec();
+
+    let selected = wallet
+        .coin_select(
+            Amount::from_btc(0.25).unwrap(),
+            MIN_FEE_RATE,
+            Some(manual.clone()),
+        )
+        .unwrap();
+    let selected_outpoints = selected
+        .iter()
+        .map(|(u, _)| OutPoint::new(u.txid, u.vout))
+        .collect::<Vec<_>>();
+
+    // The selected UTXOs should be exactly the manually specified ones
+    assert_eq!(
+        selected_outpoints, manual,
+        "Coin selection did not honor manual_utxo_outpoints"
+    );
+
+    // Should fail if manual_utxo_outpoints can't cover the target
+    let too_small = wallet
+        .coin_select(Amount::from_btc(0.5).unwrap(), MIN_FEE_RATE, Some(manual))
+        .err();
+    assert!(
+        too_small.is_some(),
+        "Should fail if manual UTXOs can't cover target"
+    );
+
+    // Should succeed if all UTXOs are allowed
+    let all = wallet
+        .coin_select(Amount::from_btc(0.5).unwrap(), MIN_FEE_RATE, None)
+        .unwrap();
+    let total: Amount = all.iter().map(|(u, _)| u.amount).sum();
+    assert!(total >= Amount::from_btc(0.5).unwrap());
+
+    println!("✅ Manual UTXO coin selection test passed");
+}

--- a/tests/multi-taker.rs
+++ b/tests/multi-taker.rs
@@ -111,6 +111,7 @@ fn multi_taker_single_maker_swap() {
                 send_amount: Amount::from_sat(500000),
                 maker_count: 2,
                 tx_count: 3,
+                manual_utxo_outpoints: None,
             };
             s.spawn(move || {
                 taker.do_coinswap(swap_params).unwrap();

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -91,6 +91,7 @@ fn test_standard_coinswap() {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
         tx_count: 3,
+        manual_utxo_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/utxo_behavior.rs
+++ b/tests/utxo_behavior.rs
@@ -127,7 +127,9 @@ fn test_address_grouping_behavior() {
         let target_amount = Amount::from_btc(target_btc).unwrap();
 
         // Call the coin selection algorithm we're testing
-        let selected_utxos = wallet.coin_select(target_amount, MIN_FEE_RATE).unwrap();
+        let selected_utxos = wallet
+            .coin_select(target_amount, MIN_FEE_RATE, None)
+            .unwrap();
 
         let selected_amounts: Vec<f64> = selected_utxos
             .iter()


### PR DESCRIPTION
# Introduction

This PR adds the feature for supporting selection of UTXOs by the taker input for the purposes of transacting a Coinswap. It is a conjugation of 2 PRs including #576 , together defining the entire flow of user inputs.  We are using [crossterm](https://docs.rs/crate/crossterm) for the UI display in the CLI, motivations for which are given below. 

# Motivations

- First step to empower users with fine-grained control over their transactions, enabling manual UTXO selection and other customizable features to uphold cypherpunk principles of privacy, decentralization, and self-sovereignty in the Coinswap protocol.
-  **Privacy Enhancement**: Manual UTXO selection prevents unintended linking of specific inputs, enhancing privacy during Coinswap transactions by ensuring input diversity and reducing blockchain analysis risks.
- **Selective UTXO sourcing**: Allows users to choose UTXOs from specific origins (e.g., trusted wallets) to align with personal or jurisdictional requirements, while prioritizing privacy.
- **UTXO Management**: Enables users to optimize their wallet by consolidating small UTXOs or preserving specific coins, improving efficiency and reducing fees in Coinswap transactions.
-  **DX (Dev Experience) -** **Debugging**: Facilitates development and testing by allowing developers to select specific UTXO sets to simulate edge cases or validate the Coinswap protocol’s behavior.

## Why Crossterm? 

| Library   | Transitive Deps (New) | Binary Size Impact | Compile Time | Ease of Use for CLI                                |
|-----------|------------------------|-------------------|--------------|----------------------------------------------------|
| Crossterm | 5                   | ~0.5–1 MB         | Fast         | High (flexible, mouse support, in-place updates)   |
| Termion   | 2                   | ~0.5–1 MB         | Fast         | Moderate (basic mouse, less ergonomic)             |
| Ratatui   | 5                  | ~1.5–3 MB         | Slower       | Low (heavy TUI framework, overkill for simple CLI) |
| Inquire   | 6                   | ~1–2 MB           | Moderate     | Moderate (prompt-based, limited mouse)             |
| Dialoguer | 6                   | ~1–1.5 MB         | Moderate     | Moderate (prompt-based, similar to Inquire)        |

- Chose Crossterm over Termion because the latter not as frequently maintained. 

## Cargo-depsize

Final Size of these dependencies for Coinswap crate calculated via cargo-depsize : 
```
termion (v4.0.5)          : 90.68KB (92859 bytes)
crossterm (v0.29.0)       : 110.97KB (113633 bytes)
dialoguer (v0.11.0)       : 163.58KB (167502 bytes)
inquire (v0.7.5)          : 531.59KB (544353 bytes)
ratatui (v0.29.0)         : 2.50MB (2623085 bytes)
```


# Manual UTXO Selection Call Flow

```text
Taker Binary (taker.rs)
└── Calls interactive selection() (from src/utils.rs)
    └── Passes `manual_utxo_outpoints`
        ↓
        SwapParams
        ↓
Taker API (api.rs)
└── do_coinswap()
    └── send_coinswap()
        └── init_first_hop()
            └── wallet.initialize_coinswap
                ↓
Wallet API (api.rs)
└── initialize_coinswap()
    └── create_funding_txes(manual_utxo_outpoints)
        └── coin_select(manual_utxo_outpoints)
            └── [UTXO selection logic happens here]
```

# Future works 

- This can be a reference for integration of other toggle-able features for user from the taker cli unto the lower level api functions. 