### PR TITLE
Add Rustdoc comments for public Wallet API functions

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -135,7 +135,7 @@ pub enum MakerBehavior {
     BroadcastContractAfterSetup,
 }
 
-/// Expected messages for the taker in the context of [ConnectionState] structure.
+/// Expected messages for the taker in the context of [`ConnectionState`] structure.
 ///
 /// If the received message doesn't match the expected message,
 /// a protocol error will be returned.
@@ -371,7 +371,7 @@ impl Maker {
         Ok(())
     }
 
-    /// Checks consistency of the [ProofOfFunding] message and return the Hashvalue
+    /// Checks consistency of the [`ProofOfFunding`] message and return the Hashvalue
     /// used in hashlock transaction.
     pub(crate) fn verify_proof_of_funding(
         &self,

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -83,7 +83,7 @@ impl Default for MakerConfig {
 }
 
 impl MakerConfig {
-    /// Constructs a [MakerConfig] from a specified data directory. Or creates default configs and load them.
+    /// Constructs a [`MakerConfig`] from a specified data directory. Or creates default configs and load them.
     ///
     /// The maker(/taker).toml file should exist at the provided data-dir location.
     /// Or else, a new default-config will be loaded and created at the given data-dir location.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -43,7 +43,7 @@ use crate::{
 };
 
 /// The Global Handle Message function. Takes in a [`Arc<Maker>`] and handles messages
-/// according to a [ConnectionState].
+/// according to a [`ConnectionState`].
 pub(crate) fn handle_message(
     maker: &Arc<Maker>,
     connection_state: &mut ConnectionState,
@@ -219,7 +219,7 @@ pub(crate) fn handle_message(
 }
 
 impl Maker {
-    /// This is the first message handler for the Maker. It receives a [ReqContractSigsForSender] message,
+    /// This is the first message handler for the Maker. It receives a [`ReqContractSigsForSender`] message,
     /// checks the validity of contract transactions, and provides the signature for the sender side.
     /// This will fail if the maker doesn't have enough utxos to fund the next coinswap hop, or the contract
     /// transaction isn't valid.
@@ -266,7 +266,7 @@ impl Maker {
         }
     }
 
-    /// Validates the [ProofOfFunding] message, initiate the next hop,
+    /// Validates the [`ProofOfFunding`] message, initiate the next hop,
     /// and create the `[ReqContractSigsAsRecvrAndSender`\] message.
     pub(crate) fn handle_proof_of_funding(
         &self,
@@ -483,7 +483,7 @@ impl Maker {
         ))
     }
 
-    /// Handles [ContractSigsForRecvrAndSender] message and updates the wallet state
+    /// Handles [`ContractSigsForRecvrAndSender`] message and updates the wallet state
     pub(crate) fn handle_contract_sigs_for_recvr_and_sender(
         &self,
         connection_state: &mut ConnectionState,
@@ -558,7 +558,7 @@ impl Maker {
         Ok(())
     }
 
-    /// Handles [ReqContractSigsForRecvr] and returns a [MakerToTakerMessage::RespContractSigsForRecvr]
+    /// Handles [`ReqContractSigsForRecvr`] and returns a [`MakerToTakerMessage::RespContractSigsForRecvr`]
     pub(crate) fn handle_req_contract_sigs_for_recvr(
         &self,
         message: ReqContractSigsForRecvr,
@@ -585,7 +585,7 @@ impl Maker {
         ))
     }
 
-    /// Handles a [HashPreimage] message and returns a [MakerToTakerMessage::RespPrivKeyHandover]
+    /// Handles a [`HashPreimage`] message and returns a [`MakerToTakerMessage::RespPrivKeyHandover`]
     pub(crate) fn handle_hash_preimage(
         &self,
         message: HashPreimage,
@@ -639,7 +639,7 @@ impl Maker {
         }))
     }
 
