### PR TITLE
Manual Selection of UTXOs Flow from Swap Params to CoinSelection

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -245,9 +245,11 @@ fn main() -> Result<(), TakerError> {
                 } => {
                     let amount = Amount::from_sat(*amount);
 
-                    let coins_to_spend = taker
-                        .get_wallet_mut()
-                        .coin_select(amount, feerate.unwrap_or(MIN_FEE_RATE))?;
+                    let coins_to_spend = taker.get_wallet_mut().coin_select(
+                        amount,
+                        feerate.unwrap_or(MIN_FEE_RATE),
+                        None,
+                    )?;
 
                     let outputs = vec![(Address::from_str(address)?.assume_checked(), amount)];
                     let destination = Destination::Multi {
@@ -291,6 +293,7 @@ fn main() -> Result<(), TakerError> {
                     let swap_params = SwapParams {
                         send_amount: Amount::from_sat(*amount),
                         maker_count: *makers,
+                        manually_selected_outpoints: None,
                     };
                     taker.do_coinswap(swap_params)?;
                 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -38,6 +38,7 @@ use crate::{
         },
         Hash160,
     },
+    taker::SwapParams,
     utill::{calculate_fee_sats, MIN_FEE_RATE, REQUIRED_CONFIRMS},
     wallet::{IncomingSwapCoin, SwapCoin, WalletError},
 };
@@ -390,7 +391,11 @@ impl Maker {
         // Create outgoing coinswap of the next hop
         let (my_funding_txes, outgoing_swapcoins, act_funding_txs_fees) = {
             self.wallet.write()?.initalize_coinswap(
-                Amount::from_sat(outgoing_amount),
+                &SwapParams {
+                    send_amount: Amount::from_sat(outgoing_amount),
+                    maker_count: 0,
+                    manually_selected_outpoints: None,
+                },
                 &message
                     .next_coinswap_info
                     .iter()

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -86,7 +86,10 @@ fn handle_request(maker: &Arc<Maker>, socket: &mut TcpStream) -> Result<(), Make
                 op_return_data: None,
             };
 
-            let coins_to_send = maker.get_wallet().read()?.coin_select(amount, feerate)?;
+            let coins_to_send = maker
+                .get_wallet()
+                .read()?
+                .coin_select(amount, feerate, None)?;
             let tx = maker.get_wallet().write()?.spend_from_wallet(
                 feerate,
                 destination,

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -335,7 +335,7 @@ impl Wallet {
     ) -> Result<u32, WalletError> {
         let (index, fidelity_addr, fidelity_pubkey) = self.get_next_fidelity_address(locktime)?;
 
-        let coins = self.coin_select(amount, feerate)?;
+        let coins = self.coin_select(amount, feerate, None)?;
         let outputs = vec![(fidelity_addr, amount)];
         let destination = Destination::Multi {
             outputs,

--- a/src/wallet/split_utxos.rs
+++ b/src/wallet/split_utxos.rs
@@ -285,7 +285,7 @@ impl Wallet {
 
             // Delta_c finds the threshold, which is used for a second coinselection
             let delta_c = target - target_change;
-            let delta_inputs = match self.coin_select(Amount::from_sat(delta_c), fee_rate) {
+            let delta_inputs = match self.coin_select(Amount::from_sat(delta_c), fee_rate, None) {
                 Ok(inputs) => inputs,
                 Err(e) => {
                     log::info!("Error other than insufficient amount during second coin selection in dynamic splitting logic: {e:?}, backtracking and returning previous state");

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -105,6 +105,7 @@ fn test_stop_taker_after_setup() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -104,6 +104,7 @@ fn test_abort_case_2_move_on_with_other_makers() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -111,6 +111,7 @@ fn test_abort_case_2_recover_if_no_makers_found() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
 
     if let Err(e) = taker.do_coinswap(swap_params) {

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -104,6 +104,7 @@ fn maker_drops_after_sending_senders_sigs() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -109,6 +109,7 @@ fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -102,6 +102,7 @@ fn abort3_case2_close_at_contract_sigs_for_recvr() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -101,6 +101,7 @@ fn abort3_case3_close_at_hash_preimage_handover() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -392,7 +392,7 @@ fn test_fidelity_spending() {
         let tx_result = {
             let mut wallet = maker.get_wallet().write().unwrap();
             let selected_utxos = wallet
-                .coin_select(Amount::from_sat(REGULAR_TX_AMOUNT), MIN_FEE_RATE)
+                .coin_select(Amount::from_sat(REGULAR_TX_AMOUNT), MIN_FEE_RATE, None)
                 .unwrap();
 
             for (_utxo, spend_info) in &selected_utxos {

--- a/tests/funding_dynamic_splits.rs
+++ b/tests/funding_dynamic_splits.rs
@@ -85,6 +85,7 @@ fn test_create_funding_txn_with_varied_distributions() {
                 target,
                 destinations.clone(),
                 Amount::from_sat(MIN_FEE_RATE as u64),
+                None,
             )
             .unwrap();
 

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -98,6 +98,7 @@ fn malice1_taker_broadcast_contract_prematurely() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -100,6 +100,7 @@ fn malice2_maker_broadcast_contract_prematurely() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 

--- a/tests/multi-taker.rs
+++ b/tests/multi-taker.rs
@@ -109,6 +109,7 @@ fn multi_taker_single_maker_swap() {
             let swap_params = SwapParams {
                 send_amount: Amount::from_sat(500000),
                 maker_count: 2,
+                manually_selected_outpoints: None,
             };
             s.spawn(move || {
                 taker.do_coinswap(swap_params).unwrap();

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -90,6 +90,7 @@ fn test_standard_coinswap() {
     let swap_params = SwapParams {
         send_amount: Amount::from_sat(500000),
         maker_count: 2,
+        manually_selected_outpoints: None,
     };
     taker.do_coinswap(swap_params).unwrap();
 


### PR DESCRIPTION
# Introduction

This PR adds the feature for supporting selection of UTXOs by the taker input for the purposes of transacting a Coinswap. It is a conjugation of 2 PRs including #576 , together defining the entire flow of user inputs.  We are using [crossterm](https://docs.rs/crate/crossterm) for the UI display in the CLI, motivations for which are given below. 

# Motivations

- First step to empower users with fine-grained control over their transactions, enabling manual UTXO selection and other customizable features to uphold cypherpunk principles of privacy, decentralization, and self-sovereignty in the Coinswap protocol.
-  **Privacy Enhancement**: Manual UTXO selection prevents unintended linking of specific inputs, enhancing privacy during Coinswap transactions by ensuring input diversity and reducing blockchain analysis risks.
- **Selective UTXO sourcing**: Allows users to choose UTXOs from specific origins (e.g., trusted wallets) to align with personal or jurisdictional requirements, while prioritizing privacy.
- **UTXO Management**: Enables users to optimize their wallet by consolidating small UTXOs or preserving specific coins, improving efficiency and reducing fees in Coinswap transactions.
-  **DX (Dev Experience) -** **Debugging**: Facilitates development and testing by allowing developers to select specific UTXO sets to simulate edge cases or validate the Coinswap protocol’s behavior.

# Manual UTXO Selection Call Flow

```text
Taker Binary (taker.rs)
└── Calls interactive selection() (from src/utils.rs)
    └── Passes `manual_utxo_outpoints`
        ↓
        SwapParams
        ↓
Taker API (api.rs)
└── do_coinswap()
    └── send_coinswap()
        └── init_first_hop()
            └── wallet.initialize_coinswap
                ↓
Wallet API (api.rs)
└── initialize_coinswap()
    └── create_funding_txes(manual_utxo_outpoints)
        └── coin_select(manual_utxo_outpoints)
            └── [UTXO selection logic happens here]
```

# Future works 

- This can be a reference for integration of other toggle-able features for user from the taker cli unto the lower level api functions. 