### PR TITLE
[Loupe Finding] Validate fidelity bond amount against chain output

### DIFF
--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -175,6 +175,9 @@ pub(crate) fn verify_fidelity_checks(
     if tx_out.script_pubkey != derived_script_pubkey {
         return Err(WalletError::Fidelity(FidelityError::BondDoesNotExist));
     }
+    // QA: A maker could advertise a larger bond amount than the output actually
+    // locks, inflating its fidelity value and offer ranking. Bind the signed
+    // proof amount to the real chain output before accepting the bond.
     if tx_out.value != proof.bond.amount {
         return Err(WalletError::Fidelity(FidelityError::General(format!(
             "Bond amount mismatch: expected {}, actual {}",

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -175,6 +175,12 @@ pub(crate) fn verify_fidelity_checks(
     if tx_out.script_pubkey != derived_script_pubkey {
         return Err(WalletError::Fidelity(FidelityError::BondDoesNotExist));
     }
+    if tx_out.value != proof.bond.amount {
+        return Err(WalletError::Fidelity(FidelityError::General(format!(
+            "Bond amount mismatch: expected {}, actual {}",
+            proof.bond.amount, tx_out.value
+        ))));
+    }
 
     // Verify ECDSA signature
     let cert_message = Message::from_digest_slice(proof.cert_hash.as_byte_array())?;


### PR DESCRIPTION
# Pull Request

## Description
Fixes a small issue, that is maker’s advertised fidelity amount should equals `txout.value` . 
Otherwise a maker can lock a small output but advertise a larger bond, weakening taker-side Sybil resistance and offer selection. 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fidelity bond validation now verifies that the bond output amount exactly matches the declared proof amount. If there’s a mismatch, the validation fails with an error, helping detect incorrect or tampered bond amounts earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->