### PR TITLE
[Loupe Finding] Harden maker Taproot contract validation

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -924,28 +924,31 @@ impl MakerTrait for MakerServer {
 
     #[hotpath::measure]
     fn verify_contract_tx_on_chain(&self, txid: &bitcoin::Txid) -> Result<(), MakerError> {
-        // The taker broadcasts the contract tx before sending us the contract
-        // data, but there can be a brief delay before our bitcoind sees it in
-        // the mempool. Retry a few times before giving up.
+        // QA: A mempool-only contract may be replaced via RBF after the maker
+        // funds the next hop. Require at least one confirmation before proceeding.
         const MAX_ATTEMPTS: u32 = 12;
         const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+        let required_confirms = self.config.required_confirms.max(1);
 
         for attempt in 0..MAX_ATTEMPTS {
-            let seen = {
+            let confirmed = {
                 let wallet = self
                     .wallet
                     .read()
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?;
-                wallet.rpc.get_raw_transaction(txid, None).is_ok()
+                wallet
+                    .rpc
+                    .get_raw_transaction_info(txid, None)
+                    .is_ok_and(|info| info.confirmations.unwrap_or(0) >= required_confirms)
             };
 
-            if seen {
+            if confirmed {
                 return Ok(());
             }
 
             if attempt + 1 < MAX_ATTEMPTS {
                 log::info!(
-                    "Contract tx {} not yet visible (attempt {}/{}), retrying in {}s",
+                    "Contract tx {} not yet confirmed (attempt {}/{}), retrying in {}s",
                     txid,
                     attempt + 1,
                     MAX_ATTEMPTS,
@@ -956,7 +959,7 @@ impl MakerTrait for MakerServer {
         }
 
         Err(MakerError::General(
-            "Incoming contract tx not found on-chain",
+            "Incoming contract tx does not have the required confirmations",
         ))
     }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -255,7 +255,7 @@ pub trait Maker: Send + Sync {
     /// Get the current block height from the Bitcoin node.
     fn get_current_height(&self) -> Result<u32, MakerError>;
 
-    /// Verify that a contract transaction is on-chain or in the mempool.
+    /// Verify that a contract transaction has the required on-chain confirmations.
     fn verify_contract_tx_on_chain(&self, txid: &bitcoin::Txid) -> Result<(), MakerError>;
 
     /// Verify and sign sender's contract transactions.

--- a/src/maker/taproot_verification.rs
+++ b/src/maker/taproot_verification.rs
@@ -45,35 +45,73 @@ pub(crate) fn verify_taproot_contract_data(
         MakerError::General(format!("Taproot hashlock script is invalid: {:?}", e).leak())
     })?;
 
-    let hashlock_instruction_count = data.hashlock_script.instructions().count();
-    if hashlock_instruction_count != 5 {
+    let hashlock_instructions = data
+        .hashlock_script
+        .instructions()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            MakerError::General(format!("Taproot hashlock script parse error: {:?}", e).leak())
+        })?;
+    if hashlock_instructions.len() != 5 {
         return Err(MakerError::General(
             format!(
                 "Taproot hashlock script has {} instructions, expected 5",
-                hashlock_instruction_count
+                hashlock_instructions.len()
             )
             .leak(),
+        ));
+    }
+    if !matches!(
+        hashlock_instructions.as_slice(),
+        [
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_SHA256),
+            bitcoin::script::Instruction::PushBytes(hash),
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_EQUALVERIFY),
+            bitcoin::script::Instruction::PushBytes(pubkey),
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CHECKSIG),
+        ] if hash.len() == 32 && pubkey.len() == 32
+    ) {
+        return Err(MakerError::General(
+            "Taproot hashlock script has unexpected template",
         ));
     }
 
     // Verify timelock script has expected format (5 instructions):
     // <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG
-    let timelock_instruction_count = data.timelock_script.instructions().count();
-    if timelock_instruction_count != 5 {
+    let timelock_instructions = data
+        .timelock_script
+        .instructions()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            MakerError::General(format!("Taproot timelock script parse error: {:?}", e).leak())
+        })?;
+    if timelock_instructions.len() != 5 {
         return Err(MakerError::General(
             format!(
                 "Taproot timelock script has {} instructions, expected 5",
-                timelock_instruction_count
+                timelock_instructions.len()
             )
             .leak(),
         ));
     }
+    if !matches!(
+        timelock_instructions.as_slice(),
+        [
+            _,
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CLTV),
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_DROP),
+            bitcoin::script::Instruction::PushBytes(pubkey),
+            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CHECKSIG),
+        ] if pubkey.len() == 32
+    ) {
+        return Err(MakerError::General(
+            "Taproot timelock script has unexpected template",
+        ));
+    }
 
     // Extract and validate the timelock value from the timelock script