-    /// Handles [PrivKeyHandover] message and updates all the coinswap wallet states and stores it to disk.
+    /// Handles [`PrivKeyHandover`] message and updates all the coinswap wallet states and stores it to disk.
     /// This is the last step of completing a coinswap round.
     pub(crate) fn handle_private_key_handover(
         &self,

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -161,7 +161,7 @@ impl Default for DirectoryServer {
 }
 
 impl DirectoryServer {
-    /// Constructs a [DirectoryServer] from a specified data directory. Or creates default configs and load them.
+    /// Constructs a [`DirectoryServer`] from a specified data directory. Or creates default configs and load them.
     ///
     /// The directory.toml file should exist at the provided data-dir location.
     /// Or else, a new default-config will be loaded and created at the given data-dir location.

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -193,7 +193,7 @@ pub(crate) enum TakerToMakerMessage {
     ReqGiveOffer(GiveOffer),
     /// Request Contract Sigs **for** the Sender side of the hop. The Maker receiving this message is the Receiver of the hop.
     ReqContractSigsForSender(ReqContractSigsForSender),
-    /// Respond with the [ProofOfFunding] message. This is sent when the funding transaction gets confirmed.
+    /// Respond with the [`ProofOfFunding`] message. This is sent when the funding transaction gets confirmed.
     RespProofOfFunding(ProofOfFunding),
     /// Respond with Contract Sigs **for** the Receiver and Sender side of the Hop.
     RespContractSigsForRecvrAndSender(ContractSigsForRecvrAndSender),

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1,6 +1,6 @@
 //! The Taker API.
 //!
-//! This module describes the main [Taker] structure and all other associated data sets related to a coinswap round.
+//! This module describes the main [`Taker`] structure and all other associated data sets related to a coinswap round.
 //! This includes the main protocol workflow and all the subroutines that are called sequentially.
 //!
 //! [Taker::do_coinswap] is the main routine running all other subroutines. Follow the white rabbit from here.
@@ -293,9 +293,9 @@ impl Taker {
         self.send_coinswap(swap_params)
     }
 
-    /// Perform a coinswap round with given [SwapParams]. The Taker will try to perform swap with makers
-    /// in it's [OfferBook] sequentially as per the maker_count given in swap params.
-    /// If [SwapParams] doesn't fit suitably with any available offers, or not enough makers
+    /// Perform a coinswap round with given [`SwapParams`]. The Taker will try to perform swap with makers
+    /// in it's [`OfferBook`] sequentially as per the maker_count given in swap params.
+    /// If [`SwapParams`] doesn't fit suitably with any available offers, or not enough makers
     /// respond back, the swap round will fail.
     ///
     /// Depending upon the failure situation, Taker will automatically try to recover from failed swaps
@@ -491,9 +491,9 @@ impl Taker {
 
     // ######## PROTOCOL SUBROUTINES ############
 
-    /// Initiate the first coinswap hop. Makers are selected from the [OfferBook], and round will
+    /// Initiate the first coinswap hop. Makers are selected from the [`OfferBook`], and round will
     /// fail if no suitable makers are found.
-    /// Creates and stores the [OutgoingSwapCoin] into [OngoingSwapState], and also saves it into the [Wallet] file.
+    /// Creates and stores the [`OutgoingSwapCoin`] into [`OngoingSwapState`], and also saves it into the [`Wallet`] file.
     fn init_first_hop(&mut self) -> Result<(), TakerError> {
         log::info!("Initializing First Hop.");
         // Set the Taker Position state
@@ -625,7 +625,7 @@ impl Taker {
 
     /// Return a list of confirmed funding txs with their corresponding merkle proofs.
     /// Errors if any watching contract txs have been broadcasted during the time too.
-    /// The error contanis the list of broadcasted contract [Txid]s.
+    /// The error contanis the list of broadcasted contract [`Txid`]s.
     fn watch_for_txs(
         &self,
         funding_txids: &Vec<Txid>,
@@ -764,8 +764,8 @@ impl Taker {
         }
     }
 
-    /// Create [FundingTxInfo] for the "next_maker". Next maker is the last stored [NextPeerInfo] in the swp state.
-    /// All other data from the swap state's last entries are collected and a [FundingTxInfo] protocol message data is generated.
+    /// Create [`FundingTxInfo`] for the "next_maker". Next maker is the last stored [`NextPeerInfo`] in the swp state.
+    /// All other data from the swap state's last entries are collected and a [`FundingTxInfo`] protocol message data is generated.
     fn funding_info_for_next_maker(&self) -> Vec<FundingTxInfo> {
         // Get the redeemscripts.
         let (this_maker_multisig_redeemscripts, this_maker_contract_redeemscripts) =
@@ -861,7 +861,7 @@ impl Taker {
     }
 
     /// Send signatures to a maker, and initiate the next hop of the swap by finding a new maker.
-    /// If no suitable makers are found in [OfferBook], next swap will not initiate and the swap round will fail.
+    /// If no suitable makers are found in [`OfferBook`], next swap will not initiate and the swap round will fail.
     fn send_sigs_init_next_hop(
         &mut self,
         maker_refund_locktime: u16,
@@ -1116,7 +1116,7 @@ impl Taker {
         // If This Maker is the Reciver, and We (The Taker) are the Sender (First Hop), Sign the Contract Tx.
         let receivers_sigs = if self.ongoing_swap_state.taker_position == TakerPosition::FirstPeer {
             log::info!("Taker is previous peer. Signing Receivers Contract Txs");
-            // Sign the receiver's contract using our [OutgoingSwapCoin].
+            // Sign the receiver's contract using our `OutgoingSwapCoin`.
             contract_sigs_as_recvr_sender
                 .receivers_contract_txs
                 .iter()
@@ -1181,7 +1181,7 @@ impl Taker {
         Ok((next_swap_info, contract_sigs_as_recvr_sender))
     }
 
-    /// Create [WatchOnlySwapCoin] for the current Maker.
+    /// Create [`WatchOnlySwapCoin`] for the current Maker.
     pub(crate) fn create_watch_only_swapcoins(
         &self,
         contract_sigs_as_recvr_and_sender: &ContractSigsAsRecvrAndSender,
@@ -1212,7 +1212,7 @@ impl Taker {
         Ok(next_swapcoins)
     }
 
-    /// Create the [IncomingSwapCoin] for this round. The Taker is always the "next_peer" here
+    /// Create the [`IncomingSwapCoin`] for this round. The Taker is always the "next_peer" here
     /// and the sender side is the laste Maker in the route.
     fn create_incoming_swapcoins(
         &mut self,
@@ -1339,7 +1339,7 @@ impl Taker {
         Ok(incoming_swapcoins)
     }
 
-    /// Request signatures for the [IncomingSwapCoin] from the last maker of the swap round.
+    /// Request signatures for the [`IncomingSwapCoin`] from the last maker of the swap round.
     fn request_sigs_for_incoming_swap(&mut self) -> Result<(), TakerError> {
         // Intermediate hops completed. Perform the last receiving hop.
         let last_maker = self
@@ -1767,17 +1767,17 @@ impl Taker {
             .ok_or(TakerError::NotEnoughMakersInOfferBook)
     }
 
-    /// Get the [Preimage] of the ongoing swap. If no swap is in progress will return a `[0u8; 32]`.
+    /// Get the [`Preimage`] of the ongoing swap. If no swap is in progress will return a `[0u8; 32]`.
     fn get_preimage(&self) -> &Preimage {
         &self.ongoing_swap_state.active_preimage
     }
 
-    /// Get the [Preimage] hash for the ongoing swap. If no swap is in progress will return `hash160([0u8; 32])`.
+    /// Get the [`Preimage`] hash for the ongoing swap. If no swap is in progress will return `hash160([0u8; 32])`.
     fn get_preimage_hash(&self) -> Hash160 {
         Hash160::hash(self.get_preimage())
     }
 
-    /// Clear the [OngoingSwapState].
+    /// Clear the [`OngoingSwapState`].
     fn clear_ongoing_swaps(&mut self) {
         self.ongoing_swap_state = OngoingSwapState::default();
     }
@@ -1787,7 +1787,7 @@ impl Taker {
         self.offerbook.get_bad_makers()
     }
 
-    /// Save all the finalized swap data and reset the [OngoingSwapState].
+    /// Save all the finalized swap data and reset the [`OngoingSwapState`].
     fn save_and_reset_swap_round(&mut self) -> Result<(), TakerError> {
         // Mark incoiming swapcoins as done
         for incoming_swapcoin in &self.ongoing_swap_state.incoming_swapcoins {

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -45,7 +45,7 @@ impl Default for TakerConfig {
 }
 
 impl TakerConfig {
-    /// Constructs a [TakerConfig] from a specified data directory. Or create default configs and load them.
+    /// Constructs a [`TakerConfig`] from a specified data directory. Or create default configs and load them.
     ///
     /// The maker(/taker).toml file should exist at the provided data-dir location.
     /// Or else, a new default-config will be loaded and created at the given data-dir location.

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -1,7 +1,7 @@
 //! Download, process and store Maker offers from the directory-server.
 //!
-//! It defines structures like [OfferAndAddress] and [MakerAddress] for representing maker offers and addresses.
-//! The [OfferBook] struct keeps track of good and bad makers, and it provides methods for managing offers.
+//! It defines structures like [`OfferAndAddress`] and [`MakerAddress`] for representing maker offers and addresses.
+//! The [`OfferBook`] struct keeps track of good and bad makers, and it provides methods for managing offers.
 //! The module handles the syncing of the offer book with addresses obtained from directory servers and local configurations.
 //! It uses asynchronous channels for concurrent processing of maker offers.
 

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -2,7 +2,7 @@
 //!
 //! It includes functions for handshaking, requesting contract signatures, sending proofs of funding, and downloading maker offers.
 //! It also defines structs for contract transactions and contract information.
-//! Notable types include [ThisMakerInfo], and [NextMakerInfo].
+//! Notable types include [`ThisMakerInfo`], and [`NextMakerInfo`].
 //! It also handles downloading maker offers with retry mechanisms and implements the necessary message structures
 //! for communication between taker and maker.
 

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -805,7 +805,7 @@ impl Wallet {
         Ok(processed_utxos)
     }
 
-    /// Lists live contract UTXOs along with their [UTXOSpendInfo].
+    /// Lists live contract UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_live_contract_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -821,7 +821,7 @@ impl Wallet {
         Ok(filtered_utxos)
     }
 
-    /// Lists live timelock contract UTXOs along with their [UTXOSpendInfo].
+    /// Lists live timelock contract UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_live_timelock_contract_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -833,7 +833,7 @@ impl Wallet {
             .collect();
         Ok(filtered_utxos)
     }
-
+    /// Lists all live hashlock contract UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_live_hashlock_contract_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -846,7 +846,7 @@ impl Wallet {
         Ok(filtered_utxos)
     }
 
-    /// Lists fidelity UTXOs along with their [UTXOSpendInfo].
+    /// Lists fidelity UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_fidelity_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -859,7 +859,7 @@ impl Wallet {
         Ok(filtered_utxos)
     }
 
-    /// Lists descriptor UTXOs along with their [UTXOSpendInfo].
+    /// Lists descriptor UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_descriptor_utxo_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -872,7 +872,7 @@ impl Wallet {
         Ok(filtered_utxos)
     }
 
-    /// Lists swap coin UTXOs along with their [UTXOSpendInfo].
+    /// Lists swap coin UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_swap_coin_utxo_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -890,7 +890,7 @@ impl Wallet {
         Ok(filtered_utxos)
     }
 
-    /// Lists all incoming swapcoin UTXOs along with their [UTXOSpendInfo].
+    /// Lists all incoming swapcoin UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_incoming_swap_coin_utxo_spend_info(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -902,7 +902,7 @@ impl Wallet {
             .collect();
         Ok(filtered_utxos)
     }
-    /// Lists all swept incoming swapcoin UTXOs along with their [UTXOSpendInfo].
+    /// Lists all swept incoming swapcoin UTXOs along with their [`UTXOSpendInfo`].
     pub fn list_swept_incoming_swap_utxos(
         &self,
     ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
@@ -1679,7 +1679,7 @@ impl Wallet {
     pub fn send_tx(&self, tx: &Transaction) -> Result<Txid, WalletError> {
         Ok(self.rpc.send_raw_transaction(tx)?)
     }
-
+    /// Sweeps all completed incoming swapcoins to an internal wallet address, broadcasting transactions and recording their [`Txid`]s.
     pub fn sweep_incoming_swapcoins(&mut self, feerate: f64) -> Result<Vec<Txid>, WalletError> {
         let mut swept_txids = Vec::new();
 

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -226,7 +226,7 @@ impl Wallet {
             .map(|(i, _)| *i))
     }
 
-    /// Get the [Keypair] for the fidelity bond at given index.
+    /// Get the [`Keypair`] for the fidelity bond at given index.
     pub(crate) fn get_fidelity_keypair(&self, index: u32) -> Result<Keypair, WalletError> {
         let secp = Secp256k1::new();
 
@@ -252,7 +252,7 @@ impl Wallet {
     }
 
     /// Get the next fidelity bond address. If no fidelity bond is created
-    /// returned address will be derived from index 0, of the [FIDELITY_DERIVATION_PATH]
+    /// returned address will be derived from index 0, of the [`FIDELITY_DERIVATION_PATH`]
     pub(crate) fn get_next_fidelity_address(
         &self,
         locktime: LockTime,
@@ -414,7 +414,7 @@ impl Wallet {
         })
     }
 
-    /// Generate a [FidelityProof] for bond at a given index and a specific onion address.
+    /// Generate a [`FidelityProof`] for bond at a given index and a specific onion address.
     pub(crate) fn generate_fidelity_proof(
         &self,
         index: u32,
@@ -449,7 +449,7 @@ impl Wallet {
         })
     }
 
-    /// Verify a [FidelityProof] received from the directory servers.
+    /// Verify a [`FidelityProof`] received from the directory servers.
     pub(crate) fn verify_fidelity_proof(
         &self,
         proof: &FidelityProof,

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -123,8 +123,8 @@ impl Wallet {
         Ok(output_values)
     }
 
-    // This function creates a single funding transaction with random, distrubuted, bounded amounts
-    // Which are distributed among the destinations in different outputs.
+    /// This function creates a single funding transaction with random, distrubuted, bounded amounts
+    /// Which are distributed among the destinations in different outputs.
     pub fn create_funding_txes_regular_swaps(
         &mut self,
         normie_flag: bool,

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -206,6 +206,7 @@ impl Wallet {
         Err(WalletError::General("Contract Does not exist".to_string()))
     }
 
+    /// Creates a [`Transaction`] spending given UTXOs to a [`Destination`] with fee calculated from `feerate`.
     pub fn spend_coins(
         &self,
         coins: &[(ListUnspentResultEntry, UTXOSpendInfo)],

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -3,9 +3,9 @@
 //! and made in the process of a CoinSwap.
 //!
 //! There are three types of SwapCoins:
-//! [IncomingSwapCoin]: The contract data defining an **incoming** swap.
-//! [OutgoingSwapCoin]: The contract data defining an **outgoing** swap.
-//! [WatchOnlySwapCoin]: The contract data defining a **watch-only** swap. This is only applicable for Takers,
+//! [`IncomingSwapCoin`]: The contract data defining an **incoming** swap.
+//! [`OutgoingSwapCoin`]: The contract data defining an **outgoing** swap.
+//! [`WatchOnlySwapCoin`]: The contract data defining a **watch-only** swap. This is only applicable for Takers,
 //! for monitoring the swaps happening between two Makers.
 
 use bitcoin::{

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -156,9 +156,9 @@ fn test_abort_case_2_recover_if_no_makers_found() {
     // |----------------|------------------------|-------------------------|------------|----------------------------|-------------------|
     // | **Taker**      | _                      | 500,000                 | _          | 3,000                      | 3,000             |
     //
-    // - Taker sends [ProofOfFunding] to Maker16102.
-    // - Maker16102 responds with [ReqContractSigsAsRecvrAndSender] to the Taker.
-    // - Taker forwards [ReqContractSigsForSender] to Maker6102, but Maker6102 does not respond, and the Taker recovers from the swap.
+    // - Taker sends [`ProofOfFunding`] to Maker16102.
+    // - Maker16102 responds with [`ReqContractSigsAsRecvrAndSender`] to the Taker.
+    // - Taker forwards [`ReqContractSigsForSender`] to Maker6102, but Maker6102 does not respond, and the Taker recovers from the swap.
     //
     // Final Outcome for Taker (Recover from Swap):
     //
@@ -171,7 +171,7 @@ fn test_abort_case_2_recover_if_no_makers_found() {
     // Case 2: Maker6102 is the first maker.
     // Workflow: Taker -> Maker6102 (CloseAtReqContractSigsForSender)
     //
-    // - Taker creates unbroadcasted funding transactions and sends [ReqContractSigsForSender] to Maker6102.
+    // - Taker creates unbroadcasted funding transactions and sends [`ReqContractSigsForSender`] to Maker6102.
     // - Maker6102 does not respond, and the swap fails.
     //
     // Final Outcome for Taker:

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -144,8 +144,8 @@ fn maker_drops_after_sending_senders_sigs() {
     // |----------------|------------------------|-------------------------|------------|----------------------------|-------------------|
     // | **Taker**      | _                      | 500,000                 | _          | 3,000                      | 3,000             |
 
-    // - Taker sends [ReqContractSigsForSender] to Maker6102, Maker6102 responds with signatures.
-    // - Taker forwards [ProofOfFunding], but Maker6102 doesn't respond, leading to swap recovery.
+    // - Taker sends [`ReqContractSigsForSender`] to Maker6102, Maker6102 responds with signatures.
+    // - Taker forwards [`ProofOfFunding`], but Maker6102 doesn't respond, leading to swap recovery.
 
     //
     // Final Outcome for Taker (Recover from Swap):

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -150,7 +150,7 @@ fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
     // |----------------|------------------------|-------------------------|------------|----------------------------|-------------------|
     // | **Taker**      | _                      | 500,000                 | _          | 3,000                      | 3,000             |
     //
-    // - Taker forwards [ProofOfFunding] to Maker6102, receives [ReqContractSigsAsRecvrAndSender].
+    // - Taker forwards [`ProofOfFunding`] to Maker6102, receives [`ReqContractSigsAsRecvrAndSender`].
     // - Maker6102 reaches CloseAtContractSigsForRecvrAndSender and doesn't broadcast funding tx.
     // - Taker recovers from the swap.
     //
@@ -177,7 +177,7 @@ fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
     // | **Taker**      | _                      | 500,000                 | _          | 3,000                      | 3,000             |
     // | **Maker16102** | 500,000                | 463,500                 | 33,500     | 3,000                      | 36,500            |
     //
-    // - Maker6102 receives [ProofOfFunding] of Maker16102, sends [ReqContractSigsAsRecvrAndSender].
+    // - Maker6102 receives [`ProofOfFunding`] of Maker16102, sends [`ReqContractSigsAsRecvrAndSender`].
     // - Maker6102 reaches CloseAtContractSigsForRecvrAndSender and doesn't broadcast funding tx.
     //
     // - After timeout, Taker and Maker16102 recover funds but lose **6,768 sats** each in fees.

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -144,8 +144,8 @@ fn abort3_case2_close_at_contract_sigs_for_recvr() {
     // | **Taker**      | _                      | 500,000                 | _          | 3,000                      | 3,000             |
     // | **Maker6102**  | 500,000                | 463,500                 | 33,500     | 3,000                      | 36,500            |
     //
-    // - Taker sends [ProofOfFunding] of Maker6102 to Maker16102, who replies with [ReqContractSigsForRecvrAndSender].
-    // - Taker forwards [ReqContractSigsForRecvr] to Maker6102, but Maker6102 doesn't respond.
+    // - Taker sends [`ProofOfFunding`] of Maker6102 to Maker16102, who replies with [`ReqContractSigsForRecvrAndSender`].
+    // - Taker forwards [`ReqContractSigsForRecvr`] to Maker6102, but Maker6102 doesn't respond.
     // - After a timeout, both Taker and Maker6102 recover from the swap, incurring losses.
     //
     // Final Outcome for Taker & Maker6102 (Recover from Swap):
@@ -168,7 +168,7 @@ fn abort3_case2_close_at_contract_sigs_for_recvr() {
     // Case 2: Maker6102 is the Second Maker.
     // Workflow: Taker -> Maker16102 -> Maker6102 (CloseAtContractSigsForRecvr)
     //
-    // In this case, the Coinswap completes successfully since Maker6102, being the last maker, does not receive [ReqContractSigsForRecvr] from the Taker.
+    // In this case, the Coinswap completes successfully since Maker6102, being the last maker, does not receive [`ReqContractSigsForRecvr`] from the Taker.
     //
     // The Fee balance would look like `standard_swap` IT for this case.
 

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -612,11 +612,11 @@ impl TestFramework {
     /// This object holds the reference to backend bitcoind process and RPC.
     /// It takes:
     /// - bitcoind conf.
-    /// - a map of [port, [MakerBehavior]]
+    /// - a vector of mappings from (port, optional port) tuples to [`MakerBehavior`]
     /// - optional taker behavior.
     /// - connection type
     ///
-    /// Returns ([TestFramework], [Taker], [`Vec<Maker>`]).
+    /// Returns ([`TestFramework`], [`Taker`], [`Vec<Maker>`]).
     /// Maker's config will follow the pattern given the input HashMap.
     /// If no bitcoind conf is provided, a default value will be used.
     #[allow(clippy::type_complexity)]
@@ -764,7 +764,7 @@ impl TestFramework {
     }
 }
 
-/// Initializes a [TestFramework] given a [RPCConfig].
+/// Initializes a [`TestFramework`] given a [`RPCConfig`].
 impl From<&TestFramework> for RPCConfig {
     fn from(value: &TestFramework) -> Self {
         let url = value.bitcoind.rpc_url().split_at(7).1.to_string();


### PR DESCRIPTION
During local testing, I noticed that several public wallet functions lack Rustdoc documentation. This PR adds clear and concise Rustdoc comments.