### PR TITLE
feat: derive Tor identity from wallet and add BIP32 bond ownership check

### DIFF
--- a/docs/taproot.md
+++ b/docs/taproot.md
@@ -143,7 +143,7 @@ PrivateKeyHandover {
 2. **Independent Sweeping**: Each party generates their own nonces and performs MuSig2 aggregation locally
 3. **No Coordination Required**: No need to exchange nonces or partial signatures between parties
 4. **Simplified Protocol**: Reduced from 16 messages to 4 messages (2 per maker)
-5. **Security Note**: Uses master-derived keys (m/0' path) - parties trust each other not to double-spend during the brief handover window
+5. **Security Note**: Uses master-derived keys (m/175' path) - parties trust each other not to double-spend during the brief handover window
 
 ## Spending Transaction Details
 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -497,7 +497,12 @@ impl MakerServer {
                 .wallet
                 .read()
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?;
-            let bond = wallet_read.store.fidelity_bond.get(&i).unwrap().clone();
+            let bond = wallet_read
+                .store
+                .fidelity_bond
+                .get(i as usize)
+                .unwrap()
+                .clone();
             let current_height = wallet_read
                 .rpc
                 .get_block_count()

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bitcoin::{Amount, Network, OutPoint, PublicKey, Transaction};
+use bitcoin::{bip32::ChainCode, Amount, Network, OutPoint, PublicKey, Transaction};
 use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
@@ -772,7 +772,7 @@ impl MakerTrait for MakerServer {
 
     fn get_tweakable_keypair(
         &self,
-    ) -> Result<(bitcoin::secp256k1::SecretKey, PublicKey), MakerError> {
+    ) -> Result<(bitcoin::secp256k1::SecretKey, PublicKey, ChainCode), MakerError> {
         let wallet = self
             .wallet
             .read()
@@ -1172,7 +1172,7 @@ impl MakerTrait for MakerServer {
         );
 
         // Full verification: multisig format, pubkeys, structure, P2WSH output
-        let (tweakable_privkey, tweakable_pubkey) = self.get_tweakable_keypair()?;
+        let (tweakable_privkey, tweakable_pubkey, _) = self.get_tweakable_keypair()?;
         super::legacy_verification::verify_req_contract_sigs_for_sender(
             txs_info,
             &tweakable_pubkey,
@@ -1299,7 +1299,7 @@ impl MakerTrait for MakerServer {
 
             check_reedemscript_is_multisig(&funding_info.multisig_redeemscript)?;
 
-            let (_, tweakable_pubkey) = wallet_read.get_tweakable_keypair()?;
+            let (_, tweakable_pubkey, _) = wallet_read.get_tweakable_keypair()?;
 
             check_multisig_has_pubkey(
                 &funding_info.multisig_redeemscript,
@@ -1519,11 +1519,18 @@ impl MakerRpc for MakerServer {
     }
 
     fn get_tor_hostname(&self) -> Result<String, crate::utill::TorError> {
+        let tor_key_bytes = self
+            .wallet
+            .read()
+            .map_err(|_| crate::utill::TorError::General("wallet lock poisoned".into()))?
+            .derive_tor_key();
+
         crate::utill::get_tor_hostname(
             &self.data_dir,
             self.config.control_port,
             self.config.network_port,
             &self.config.tor_auth_password,
+            tor_key_bytes,
         )
     }
 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::Arc, time::Instant};
 
-use bitcoin::{Amount, PublicKey, Transaction};
+use bitcoin::{bip32::ChainCode, Amount, PublicKey, Transaction};
 
 use super::error::MakerError;
 use crate::{
@@ -190,7 +190,7 @@ pub trait Maker: Send + Sync {
     /// Get the tweakable keypair for swap address derivation.
     fn get_tweakable_keypair(
         &self,
-    ) -> Result<(bitcoin::secp256k1::SecretKey, PublicKey), MakerError>;
+    ) -> Result<(bitcoin::secp256k1::SecretKey, PublicKey, ChainCode), MakerError>;
 
     /// Get the highest fidelity proof.
     fn get_fidelity_proof(&self) -> Result<FidelityProof, MakerError>;
@@ -422,7 +422,7 @@ fn handle_get_offer<M: Maker>(
         Maker::network_port(maker.as_ref())
     );
 
-    let (_, tweakable_point) = maker.get_tweakable_keypair()?;
+    let (_, tweakable_point, tweak_chain_code) = maker.get_tweakable_keypair()?;
     let fidelity = maker.get_fidelity_proof()?;
     let config = maker.get_config();
 
@@ -438,6 +438,7 @@ fn handle_get_offer<M: Maker>(
         min_size: config.min_swap_amount,
         tweakable_point,
         fidelity,
+        tweak_chain_code,
     };
 
     log::info!(
@@ -478,7 +479,7 @@ fn handle_swap_details<M: Maker>(
 
     maker.store_connection_state(&details.id, state)?;
 
-    let (_, tweakable_point) = maker.get_tweakable_keypair()?;
+    let (_, tweakable_point, _) = maker.get_tweakable_keypair()?;
 
     log::info!(
         "[{}] Accepting swap (id: {})",

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -160,7 +160,7 @@ fn process_proof_of_funding<M: Maker>(
 
     state.contract_feerate = pof.contract_feerate;
 
-    let (tweakable_privkey, _) = maker.get_tweakable_keypair()?;
+    let (tweakable_privkey, _, _) = maker.get_tweakable_keypair()?;
     let secp = bitcoin::secp256k1::Secp256k1::new();
 
     let mut incoming_swapcoins = Vec::new();

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -76,7 +76,7 @@ fn process_taproot_contract<M: Maker>(
         data.id
     );
 
-    let (tweakable_privkey, tweakable_pubkey) = maker.get_tweakable_keypair()?;
+    let (tweakable_privkey, tweakable_pubkey, _) = maker.get_tweakable_keypair()?;
     let secp = bitcoin::secp256k1::Secp256k1::new();
 
     // Use the nonce from the received message to reconstruct hashlock_privkey.

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -121,12 +121,11 @@ pub fn broadcast_bond_on_nostr(
         + EXPIRATION_SECS;
 
     log::debug!(
-        "Publishing fidelity bond to Nostr | outpoint={} amount_sats={} lock_time={} conf_height={:?} cert_expiry={:?} is_spent={} pubkey={} cert_hash={} cert_sig={:?} content={} d_tag={} expiration_unix={}",
+        "Publishing fidelity bond to Nostr | outpoint={} amount_sats={} lock_time={} conf_height={:?} is_spent={} pubkey={} cert_hash={} cert_sig={:?} content={} d_tag={} expiration_unix={}",
         fidelity.bond.outpoint,
         fidelity.bond.amount.to_sat(),
         fidelity.bond.lock_time.to_consensus_u32(),
         fidelity.bond.conf_height,
-        fidelity.bond.cert_expiry,
         fidelity.bond.is_spent,
         fidelity.bond.pubkey,
         fidelity.cert_hash,

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -1,6 +1,6 @@
 //! Common Coinswap Protocol Messages and Top-Level Message Enums.
 
-use bitcoin::{hashes::sha256d::Hash, Amount, PublicKey};
+use bitcoin::{bip32::ChainCode, hashes::sha256d::Hash, Amount, PublicKey};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -77,6 +77,8 @@ pub struct Offer {
     pub tweakable_point: PublicKey,
     /// Cryptographic proof of fidelity bond for Sybil resistance.
     pub fidelity: FidelityProof,
+    /// Chain code for deterministic derivation of swap addresses from the tweakable point.
+    pub tweak_chain_code: ChainCode,
 }
 
 /// Swap details from Taker to Maker.

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -517,6 +517,8 @@ impl OfferSyncService {
                                 &rest_backend,
                                 &oa.offer.fidelity,
                                 &oa.address.to_string(),
+                                &oa.offer.tweakable_point,
+                                &oa.offer.tweak_chain_code,
                             );
                             let mut book = offerbook.write().unwrap();
                             match verified {
@@ -639,13 +641,22 @@ fn verify_fidelity_with_backend(
     rest_backend: &BitcoinRest,
     proof: &FidelityProof,
     onion_addr: &str,
+    tweakable_point: &bitcoin::PublicKey,
+    tweak_chain_code: &bitcoin::bip32::ChainCode,
 ) -> Result<(), TakerError> {
     let txid = proof.bond.outpoint.txid;
     let transaction = rest_backend.get_raw_tx(&txid)?;
     let current_height = rest_backend.get_block_count()?;
 
-    verify_fidelity_checks(proof, onion_addr, transaction, current_height)
-        .map_err(TakerError::Wallet)
+    verify_fidelity_checks(
+        proof,
+        onion_addr,
+        transaction,
+        current_height,
+        tweakable_point,
+        tweak_chain_code,
+    )
+    .map_err(TakerError::Wallet)
 }
 
 /// An ephemeral Offerbook tracking good and bad makers. Currently, Offerbook is initiated
@@ -925,6 +936,7 @@ impl MakerAddress {
                 cert_hash: router_offer.fidelity.cert_hash,
                 cert_sig: router_offer.fidelity.cert_sig,
             },
+            tweak_chain_code: router_offer.tweak_chain_code,
         };
 
         log::info!(
@@ -976,13 +988,11 @@ mod tests {
             lock_time: LockTime::from_height(1000).expect("valid height locktime"),
             pubkey,
             conf_height: Some(1000),
-            cert_expiry: Some(1),
             is_spent: false,
+            bond_index: 0,
         };
 
-        let cert_hash = bond
-            .generate_cert_hash(maker_addr)
-            .expect("cert_expiry set");
+        let cert_hash = bond.generate_cert_hash(maker_addr, &pubkey);
         let msg = Message::from_digest_slice(cert_hash.as_byte_array()).expect("32-byte digest");
         let cert_sig = secp.sign_ecdsa(&msg, &secret_key);
 
@@ -1000,6 +1010,7 @@ mod tests {
                 cert_hash,
                 cert_sig,
             },
+            tweak_chain_code: bitcoin::bip32::ChainCode::from([0u8; 32]),
         }
     }
 

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -6,7 +6,7 @@ use bitcoin::{
     secp256k1::{Secp256k1, SecretKey},
     Address, Amount, FeeRate, Network, PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
 };
-use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
+use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, jsonrpc::base64};
 use crossterm::{
     cursor::MoveTo,
     event::{
@@ -611,33 +611,30 @@ pub fn prompt_password(message: String) -> io::Result<String> {
     Ok(password.trim_end().to_string())
 }
 
-pub(crate) fn get_emphemeral_address(
+pub(crate) fn get_ephemeral_address(
     control_port: u16,
     local_port: u16,
     password: &str,
-    private_key_data: Option<&str>,
+    private_key_data: &str,
     service_id_data: Option<&str>,
-) -> Result<(String, String), TorError> {
+) -> Result<String, TorError> {
     use crate::protocol::common_messages::COINSWAP_PORT;
     use std::io::BufRead;
     let mut stream = TcpStream::connect(format!("127.0.0.1:{control_port}"))?;
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut response = String::new();
     let mut service_id = String::new();
-    let mut private_key = String::new();
     let auth_command = format!("AUTHENTICATE \"{password}\"\r\n");
     stream.write_all(auth_command.as_bytes())?;
     if let Some(service_id) = service_id_data {
         let remove_command = format!("DEL_ONION {service_id}\r\n");
         stream.write_all(remove_command.as_bytes())?;
     }
-    let mut add_onion_command =
-        format!("ADD_ONION NEW:BEST Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n");
-    if let Some(pk) = private_key_data {
-        add_onion_command =
-            format!("ADD_ONION {pk} Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n");
-        private_key = pk.to_string();
-    }
+
+    let add_onion_command = format!(
+        "ADD_ONION {private_key_data} Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n"
+    );
+
     stream.write_all(add_onion_command.as_bytes())?;
 
     while reader.read_line(&mut response)? > 0 {
@@ -646,25 +643,17 @@ pub(crate) fn get_emphemeral_address(
                 .trim_start_matches("250-ServiceID=")
                 .trim()
                 .to_string();
-            if private_key_data.is_some() {
-                break;
-            }
-        } else if response.starts_with("250-PrivateKey=") {
-            private_key = response
-                .trim_start_matches("250-PrivateKey=")
-                .trim()
-                .to_string();
             break;
         }
         response.clear();
     }
 
-    if service_id.is_empty() || private_key.is_empty() {
+    if service_id.is_empty() {
         return Err(TorError::General(
             "Failed to retrieve ephemeral onion service details".to_string(),
         ));
     }
-    Ok((format!("{service_id}.onion"), private_key))
+    Ok(format!("{service_id}.onion"))
 }
 
 pub(crate) fn get_tor_hostname(
@@ -672,26 +661,23 @@ pub(crate) fn get_tor_hostname(
     control_port: u16,
     local_port: u16,
     password: &str,
+    tor_key: [u8; 64],
 ) -> Result<String, TorError> {
     let tor_config_path = data_dir.join("tor/hostname");
-
+    let tor_private_key = format!("ED25519-V3:{}", base64::encode(tor_key));
     if tor_config_path.exists() {
         if let Ok(tor_metadata) = fs::read(&tor_config_path) {
-            let data: [&str; 2] = serde_cbor::de::from_slice(&tor_metadata)?;
+            let hostname_data: String = serde_cbor::de::from_slice(&tor_metadata)?;
 
-            let hostname_data = data[1];
-            let private_key_data = data[0];
-
-            let (hostname, private_key) = get_emphemeral_address(
+            let hostname = get_ephemeral_address(
                 control_port,
                 local_port,
                 password,
-                Some(private_key_data),
-                Some(hostname_data.replace(".onion", "").as_str()),
+                &tor_private_key,
+                Some(hostname_data.trim_end_matches(".onion")),
             )?;
 
             assert_eq!(hostname, hostname_data);
-            assert_eq!(private_key, private_key_data);
 
             log::info!("Generated existing Tor Hidden Service Hostname: {hostname}");
 
@@ -699,17 +685,14 @@ pub(crate) fn get_tor_hostname(
         }
     }
 
-    let (hostname, private_key) =
-        get_emphemeral_address(control_port, local_port, password, None, None)?;
+    let hostname =
+        get_ephemeral_address(control_port, local_port, password, &tor_private_key, None)?;
 
     if let Some(parent) = tor_config_path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    fs::write(
-        &tor_config_path,
-        serde_cbor::ser::to_vec(&[private_key, hostname.clone()])?,
-    )?;
+    fs::write(&tor_config_path, serde_cbor::ser::to_vec(&hostname)?)?;
 
     log::info!("Generated new Tor Hidden Service Hostname: {hostname}");
 

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -188,7 +188,7 @@ impl UTXOSpendInfo {
     pub fn estimate_witness_size(&self) -> usize {
         const P2WPKH_WITNESS_SIZE: usize = 107; // 1 + 72 (sig) + 33 (pubkey) + 1 (count)
         const P2TR_WITNESS_SIZE: usize = 65; // 1 + 64 (Schnorr sig)
-        const P2WSH_MULTISIG_2OF2_WITNESS_SIZE: usize = 222;
+        const P2WSH_MULTISIG_2OF2_WITNESS_SIZE: usize = 218; //1 + 1 + 72 + 72 + 72
         const FIDELITY_BOND_WITNESS_SIZE: usize = 115;
         const TIME_LOCK_CONTRACT_TX_WITNESS_SIZE: usize = 179;
         const HASH_LOCK_CONTRACT_TX_WITNESS_SIZE: usize = 211;
@@ -1573,7 +1573,7 @@ impl Wallet {
         } = self
             .store
             .master_key
-            .derive_priv(&secp, &[ChildNumber::from_hardened_idx(0)?])?;
+            .derive_priv(&secp, &[ChildNumber::from_hardened_idx(175)?])?;
 
         let public_key = PublicKey {
             compressed: true,
@@ -1947,7 +1947,7 @@ impl Wallet {
 
         // Convert weight units to virtual bytes for fee calculation
         // Weight is divided by 4 to get vbytes (BIP 141 standard)
-        let estimated_tx_vbytes: u64 = estimated_tx_weight / 4;
+        let estimated_tx_vbytes: u64 = estimated_tx_weight.div_ceil(4);
 
         // P2WPKH input weight: OutPoint(32) + sequence(4) + vout(4) + empty_scriptsig(1) = 41 bytes
         // Weight = bytes * 4 for non-witness data = 164 WU
@@ -2250,7 +2250,7 @@ impl Wallet {
                 target_value: remaining_target,
                 target_feerate: feerate as f32 / 4.0, //sats per wu
                 long_term_feerate: Some(LONG_TERM_FEERATE),
-                min_absolute_fee: MIN_FEE_RATE as u64 * (tx_base_weight / 4),
+                min_absolute_fee: MIN_FEE_RATE as u64 * tx_base_weight.div_ceil(4),
                 base_weight: tx_base_weight,
                 change_weight: change_weight.to_wu(),
                 change_cost: cost_of_change,

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -13,7 +13,8 @@ use crate::security::KeyMaterial;
 
 use bip39::Mnemonic;
 use bitcoin::{
-    bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
+    bip32::{ChainCode, ChildNumber, DerivationPath, Xpriv, Xpub},
+    hashes::{sha512, Hash},
     key::TapTweak,
     secp256k1,
     secp256k1::{Keypair, Secp256k1, SecretKey},
@@ -1543,20 +1544,38 @@ impl Wallet {
         Ok(())
     }
 
+    //expose a deterministically-derived 64-byte Ed25519-V3 Tor key
+    // built from the wallet's master_key
+    pub(crate) fn derive_tor_key(&self) -> [u8; 64] {
+        // Hash the 32-byte secp256k1 private key bytes RFC 8032 per 5.1.5,
+        // then clamp into a valid Ed25519 expanded key.
+        let mut tor_key =
+            *sha512::Hash::hash(&self.store.master_key.private_key.secret_bytes()).as_byte_array();
+        tor_key[0] &= 248;
+        tor_key[31] &= 127;
+        tor_key[31] |= 64;
+        tor_key
+    }
+
     /// Gets a tweakable key pair from the master key of the wallet.
-    pub(crate) fn get_tweakable_keypair(&self) -> Result<(SecretKey, PublicKey), WalletError> {
+    pub(crate) fn get_tweakable_keypair(
+        &self,
+    ) -> Result<(SecretKey, PublicKey, ChainCode), WalletError> {
         let secp = Secp256k1::new();
-        let privkey = self
+        let Xpriv {
+            private_key,
+            chain_code,
+            ..
+        } = self
             .store
             .master_key
-            .derive_priv(&secp, &[ChildNumber::from_hardened_idx(0)?])?
-            .private_key;
+            .derive_priv(&secp, &[ChildNumber::from_hardened_idx(0)?])?;
 
         let public_key = PublicKey {
             compressed: true,
-            inner: privkey.public_key(&secp),
+            inner: private_key.public_key(&secp),
         };
-        Ok((privkey, public_key))
+        Ok((private_key, public_key, chain_code))
     }
 
     /// Refreshes the UTXO cache by adding only new UTXOs while preserving existing ones.

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1159,16 +1159,20 @@ impl Wallet {
 
     /// Checks if a UTXO belongs to fidelity bonds, and then returns corresponding UTXOSpendInfo
     fn check_if_fidelity(&self, utxo: &ListUnspentResultEntry) -> Option<UTXOSpendInfo> {
-        self.store.fidelity_bond.iter().find_map(|(i, bond)| {
-            if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
-                Some(UTXOSpendInfo::FidelityBondCoin {
-                    index: *i,
-                    input_value: bond.amount,
-                })
-            } else {
-                None
-            }
-        })
+        self.store
+            .fidelity_bond
+            .iter()
+            .enumerate()
+            .find_map(|(i, bond)| {
+                if bond.script_pub_key() == utxo.script_pub_key && bond.amount == utxo.amount {
+                    Some(UTXOSpendInfo::FidelityBondCoin {
+                        index: i as u32,
+                        input_value: bond.amount,
+                    })
+                } else {
+                    None
+                }
+            })
     }
 
     /// Check if a UTXO is a swept incoming swap coin based on ScriptPubkey
@@ -2373,7 +2377,7 @@ impl Wallet {
         descriptors_to_import.extend(
             self.store
                 .fidelity_bond
-                .values()
+                .iter()
                 .map(|bond| {
                     let descriptor_without_checksum = format!("raw({:x})", bond.script_pub_key());
                     Ok(format!(

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -6,6 +6,7 @@ use crate::{
 use bitcoin::{
     absolute::LockTime,
     bip32::{ChildNumber, DerivationPath},
+    consensus::encode::{serialize, VarInt},
     hashes::{sha256d, Hash},
     opcodes::all::{OP_CHECKSIGVERIFY, OP_CLTV},
     script::{Builder, Instruction},
@@ -34,7 +35,7 @@ const BOND_VALUE_EXPONENT: f64 = 1.3;
 const BOND_VALUE_INTEREST_RATE: f64 = 0.015;
 
 /// Constant representing the derivation path for fidelity addresses.
-const FIDELITY_DERIVATION_PATH: &str = "m/0'/2";
+const FIDELITY_DERIVATION_PATH: &str = "m/175'/2";
 // Fidelity Bond relative timelock in number of blocks ( 1 block ~= 10mins)
 // Must be between 12,960 (≈3 months) and 25,920 (≈6 months)
 #[cfg(not(feature = "integration-test"))]
@@ -106,7 +107,7 @@ pub(crate) fn verify_fidelity_checks(
     addr: &str,
     tx: Transaction,
     current_height: u64,
-    tweakable_point: &PublicKey, //can be sent as not referece check once
+    tweakable_point: &PublicKey,
     tweak_chain_code: &bitcoin::bip32::ChainCode,
 ) -> Result<(), WalletError> {
     // Ensure fidelity bond timelock lies within allowed range
@@ -242,7 +243,7 @@ pub struct FidelityBond {
     pub(crate) conf_height: Option<u32>,
     /// Whether this bond is spent or not.
     pub(crate) is_spent: bool,
-    /// The child index used in the HD derivation path `m/0'/2/<bond_index>`.
+    /// The child index used in the HD derivation path `m/175'/2/<bond_index>`.
     /// Note: Fidelity bonds must only be appended to the store; they should never be removed or reordered.
     pub bond_index: u32,
 }
@@ -280,7 +281,7 @@ impl FidelityBond {
         let cert_msg = cert_msg_str.as_bytes();
         let mut btc_signed_msg = Vec::<u8>::new();
         btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
-        btc_signed_msg.push(cert_msg.len() as u8);
+        btc_signed_msg.extend(serialize(&VarInt(cert_msg.len() as u64)));
         btc_signed_msg.extend(cert_msg);
 
         sha256d::Hash::hash(&btc_signed_msg)

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -35,7 +35,7 @@ const BOND_VALUE_EXPONENT: f64 = 1.3;
 const BOND_VALUE_INTEREST_RATE: f64 = 0.015;
 
 /// Constant representing the derivation path for fidelity addresses.
-const FIDELITY_DERIVATION_PATH: &str = "m/84'/0'/0'/2";
+const FIDELITY_DERIVATION_PATH: &str = "m/0'/2";
 // Fidelity Bond relative timelock in number of blocks ( 1 block ~= 10mins)
 // Must be between 12,960 (≈3 months) and 25,920 (≈6 months)
 #[cfg(not(feature = "integration-test"))]
@@ -56,7 +56,6 @@ pub enum FidelityError {
     BondDoesNotExist,
     BondAlreadyRedeemed,
     BondLocktimeExpired,
-    CertExpired,
     InvalidCertHash,
     General(String),
     InvalidBondLocktime,
@@ -72,7 +71,6 @@ impl std::fmt::Display for FidelityError {
                 write!(f, "Fidelity bond has already been redeemed")
             }
             FidelityError::BondLocktimeExpired => write!(f, "Fidelity bond locktime has expired"),
-            FidelityError::CertExpired => write!(f, "Fidelity certificate has expired"),
             FidelityError::InvalidCertHash => write!(f, "Invalid fidelity certificate hash"),
             FidelityError::InvalidBondLocktime => {
                 write!(f, "Fidelity bond locktime is outside the acceptable range")
@@ -109,6 +107,8 @@ pub(crate) fn verify_fidelity_checks(
     addr: &str,
     tx: Transaction,
     current_height: u64,
+    tweakable_point: &PublicKey, //can be sent as not referece check once
+    tweak_chain_code: &bitcoin::bip32::ChainCode,
 ) -> Result<(), WalletError> {
     // Ensure fidelity bond timelock lies within allowed range
     let bond_height = proof.bond.lock_time.to_consensus_u32()
@@ -133,12 +133,36 @@ pub(crate) fn verify_fidelity_checks(
     }
 
     // Verify certificate hash
-    let expected_cert_hash = proof
-        .bond
-        .generate_cert_hash(addr)
-        .ok_or(WalletError::Fidelity(FidelityError::BondUncomfirmed))?;
+    let expected_cert_hash = proof.bond.generate_cert_hash(addr, tweakable_point);
     if proof.cert_hash != expected_cert_hash {
         return Err(FidelityError::InvalidCertHash.into());
+    }
+
+    // Verify fidelity pubkey derivation from tweak key.
+    // Only public_key and chain_code are used in BIP32 derivation;
+    // network, depth, parent_fingerprint, child_number are metadata only.
+    let offer_xpub = bitcoin::bip32::Xpub {
+        network: bitcoin::NetworkKind::Main,
+        depth: 1,
+        parent_fingerprint: Default::default(),
+        child_number: ChildNumber::Hardened { index: 0 },
+        public_key: tweakable_point.inner,
+        chain_code: *tweak_chain_code,
+    };
+    let secp = Secp256k1::new();
+    let derived = offer_xpub.derive_pub(
+        &secp,
+        &[
+            ChildNumber::Normal { index: 2 },
+            ChildNumber::Normal {
+                index: proof.bond.bond_index,
+            },
+        ],
+    )?;
+    if derived.public_key != proof.bond.pubkey.inner {
+        return Err(WalletError::General(
+            "Bond does not belong to this tweak point".to_string(),
+        ));
     }
 
     // Validate redeem script and corresponding output scriptPubKey
@@ -153,7 +177,6 @@ pub(crate) fn verify_fidelity_checks(
     }
 
     // Verify ECDSA signature
-    let secp = Secp256k1::new();
     let cert_message = Message::from_digest_slice(proof.cert_hash.as_byte_array())?;
     secp.verify_ecdsa(&cert_message, &proof.cert_sig, &proof.bond.pubkey.inner)?;
 
@@ -218,10 +241,10 @@ pub struct FidelityBond {
     pub(crate) pubkey: PublicKey,
     // Height at which the bond was confirmed.
     pub(crate) conf_height: Option<u32>,
-    // Cert expiry denoted in multiple of difficulty adjustment period (2016 blocks)
-    pub(crate) cert_expiry: Option<u32>,
     /// Whether this bond is spent or not.
     pub(crate) is_spent: bool,
+    /// Child index at `m/0'/2/<bond_index>`; also the key in `WalletStore::fidelity_bond`.
+    pub bond_index: u32,
 }
 
 impl FidelityBond {
@@ -245,25 +268,22 @@ impl FidelityBond {
     }
 
     /// Generate the bond's certificate hash.
-    pub(crate) fn generate_cert_hash(&self, addr: &str) -> Option<sha256d::Hash> {
-        self.cert_expiry.map(|expiry| {
-            let cert_msg_str = format!(
-                "fidelity-bond-cert|{}|{}|{}|{}|{}|{}",
-                self.outpoint, self.pubkey, expiry, self.lock_time, self.amount, addr
-            );
-            let cert_msg = cert_msg_str.as_bytes();
-            let mut btc_signed_msg = Vec::<u8>::new();
-            btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
-            btc_signed_msg.push(cert_msg.len() as u8);
-            btc_signed_msg.extend(cert_msg);
+    pub(crate) fn generate_cert_hash(
+        &self,
+        addr: &str,
+        tweakable_point: &PublicKey,
+    ) -> sha256d::Hash {
+        let cert_msg_str = format!(
+            "fidelity-bond-cert|{}|{}|{}|{}|{}|{}",
+            self.outpoint, self.pubkey, self.lock_time, self.amount, addr, tweakable_point
+        );
+        let cert_msg = cert_msg_str.as_bytes();
+        let mut btc_signed_msg = Vec::<u8>::new();
+        btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
+        btc_signed_msg.push(cert_msg.len() as u8);
+        btc_signed_msg.extend(cert_msg);
 
-            sha256d::Hash::hash(&btc_signed_msg)
-        })
-    }
-
-    /// Calculate the expiry value. This depends on the bond's confirmation height
-    pub(crate) fn get_fidelity_expiry(conf_height: u32) -> u32 {
-        (conf_height + 2) /* safety buffer */ / 2016 + 5
+        sha256d::Hash::hash(&btc_signed_msg)
     }
 }
 
@@ -365,8 +385,8 @@ impl Wallet {
             .store
             .fidelity_bond
             .keys()
+            .max()
             .map(|i| *i + 1)
-            .last()
             .unwrap_or(0);
 
         let fidelity_pubkey = PublicKey {
@@ -469,10 +489,10 @@ impl Wallet {
                 amount,
                 lock_time: locktime,
                 pubkey: fidelity_pubkey,
-                // `Conf_height` & `cert_expiry` are considered None as they can't be known before the confirmation.
+                // `Conf_height` considered None as they can't be known before the confirmation.
                 conf_height: None,
-                cert_expiry: None,
                 is_spent: false,
+                bond_index: index,
             };
             self.store.fidelity_bond.insert(index, bond);
             self.save_to_disk()?;
@@ -481,21 +501,19 @@ impl Wallet {
         Ok((index, txid))
     }
 
-    /// Update the confirmation height and certificate expiry of a fidelity bond after it confirms.
+    /// Update the confirmation height of a fidelity bond after it confirms.
     #[hotpath::measure]
     pub fn update_fidelity_bond_conf_details(
         &mut self,
         index: u32,
         conf_height: u32,
     ) -> Result<(), WalletError> {
-        let cert_expiry = FidelityBond::get_fidelity_expiry(conf_height);
         let bond = self
             .store
             .fidelity_bond
             .get_mut(&index)
             .ok_or(FidelityError::BondDoesNotExist)?;
 
-        bond.cert_expiry = Some(cert_expiry);
         bond.conf_height = Some(conf_height);
 
         Ok(())
@@ -547,10 +565,9 @@ impl Wallet {
         }
 
         let fidelity_privkey = self.get_fidelity_keypair(index)?.secret_key();
+        let (_, tweakable_point, _) = self.get_tweakable_keypair()?;
 
-        let cert_hash = bond
-            .generate_cert_hash(maker_addr)
-            .expect("Bond is not yet confirmed");
+        let cert_hash = bond.generate_cert_hash(maker_addr, &tweakable_point);
 
         let secp = Secp256k1::new();
         let cert_sig = secp.sign_ecdsa_low_r(

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -15,7 +15,6 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::RpcApi;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -161,7 +160,7 @@ pub(crate) fn verify_fidelity_checks(
     )?;
     if derived.public_key != proof.bond.pubkey.inner {
         return Err(WalletError::General(
-            "Bond does not belong to this tweak point".to_string(),
+            "Fidelity bond does not correspond to the provided tweak point".to_string(),
         ));
     }
 
@@ -243,7 +242,8 @@ pub struct FidelityBond {
     pub(crate) conf_height: Option<u32>,
     /// Whether this bond is spent or not.
     pub(crate) is_spent: bool,
-    /// Child index at `m/0'/2/<bond_index>`; also the key in `WalletStore::fidelity_bond`.
+    /// The child index used in the HD derivation path `m/0'/2/<bond_index>`.
+    /// Note: Fidelity bonds must only be appended to the store; they should never be removed or reordered.
     pub bond_index: u32,
 }
 
@@ -290,7 +290,7 @@ impl FidelityBond {
 // Wallet APIs related to fidelity bonds.
 impl Wallet {
     /// Get a reference to the fidelity bond store
-    pub fn get_fidelity_bonds(&self) -> &HashMap<u32, FidelityBond> {
+    pub fn get_fidelity_bonds(&self) -> &Vec<FidelityBond> {
         &self.store.fidelity_bond
     }
 
@@ -300,6 +300,7 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
+            .enumerate()
             .map(|(index, bond)| {
                 let mut bond_info = serde_json::json!({
                         "index": index,
@@ -328,12 +329,13 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
+            .enumerate()
             .filter_map(|(i, bond)| {
                 if !bond.is_spent {
                     match self.calculate_bond_value(bond) {
                         Ok(v) => {
                             log::info!("Fidelity Bond found | Index: {i} | Bond Value : {v}");
-                            Some((i, v))
+                            Some((i as u32, v))
                         }
                         Err(e) => {
                             log::error!("Fidelity valuation failed for index {i}:  {e:?} ");
@@ -345,7 +347,7 @@ impl Wallet {
                 }
             })
             .max_by(|a, b| a.1.cmp(&b.1))
-            .map(|(i, _)| *i))
+            .map(|(i, _)| i))
     }
 
     /// Get the [`Keypair`] for the fidelity bond at given index.
@@ -368,7 +370,7 @@ impl Wallet {
         let bond = self
             .store
             .fidelity_bond
-            .get(&index)
+            .get(index as usize)
             .ok_or(FidelityError::BondDoesNotExist)?;
         Ok(bond.redeem_script())
     }
@@ -381,13 +383,7 @@ impl Wallet {
     ) -> Result<(u32, Address, PublicKey), WalletError> {
         // Check what was the last fidelity address index.
         // Derive a fidelity address
-        let next_index = self
-            .store
-            .fidelity_bond
-            .keys()
-            .max()
-            .map(|i| *i + 1)
-            .unwrap_or(0);
+        let next_index = self.store.fidelity_bond.len() as u32;
 
         let fidelity_pubkey = PublicKey {
             compressed: true,
@@ -489,12 +485,12 @@ impl Wallet {
                 amount,
                 lock_time: locktime,
                 pubkey: fidelity_pubkey,
-                // `Conf_height` considered None as they can't be known before the confirmation.
+                // `conf_height` is None because it can't be known before confirmation.
                 conf_height: None,
                 is_spent: false,
                 bond_index: index,
             };
-            self.store.fidelity_bond.insert(index, bond);
+            self.store.fidelity_bond.push(bond);
             self.save_to_disk()?;
         }
 
@@ -511,7 +507,7 @@ impl Wallet {
         let bond = self
             .store
             .fidelity_bond
-            .get_mut(&index)
+            .get_mut(index as usize)
             .ok_or(FidelityError::BondDoesNotExist)?;
 
         bond.conf_height = Some(conf_height);
@@ -531,9 +527,10 @@ impl Wallet {
             .store
             .fidelity_bond
             .iter()
-            .filter_map(|(&i, bond)| {
+            .enumerate()
+            .filter_map(|(i, bond)| {
                 if !bond.is_spent && curr_height > bond.lock_time.to_consensus_u32() {
-                    Some(i)
+                    Some(i as u32)
                 } else {
                     None
                 }
@@ -558,7 +555,7 @@ impl Wallet {
         let bond = self
             .store
             .fidelity_bond
-            .get(&index)
+            .get(index as usize)
             .ok_or(FidelityError::BondDoesNotExist)?;
         if bond.is_spent {
             return Err(FidelityError::BondAlreadyRedeemed.into());

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -274,7 +274,7 @@ impl Wallet {
                 };
                 tx.output.push(txout);
                 let base_size = tx.base_size();
-                let vsize = (base_size * 4 + total_witness_size).div_ceil(4);
+                let vsize = (base_size * 4 + total_witness_size + 2).div_ceil(4); // base * 4 + witness size + marker + flag
 
                 let fee = Amount::from_sat(calculate_fee_sats(vsize as u64));
 
@@ -328,7 +328,7 @@ impl Wallet {
                 });
 
                 let base_wchange = tx_wchange.base_size();
-                let vsize_wchange = (base_wchange * 4 + total_witness_size).div_ceil(4);
+                let vsize_wchange = (base_wchange * 4 + total_witness_size + 2).div_ceil(4); // base * 4 + witness size + marker + flag
 
                 let fee_wchange = Amount::from_sat(calculate_fee_sats(vsize_wchange as u64));
 
@@ -423,17 +423,17 @@ impl Wallet {
                 }
 
                 let base_wchange = tx_wchange.base_size();
-                let vsize_wchange = (base_wchange * 4 + total_witness_size).div_ceil(4);
+                let vsize_wchange = (base_wchange * 4 + total_witness_size + 2).div_ceil(4); // base * 4 + witness size + marker + flag
 
                 let fee_wchange = Amount::from_sat(calculate_fee_sats(vsize_wchange as u64));
 
-                let individual_fee_wchange = fee_wchange / change_chunks.len() as u64;
+                let individual_base_fee = fee_wchange.to_sat() / change_chunks.len() as u64;
+                let remainder = fee_wchange.to_sat() % change_chunks.len() as u64;
 
                 for (i, change_chunk) in change_chunks.iter().enumerate() {
                     // Distributing the change fee across the individual changes.
-                    let change = Amount::from_sat(
-                        change_chunk.saturating_sub(individual_fee_wchange.to_sat()),
-                    );
+                    let this_fee = individual_base_fee + if (i as u64) < remainder { 1 } else { 0 };
+                    let change = Amount::from_sat(change_chunk.saturating_sub(this_fee));
                     if change > internal_spks[i].script_pubkey().minimal_non_dust() {
                         tx.output.push(TxOut {
                             script_pubkey: internal_spks[i].script_pubkey(),
@@ -452,20 +452,6 @@ impl Wallet {
         }
 
         self.sign_transaction(&mut tx, coins.iter().map(|(_, usi)| usi.clone()))?;
-        let calc_vsize = (tx.base_size() * 4 + total_witness_size).div_ceil(4);
-        let signed_tx_vsize = tx.vsize();
-
-        // As signature size can vary between 71-73 bytes we have a tolerance
-        let tolerance_per_input = 2; // Allow a 2-byte difference per input
-        let total_tolerance = tolerance_per_input * tx.input.len();
-
-        assert!(
-            (calc_vsize as isize - signed_tx_vsize as isize).abs() <= total_tolerance as isize,
-            "Calculated vsize {} didn't match signed tx vsize {} (tolerance: {})",
-            calc_vsize,
-            signed_tx_vsize,
-            total_tolerance
-        );
 
         // The actual fee is the difference between the sum of output amounts from the total input amount
         let total_output_value = tx
@@ -485,6 +471,14 @@ impl Wallet {
             actual_fee.to_sat(),
             actual_feerate
         );
+
+        if actual_feerate < feerate as f32 {
+            log::warn!(
+                "Actual feerate {:.2} sat/vB is below requested {:.2} sat/vB",
+                actual_feerate,
+                feerate
+            );
+        }
 
         Ok(tx)
     }

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -93,7 +93,7 @@ impl Wallet {
         let bond = self
             .store
             .fidelity_bond
-            .get(&idx)
+            .get(idx as usize)
             .ok_or(FidelityError::BondDoesNotExist)?;
 
         if bond.is_spent {
@@ -128,7 +128,7 @@ impl Wallet {
                 let bond = self
                     .store
                     .fidelity_bond
-                    .get_mut(&idx)
+                    .get_mut(idx as usize)
                     .ok_or(FidelityError::BondDoesNotExist)?;
                 bond.is_spent = true;
 
@@ -148,7 +148,7 @@ impl Wallet {
             let bond = self
                 .store
                 .fidelity_bond
-                .get_mut(&idx)
+                .get_mut(idx as usize)
                 .ok_or(FidelityError::BondDoesNotExist)?;
 
             bond.is_spent = true;
@@ -206,7 +206,7 @@ impl Wallet {
                     let bond = self
                         .store
                         .fidelity_bond
-                        .get(index)
+                        .get(*index as usize)
                         .ok_or(FidelityError::BondDoesNotExist)?;
                     if bond.is_spent {
                         return Err(FidelityError::BondAlreadyRedeemed.into());

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -56,8 +56,8 @@ pub(crate) struct WalletStore {
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
     /// Set of swept incoming swap coin scriptpubkeys to prevent mixing with regular UTXOs
     pub(crate) swept_incoming_swapcoins: HashSet<ScriptBuf>,
-    /// Map for all the fidelity bond information.
-    pub(crate) fidelity_bond: HashMap<u32, FidelityBond>,
+    /// List of all fidelity bonds.
+    pub(crate) fidelity_bond: Vec<FidelityBond>,
     pub(super) last_synced_height: Option<u64>,
 
     pub(super) wallet_birthday: Option<u64>,
@@ -88,7 +88,7 @@ impl WalletStore {
             watchonly_swapcoins: HashMap::new(),
             prevout_to_contract_map: HashMap::new(),
             swept_incoming_swapcoins: HashSet::new(),
-            fidelity_bond: HashMap::new(),
+            fidelity_bond: Vec::new(),
             last_synced_height: None,
             wallet_birthday,
             utxo_cache: HashMap::new(),

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -97,7 +97,7 @@ fn test_fidelity() {
 
         let bond = wallet_read
             .get_fidelity_bonds()
-            .get(&highest_bond_index)
+            .get(highest_bond_index as usize)
             .unwrap();
         let bond_value = wallet_read.calculate_bond_value(bond).unwrap();
         // Bond value depends on wall-clock time and regtest block timing,
@@ -110,7 +110,7 @@ fn test_fidelity() {
 
         let bond = wallet_read
             .get_fidelity_bonds()
-            .get(&highest_bond_index)
+            .get(highest_bond_index as usize)
             .unwrap();
         assert_eq!(bond.amount, Amount::from_sat(5000000));
         assert!(!bond.is_spent());
@@ -161,7 +161,10 @@ fn test_fidelity() {
         let highest_bond_index = wallet_read.get_highest_fidelity_index().unwrap().unwrap();
         assert_eq!(highest_bond_index, index);
 
-        let bond = wallet_read.get_fidelity_bonds().get(&index).unwrap();
+        let bond = wallet_read
+            .get_fidelity_bonds()
+            .get(index as usize)
+            .unwrap();
         assert_eq!(bond.amount, Amount::from_sat(8000000));
         assert!(!bond.is_spent());
 
@@ -371,7 +374,10 @@ fn test_fidelity_spending() {
             );
         }
 
-        let bond = wallet.get_fidelity_bonds().get(&fidelity_index).unwrap();
+        let bond = wallet
+            .get_fidelity_bonds()
+            .get(fidelity_index as usize)
+            .unwrap();
         if bond.is_spent() {
             panic!(
                 "FAILED: Fidelity bond was marked as consumed by regular transaction #{}!",
@@ -483,7 +489,10 @@ fn test_fidelity_spending() {
             );
         }
 
-        let bond = wallet.get_fidelity_bonds().get(&fidelity_index).unwrap();
+        let bond = wallet
+            .get_fidelity_bonds()
+            .get(fidelity_index as usize)
+            .unwrap();
         assert!(
             bond.is_spent(),
             "Fidelity bond should be spent after redemption"
@@ -533,7 +542,7 @@ fn test_fidelity_spending() {
         let wallet = maker.wallet.read().unwrap();
         let new_bond = wallet
             .get_fidelity_bonds()
-            .get(&new_fidelity_index)
+            .get(new_fidelity_index as usize)
             .unwrap();
         assert!(!new_bond.is_spent(), "New fidelity bond should be unspent");
     }

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -66,7 +66,7 @@ fn test_fidelity() {
     thread::sleep(Duration::from_secs(6));
 
     let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
-    test_framework.assert_log("Send at least 0.01000424 BTC to", &log_path);
+    test_framework.assert_log("Send at least 0.01000426 BTC to", &log_path);
 
     log::info!("Adding sufficient funds for fidelity bond creation");
     // Provide the Maker with more funds.
@@ -252,7 +252,7 @@ fn test_fidelity() {
         let balances = wallet_read.get_balances().unwrap();
 
         assert_eq!(balances.fidelity.to_sat(), 0);
-        assert_eq!(balances.regular.to_sat(), 103998830);
+        assert_eq!(balances.regular.to_sat(), 103998826);
     }
 
     thread::sleep(Duration::from_secs(10));

--- a/tests/integration/fidelity_renewal.rs
+++ b/tests/integration/fidelity_renewal.rs
@@ -54,7 +54,7 @@ fn test_fidelity_auto_renewal() {
         );
 
         let idx = highest_index.unwrap();
-        let bond = wallet_read.get_fidelity_bonds().get(&idx).unwrap();
+        let bond = wallet_read.get_fidelity_bonds().get(idx as usize).unwrap();
         let locktime = bond.lock_time.to_consensus_u32();
 
         log::info!(
@@ -123,7 +123,7 @@ fn test_fidelity_auto_renewal() {
         // Check if original bond was redeemed (marked as spent)
         let original_bond = wallet_read
             .get_fidelity_bonds()
-            .get(&initial_bond_index)
+            .get(initial_bond_index as usize)
             .unwrap();
         let original_spent = original_bond.is_spent();
 

--- a/tests/integration/funding_dynamic_splits.rs
+++ b/tests/integration/funding_dynamic_splits.rs
@@ -155,10 +155,10 @@ fn test_create_funding_txn_with_varied_distributions() {
             outputs.len()
         );
 
-        // Assert Fee is less than 98% of the expected Fee Rate or equal to MIN_FEE_RATE.
+        // Assert the actual fee rate meets or exceeds MIN_FEE_RATE.
         assert!(
-            actual_feerate > MIN_FEE_RATE * 0.98 || actual_fee == MIN_FEE_RATE as u64,
-            "Fee rate ({}) is not less than 98% of MIN_FEE_RATE ({}) or fee is not equal to MIN_FEE_RATE",
+            actual_feerate >= MIN_FEE_RATE,
+            "Fee rate {} is below MIN_FEE_RATE {}",
             actual_feerate,
             MIN_FEE_RATE
         );

--- a/tests/integration/utxo_behavior.rs
+++ b/tests/integration/utxo_behavior.rs
@@ -348,7 +348,7 @@ fn test_separated_utxo_coin_selection() {
             } => {
                 println!("Correctly failed with InsufficientFund");
                 println!("   Available: {available} sats, Required: {required} sats");
-                assert_eq!(*required, target_3.to_sat() + 424); // Should include 424 sats estimated fee
+                assert_eq!(*required, target_3.to_sat() + 426); // Should include 426 sats estimated fee
                 assert_eq!(*available, balances.swap.to_sat());
                 println!("Confirmed: Only swap balance reported in insufficient funds error");
             }


### PR DESCRIPTION
# Pull Request

## Description
- Maker's .onion address is now derived deterministically from the wallet master key.
- Fidelity verification now confirms the bond pubkey descends from the maker's tweakable_point + chain_code at m/0'/2/<bond_index>, preventing a maker from presenting a bond that belongs to a different identity.
- Removes cert_expiry
- Exposes ChainCode from get_tweakable_keypair and includes it in Offer messages for taker-side verification.

##### BUG fix: next index value
- Replace hashmap with a vector

##### Fix: correct weight feerate calculations
- Add missing segwit marker+flag (+2 WU) to all vsize estimates in spend.rs
- Use div_ceil(4) instead of integer division for weight→vbytes conversions
- Fix P2WSH 2-of-2 witness size constant (222→218)
- Use VarInt encoding for fidelity cert message length (was truncating at >127 bytes)
- Distribute change fees with proper remainder handling across outputs
- remove tolerance assert
- change tweak key derivation path from m/0' to m/175'

## Related Issue(s)
Closes #849 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [x] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap offers include a tweak chain code for deterministic address derivation and fidelity verification.
  * Tor onion hostname is deterministically derived from wallet key material and stored as hostname only.

* **Refactor**
  * Fidelity bonds migrated to an indexed list; verification, proof generation, redemption, and lookups use bond indices and tweak-derived checks.
  * Keypair APIs extended to expose tweak chain code.

* **Chores**
  * Nostr debug logging simplified (removed certificate-expiry field).

* **Tests**
  * Integration and unit fixtures updated for indexed fidelity bonds, tweak chain codes, and tightened fee assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->