-    let maker_locktime_val: u64 = if let Some(first) = data.timelock_script.instructions().next() {
-        match first.map_err(|e| {
-            MakerError::General(format!("Taproot timelock script parse error: {:?}", e).leak())
-        })? {
+    let maker_locktime_val: u64 = if let Some(first) = timelock_instructions.first() {
+        match first {
             bitcoin::script::Instruction::PushBytes(locktime_bytes) => {
                 let bytes = locktime_bytes.as_bytes();
                 if bytes.is_empty() {
@@ -134,7 +172,7 @@ pub(crate) fn verify_taproot_contract_data(
     }
 
     let secp = Secp256k1::verification_only();
-    let expected_spk = {
+    let (expected_spk, expected_tap_tweak) = {
         let builder = bitcoin::taproot::TaprootBuilder::new()
             .add_leaf(1, data.hashlock_script.clone())
             .map_err(|e| {
@@ -151,8 +189,16 @@ pub(crate) fn verify_taproot_contract_data(
         let tap_info = builder.finalize(&secp, data.internal_key).map_err(|e| {
             MakerError::General(format!("Taproot tree finalization failed: {:?}", e).leak())
         })?;
-        bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key())
+        (
+            bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key()),
+            tap_info.tap_tweak().to_scalar(),
+        )
     };
+    if data.tap_tweak_scalar()? != expected_tap_tweak {
+        return Err(MakerError::General(
+            "Taproot tap tweak does not match internal key and script tree",
+        ));
+    }
 
     for (i, tx) in data.contract_txs.iter().enumerate() {
         if tx.input.is_empty() {
@@ -163,6 +209,15 @@ pub(crate) fn verify_taproot_contract_data(
         if tx.output.is_empty() {
             return Err(MakerError::General(
                 format!("Taproot contract tx {} has no outputs", i).leak(),
+            ));
+        }
+        if data.amounts[i] != tx.output[0].value {
+            return Err(MakerError::General(
+                format!(
+                    "Taproot contract tx {} amount {} does not match output value {}",
+                    i, data.amounts[i], tx.output[0].value
+                )
+                .leak(),
             ));
         }
         if tx.output[0].script_pubkey != expected_spk {
@@ -230,4 +285,155 @@ pub(crate) fn verify_taproot_privkey_handover(
         privkeys.len()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{
+        absolute::LockTime,
+        hashes::Hash,
+        opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP, OP_DUP, OP_EQUALVERIFY},
+        script, transaction, Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+
+    use crate::protocol::{
+        contract2::{create_hashlock_script, create_timelock_script},
+        taproot_messages::SerializableScalar,
+    };
+
+    const MAKER_TIMELOCK: u32 = 300;
+
+    fn keypair(byte: u8) -> bitcoin::secp256k1::Keypair {
+        let secp = Secp256k1::new();
+        let secret = bitcoin::secp256k1::SecretKey::from_slice(&[byte; 32]).unwrap();
+        bitcoin::secp256k1::Keypair::from_secret_key(&secp, &secret)
+    }
+
+    fn output_script(
+        internal_key: bitcoin::secp256k1::XOnlyPublicKey,
+        hashlock_script: bitcoin::ScriptBuf,
+        timelock_script: bitcoin::ScriptBuf,
+    ) -> (bitcoin::ScriptBuf, SerializableScalar) {
+        let secp = Secp256k1::new();
+        let tap_info = bitcoin::taproot::TaprootBuilder::new()
+            .add_leaf(1, hashlock_script)
+            .unwrap()
+            .add_leaf(1, timelock_script)
+            .unwrap()
+            .finalize(&secp, internal_key)
+            .unwrap();
+        (
+            bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key()),
+            SerializableScalar::from_bytes(tap_info.tap_tweak().to_scalar().to_be_bytes().to_vec()),
+        )
+    }
+
+    fn contract_tx(script_pubkey: bitcoin::ScriptBuf, amount: Amount) -> Transaction {
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: amount,
+                script_pubkey,
+            }],
+        }
+    }
+
+    fn valid_contract_data() -> TaprootContractData {
+        let internal_key = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&keypair(1)).0;
+        let script_key = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&keypair(2)).0;
+        let hash = [7u8; 32];
+        let hashlock_script = create_hashlock_script(&hash, &script_key);
+        let timelock = LockTime::from_height(MAKER_TIMELOCK + REFUND_LOCKTIME_STEP as u32).unwrap();
+        let timelock_script = create_timelock_script(timelock, &script_key);
+        let amount = Amount::from_sat(50_000);
+        let (script_pubkey, tap_tweak) = output_script(
+            internal_key,
+            hashlock_script.clone(),
+            timelock_script.clone(),
+        );
+
+        TaprootContractData::new(
+            "test-swap".to_string(),
+            Vec::new(),
+            bitcoin::PublicKey::new(bitcoin::secp256k1::PublicKey::from_keypair(&keypair(3))),
+            internal_key,
+            tap_tweak,
+            hashlock_script,
+            timelock_script,
+            vec![contract_tx(script_pubkey, amount)],
+            vec![amount],
+            None,
+            None,
+        )
+    }
+
+    fn refresh_output_script(data: &mut TaprootContractData) {
+        let (script_pubkey, tap_tweak) = output_script(
+            data.internal_key,
+            data.hashlock_script.clone(),
+            data.timelock_script.clone(),
+        );
+        data.contract_txs[0].output[0].script_pubkey = script_pubkey;
+        data.tap_tweak = tap_tweak;
+    }
+
+    #[test]
+    fn rejects_amount_that_does_not_match_contract_output() {
+        let mut data = valid_contract_data();
+        data.amounts[0] += Amount::from_sat(1);
+
+        assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_hashlock_script_with_wrong_template() {
+        let mut data = valid_contract_data();
+        let script_key = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&keypair(2)).0;
+        data.hashlock_script = script::Builder::new()
+            .push_opcode(OP_DUP)
+            .push_slice([7u8; 32])
+            .push_opcode(OP_EQUALVERIFY)
+            .push_x_only_key(&script_key)
+            .push_opcode(OP_CHECKSIG)
+            .into_script();
+        refresh_output_script(&mut data);
+
+        assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_timelock_script_with_wrong_template() {
+        let mut data = valid_contract_data();
+        let script_key = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&keypair(2)).0;
+        let timelock = LockTime::from_height(MAKER_TIMELOCK + REFUND_LOCKTIME_STEP as u32).unwrap();
+        data.timelock_script = script::Builder::new()
+            .push_lock_time(timelock)
+            .push_opcode(OP_DROP)
+            .push_opcode(OP_CLTV)
+            .push_x_only_key(&script_key)
+            .push_opcode(OP_CHECKSIG)
+            .into_script();
+        refresh_output_script(&mut data);
+
+        assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_tap_tweak_that_does_not_match_script_tree() {
+        let mut data = valid_contract_data();
+        data.tap_tweak = SerializableScalar::from_bytes([1u8; 32].to_vec());
+
+        assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
+    }
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -2428,6 +2428,8 @@ pub enum TakerBehavior {
     CloseAtAckResponse,
     /// Close connection when sending sender's contract data (taproot taker abort).
     CloseAtSendersContract,
+    /// Send a Taproot contract amount that does not match the transaction output.
+    InvalidTaprootContractAmount,
     /// Close connection when receiving maker's contract data response (taproot taker abort).
     CloseAtSendersContractFromMaker,
 }

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -215,6 +215,14 @@ impl Taker {
                 Self::exchange_build_from_response(&received_contracts[i - 1])
             };
 
+            #[cfg(feature = "integration-test")]
+            let amounts =
+                if self.behavior == super::api::TakerBehavior::InvalidTaprootContractAmount {
+                    vec![Amount::from_sat(50_000); amounts.len()]
+                } else {
+                    amounts
+                };
+
             let secp = Secp256k1::new();
             let my_privkey = SecretKey::new(&mut OsRng);
             let my_pubkey = PublicKey {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -39,4 +39,5 @@ mod liquidity_test;
 mod offerbook_sync_race;
 mod taker_cli;
 mod taproot_concurrent_takers;
+mod taproot_contract_validation;
 mod utxo_behavior;

--- a/tests/integration/taproot_contract_validation.rs
+++ b/tests/integration/taproot_contract_validation.rs
@@ -1,0 +1,87 @@
+//! Integration tests for maker-side Taproot contract data validation.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use log::warn;
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+#[test]
+fn test_taproot_maker_rejects_contract_amount_mismatch() {
+    warn!("Running Test: Taproot maker rejects mismatched contract amount");
+
+    let makers_config_map = vec![(7202, Some(19161)), (17202, Some(19162))];
+    let taker_behavior = vec![TakerBehavior::InvalidTaprootContractAmount];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || {
+                start_server(maker_clone).unwrap();
+            })
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_coinswap(swap_params)
+        .expect("Taproot swap preparation should succeed before contract validation");
+    let swap_result = taker.start_coinswap(&summary.swap_id);
+    assert!(
+        swap_result.is_err(),
+        "Taproot swap should fail when taker lies about contract amount"
+    );
+
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    test_framework.assert_log("does not match output value", &log_path);
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    drop(takers);
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}


### PR DESCRIPTION
# Pull Request

## Description
This PR hardens maker-side validation of taker-provided Taproot contract data before the maker funds its outgoing side.

The maker now rejects Taproot contract data when:
- the claimed contract amount does not match the actual contract transaction output value
- the hashlock script does not exactly match the expected Taproot hashlock template
- the timelock script does not exactly match the expected Taproot timelock template
- the supplied tap tweak does not match the internal key and script tree

## Testing

- Added unit tests for malformed Taproot contract data.
- Added an integration-test-only taker behavior that sends a mismatched contract amount.

## Related Issue(s)
Fixes #862 + more validation checks as described above.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [x] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)


## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
`cargo test maker::taproot_verification::tests --lib`
`cargo test --features integration-test test_taproot_maker_rejects_contract_amount_mismatch -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Taproot contract validation to more strictly verify script structure, expected Taproot tweak, and that each contract amount matches the corresponding transaction output.
  * Ensured makers wait for the required on-chain confirmations for contract transactions (not just mempool appearance).

* **Tests**
  * Added integration tests covering rejection of contract amount mismatches, malformed hashlock/timelock scripts, and Taproot tweak mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->