### PR TITLE
fix(nostr): advance discovery cursor only after successful event processing

### DIFF
--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -211,7 +211,7 @@ fn handle_relay_message(
             }
 
             if event.is_expired() || event.tags.expiration().is_none() {
-                log::debug!(
+                log::info!(
                     "Ignoring expired event or event without expiration tag from {}",
                     relay_url
                 );
@@ -222,15 +222,16 @@ fn handle_relay_message(
                 return Ok(());
             };
 
-            registry.save_nostr_cursor(relay_url, event.created_at.as_secs());
+            let tx = match bitcoin_rpc.get_raw_tx(&txid) {
+                Ok(tx) => tx,
+                Err(e) => {
+                    log::warn!("Failed to fetch raw tx {txid:?} via {relay_url}: {e}");
+                    return Ok(());
+                }
+            };
 
             if seen_txid.lock()?.insert(txid) {
-                log::debug!("add new cache {}", txid);
-                let Ok(tx) = bitcoin_rpc.get_raw_tx(&txid) else {
-                    log::debug!("Received invalid txid: {txid:?}");
-                    return Ok(());
-                };
-
+                log::info!("Added txid to Nostr discovery cache: {txid}");
                 match process_fidelity(&tx) {
                     Some(fidelity) => {
                         if registry.insert_fidelity(txid, fidelity) {
@@ -238,12 +239,13 @@ fn handle_relay_message(
                         }
                     }
                     None => {
-                        log::debug!("Invalid fidelity {txid}:{vout} via {relay_url}");
+                        log::warn!("Invalid fidelity {txid}:{vout} via {relay_url}");
                     }
                 }
             } else {
-                log::debug!("Transaction ID already present {txid} via {relay_url}")
+                log::info!("Skipping already-seen txid {txid} via {relay_url}");
             }
+            registry.save_nostr_cursor(relay_url, event.created_at.as_secs());
         }
 
         RelayMessage::EndOfStoredEvents(sub_id) => {


### PR DESCRIPTION
## Description

Small correctness fix for the watchtower's Nostr discovery path. Not responding to a reported incident, found while re-reading code around #829.

Before this PR, `handle_relay_message` in `src/watch_tower/nostr_discovery.rs` did things in this order:

1. `registry.save_nostr_cursor(relay_url, event.created_at)` persists cursor to disk
2. `seen_txid.insert(txid)` marks txid as processed
3. `bitcoin_rpc.get_raw_tx(&txid)` fetches the transaction and can fail transiently
4. early return on failure

Issue: if step 3 fails, progress was already committed. The cursor moved past the event and the txid was in the seen set. On reconnect or replay, that fidelity announcement could be skipped instead of retried.

When can step 3 realistically fail:

- bitcoind restart or upgrade
- brief RPC unavailability or network blip between watcher and bitcoind
- the tx has not propagated to the watcher's mempool yet
- REST endpoint hiccup or transient rate limit

Makers do re-broadcast fidelity events before expiry, so the protocol can self-heal over time. But relying on that leaves a blind spot where the watcher has stale bond state. The watchtower's job is reliable fidelity-bond tracking, so it should not commit progress for an event it did not actually fetch.

### What the fix does

This keeps the existing routine small, but moves the state commits later:

- fetch the raw tx first
- if the fetch fails, return without touching the seen cache or cursor
- after a successful fetch, process the event
- save the cursor only after the event has reached the processed path
- already-seen txids still advance the cursor
- logs in this routine are now `info` / `warn` instead of `debug`

### Post-fix behavior

| scenario | cursor advanced | txid marked seen |
|---|---:|---:|
| `get_raw_tx` transient fail | no | no |
| already-seen replay after successful fetch | yes | already was |
| `process_fidelity` returns `None` | yes | yes |
| happy path | yes | yes |

### Known tradeoff

Already-seen txids now fetch the raw tx before hitting the seen-cache skip. That can mean an extra RPC call for duplicate relay delivery, but it keeps the patch small and avoids adding a new helper or rollback logic in code that is already queued for refactor.

## Related Issue(s)

None. Found while auditing code around #829.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

## Protocol Version(s) Affected

- [ ] Legacy (ECDSA: `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

## Affected Component(s)

- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Testing

- [x] `cargo check`
- [x] `cargo test --lib watch_tower::`
- [x] `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings`