### PR TITLE
Add fidelity outpoint to offer

### DIFF
--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -19,6 +19,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 
@@ -97,6 +98,9 @@ pub struct MakerOfferCandidate {
     /// Maker address (hostname)
     pub address: MakerAddress,
 
+    /// Fidelity bond outpoint (txid from registry, vout is always 0).
+    pub fidelity_outpoint: Option<OutPoint>,
+
     /// Latest offer, if successfully fetched
     pub offer: Option<Offer>,
 
@@ -115,6 +119,7 @@ pub struct MakerOfferCandidate {
 
 impl MakerOfferCandidate {
     fn mark_success(&mut self, offer: Offer, protocol: MakerProtocol, now_ts: u64) {
+        self.fidelity_outpoint = Some(offer.fidelity.bond.outpoint());
         self.offer = Some(offer);
         self.protocol = Some(protocol);
         self.last_offer_update_ts = Some(now_ts);
@@ -526,7 +531,7 @@ impl OfferSyncService {
             let mut book = self.offerbook.inner.write().unwrap();
             for fidelity in fidelities {
                 match MakerAddress::try_from(fidelity.onion_address) {
-                    Ok(parsed) => book.upsert_address(parsed),
+                    Ok(parsed) => book.upsert_address(parsed, Some(fidelity.txid)),
                     Err(e) => {
                         log::warn!("Skipping invalid maker address from registry: {e}");
                     }
@@ -616,7 +621,7 @@ impl OfferSyncService {
             .inner
             .write()
             .unwrap()
-            .upsert_address(address.clone());
+            .upsert_address(address.clone(), None);
 
         Self::fetch_and_record_one(
             address,
@@ -798,13 +803,14 @@ pub struct OfferBook {
 }
 
 impl OfferBook {
-    fn upsert_address(&mut self, address: MakerAddress) {
+    fn upsert_address(&mut self, address: MakerAddress, txid: Option<Txid>) {
         if self.makers.iter().any(|m| m.address == address) {
             return;
         }
 
         self.makers.push(MakerOfferCandidate {
             address,
+            fidelity_outpoint: txid.map(|t| OutPoint::new(t, 0)),
             offer: None,
             state: MakerState::Unresponsive { retries: 0 },
             protocol: None,
@@ -1150,6 +1156,7 @@ mod tests {
         let now_ts = 170000;
         let mut candidate = MakerOfferCandidate {
             address: addr("6104"),
+            fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
             offer: None,
             state: MakerState::Good,
             protocol: None,
@@ -1189,6 +1196,7 @@ mod tests {
         let now_ts = 170000;
         let mut candidate = MakerOfferCandidate {
             address: addr("6105"),
+            fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
             offer: None,
             state: MakerState::Bad,
             protocol: None,
@@ -1212,6 +1220,7 @@ mod tests {
         let mut book = OfferBook { makers: vec![] };
         book.makers.push(MakerOfferCandidate {
             address: addr("6103"),
+            fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
             offer: None,
             state: MakerState::Unresponsive { retries: 3 },
             protocol: None,


### PR DESCRIPTION
Makes the bond UTXO accessible for unresponsive makers where offer is None.

# Pull Request

## Description
Add fidelity outpoint to MakerOfferCandidate
- Makes the bond UTXO accessible for unresponsive makers where offer is None.

## Related Issue(s)
Closes #847 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Offer book now records provenance for maker fidelity bonds, improving traceability of offers across sync and polling.
* **Tests**
  * Unit tests updated to align with the revised offer data structure and ensure fidelity provenance is preserved during syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->