### PR TITLE
feat(taker): add poll_maker and remove_maker offerbook APIs

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -108,6 +108,19 @@ enum Commands {
 
     /// List makers from the locally cached offerbook without triggering a network sync.
     ListOffers,
+    /// Fetch an offer from a single maker address, verify the fidelity proof, and
+    /// store the result in the offerbook. Adds the maker if absent.
+    PollMaker {
+        /// Maker onion address (e.g. `xyz.onion`).
+        #[clap(long, short = 'm')]
+        address: String,
+    },
+    /// Remove a maker from the local offerbook by address.
+    RemoveMaker {
+        /// Maker onion address (e.g. `xyz.onion`).
+        #[clap(long, short = 'm')]
+        address: String,
+    },
     /// Initiate the coinswap process
     Coinswap {
         /// Sets the Maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy.
@@ -437,6 +450,19 @@ fn main() -> Result<(), TakerError> {
 
             let wallet = taker.get_wallet().read().unwrap();
             display_makers_with_summary(&wallet, &makers)?;
+        }
+        Commands::PollMaker { address } => {
+            let result = taker.poll_maker(address.clone())?;
+            let wallet = taker.get_wallet().read().unwrap();
+            println!("{}", display_offer(&wallet, &result)?);
+        }
+        Commands::RemoveMaker { address } => {
+            let removed = taker.remove_maker(address.clone())?;
+            if removed {
+                println!("Removed maker {address} from offerbook");
+            } else {
+                println!("No maker with address {address} in offerbook");
+            }
         }
         Commands::Coinswap {
             makers,

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -58,8 +58,8 @@ use super::{
     config::TakerConfig,
     error::TakerError,
     offers::{
-        MakerAddress, MakerProtocol, OfferAndAddress, OfferBook, OfferBookHandle, OfferSyncHandle,
-        OfferSyncService,
+        MakerAddress, MakerOfferCandidate, MakerProtocol, OfferAndAddress, OfferBook,
+        OfferBookHandle, OfferSyncClient, OfferSyncHandle, OfferSyncService,
     },
 };
 
@@ -2386,6 +2386,32 @@ impl Taker {
     /// Triggers a manual offerbook sync and blocks until it completes.
     pub fn sync_offerbook_and_wait(&self) -> Result<(), TakerError> {
         self.offer_sync_handle.sync_and_wait()
+    }
+
+    /// Returns a clone-able client for triggering offer sync operations from
+    /// other threads (e.g. background workers) without requiring access to the
+    /// `Taker` itself. Useful for callers that want to run a manual sync off
+    /// the main thread while leaving the `Taker` free for concurrent reads.
+    pub fn offer_sync_client(&self) -> OfferSyncClient {
+        self.offer_sync_handle.client()
+    }
+
+    /// Fetches the offer from a single maker, verifies its fidelity proof, and
+    /// stores the result in the offerbook. Adds the maker to the offerbook if
+    /// it is not already present. Blocks until the poll completes and returns
+    /// the maker's final state.
+    pub fn poll_maker(&self, address: String) -> Result<MakerOfferCandidate, TakerError> {
+        let parsed = MakerAddress::try_from(address)
+            .map_err(|e| TakerError::General(format!("Invalid maker address: {e}")))?;
+        self.offer_sync_handle.poll_maker(parsed)
+    }
+
+    /// Removes a maker from the offerbook by address. Returns `true` if an
+    /// entry was removed, `false` if no matching address was found.
+    pub fn remove_maker(&self, address: String) -> Result<bool, TakerError> {
+        let parsed = MakerAddress::try_from(address)
+            .map_err(|e| TakerError::General(format!("Invalid maker address: {e}")))?;
+        self.offerbook.remove(&parsed)
     }
 
     /// Restore a wallet from a backup file (static — no taker instance needed).

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -47,6 +47,10 @@ use super::error::TakerError;
 
 enum SyncCommand {
     SyncNow(mpsc::Sender<()>),
+    PollMaker {
+        address: MakerAddress,
+        done: mpsc::Sender<MakerOfferCandidate>,
+    },
 }
 
 #[cfg(not(feature = "integration-test"))]
@@ -321,6 +325,19 @@ impl OfferBookHandle {
         self.inner.read().unwrap().write_to_disk(&self.path)
     }
 
+    /// Remove a maker from the offerbook by address.
+    /// Returns `true` if an entry was removed, `false` if no matching address was found.
+    pub fn remove(&self, address: &MakerAddress) -> Result<bool, TakerError> {
+        let mut book = self.inner.write().unwrap();
+        let before = book.makers.len();
+        book.makers.retain(|m| &m.address != address);
+        let removed = book.makers.len() < before;
+        if removed {
+            book.write_to_disk(&self.path)?;
+        }
+        Ok(removed)
+    }
+
     /// Create or load offerbook on disk
     pub fn load_or_create(data_dir: &Path) -> Result<Self, TakerError> {
         let path = data_dir.join("offerbook.json");
@@ -386,6 +403,35 @@ pub struct OfferSyncHandle {
     cmd_tx: mpsc::Sender<SyncCommand>,
 }
 
+/// Lightweight clone-able client for triggering offer sync operations from
+/// other threads without owning the join handle / shutdown flag.
+#[derive(Clone)]
+pub struct OfferSyncClient {
+    cmd_tx: mpsc::Sender<SyncCommand>,
+}
+
+impl OfferSyncClient {
+    /// Trigger an offerbook sync and block until it completes.
+    pub fn sync_and_wait(&self) -> Result<(), TakerError> {
+        let (done_tx, done_rx) = mpsc::channel();
+        self.cmd_tx.send(SyncCommand::SyncNow(done_tx))?;
+        done_rx.recv()?;
+        Ok(())
+    }
+
+    /// Run a single-maker offer fetch + fidelity verification cycle for `address`
+    /// and block until it completes. If the address is not already in the offerbook
+    /// it is inserted. Returns the maker's final state after the poll.
+    pub fn poll_maker(&self, address: MakerAddress) -> Result<MakerOfferCandidate, TakerError> {
+        let (done_tx, done_rx) = mpsc::channel();
+        self.cmd_tx.send(SyncCommand::PollMaker {
+            address,
+            done: done_tx,
+        })?;
+        Ok(done_rx.recv()?)
+    }
+}
+
 impl OfferSyncHandle {
     /// Shutdown handler
     pub fn shutdown(&mut self) {
@@ -396,6 +442,14 @@ impl OfferSyncHandle {
         }
     }
 
+    /// Return a clone-able client that can trigger sync operations without
+    /// requiring access to the owning `OfferSyncHandle`.
+    pub fn client(&self) -> OfferSyncClient {
+        OfferSyncClient {
+            cmd_tx: self.cmd_tx.clone(),
+        }
+    }
+
     /// Trigger an offerbook sync and block until it completes.
     #[hotpath::measure]
     pub fn sync_and_wait(&self) -> Result<(), TakerError> {
@@ -403,6 +457,19 @@ impl OfferSyncHandle {
         self.cmd_tx.send(SyncCommand::SyncNow(done_tx))?;
         done_rx.recv()?;
         Ok(())
+    }
+
+    /// Run a single-maker offer fetch + fidelity verification cycle for `address`
+    /// and block until it completes. If the address is not already in the offerbook
+    /// it is inserted. Returns the maker's final state after the poll.
+    #[hotpath::measure]
+    pub fn poll_maker(&self, address: MakerAddress) -> Result<MakerOfferCandidate, TakerError> {
+        let (done_tx, done_rx) = mpsc::channel();
+        self.cmd_tx.send(SyncCommand::PollMaker {
+            address,
+            done: done_tx,
+        })?;
+        Ok(done_rx.recv()?)
     }
 }
 
@@ -475,6 +542,83 @@ impl OfferSyncService {
         Ok(())
     }
 
+    /// Fetches an offer from a single maker, verifies its fidelity proof, and
+    /// updates the offerbook with the result (mark_success or mark_failure),
+    /// then persists the offerbook to disk. Shared by the periodic worker pool
+    /// and the manual `poll_one` path.
+    fn fetch_and_record_one(
+        addr: MakerAddress,
+        socks_port: u16,
+        rest_backend: &BitcoinRest,
+        offerbook: &Arc<RwLock<OfferBook>>,
+        offerbook_path: &Path,
+        now: u64,
+    ) {
+        let downloaded = addr.clone().download_offer_with_retries(socks_port);
+        let mut book = offerbook.write().unwrap();
+        match downloaded {
+            Some(oa) => {
+                match verify_fidelity_with_backend(
+                    rest_backend,
+                    &oa.offer.fidelity,
+                    &oa.address.to_string(),
+                    &oa.offer.tweakable_point,
+                    &oa.offer.tweak_chain_code,
+                ) {
+                    Ok(_) => {
+                        book.mark_success(&oa.address, oa.offer, oa.protocol, now);
+                    }
+                    Err(e) => {
+                        log::warn!("Fidelity verification failed for {}: {:?}", oa.address, e);
+                        book.mark_failure(&oa.address, now);
+                    }
+                }
+            }
+            None => {
+                book.mark_failure(&addr, now);
+            }
+        }
+        if let Err(e) = book.write_to_disk(offerbook_path) {
+            log::warn!("Failed to persist offerbook: {:?}", e);
+        }
+    }
+
+    /// Performs a single offer fetch + fidelity verification cycle for one maker,
+    /// updating the offerbook with the result. The maker is inserted if absent.
+    /// Returns the maker's final state after the poll.
+    fn poll_one(&self, address: MakerAddress) -> MakerOfferCandidate {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        // Ensure the maker is present in the offerbook before polling.
+        self.offerbook
+            .inner
+            .write()
+            .unwrap()
+            .upsert_address(address.clone());
+
+        Self::fetch_and_record_one(
+            address.clone(),
+            self.socks_port,
+            &self.rest_backend,
+            &self.offerbook.inner,
+            &self.offerbook.path,
+            now,
+        );
+
+        self.offerbook
+            .inner
+            .read()
+            .unwrap()
+            .makers
+            .iter()
+            .find(|m| m.address == address)
+            .cloned()
+            .expect("maker was just upserted")
+    }
+
     /// Spawns worker threads that fetch offers from makers and update the offerbook
     /// as each result arrives. Returns join handles.
     fn spawn_offer_workers(&self, makers: Vec<MakerAddress>) -> Vec<JoinHandle<()>> {
@@ -511,41 +655,14 @@ impl OfferSyncService {
                         .unwrap_or(Duration::ZERO)
                         .as_secs();
 
-                    match addr.clone().download_offer_with_retries(socks_port) {
-                        Some(oa) => {
-                            let verified = verify_fidelity_with_backend(
-                                &rest_backend,
-                                &oa.offer.fidelity,
-                                &oa.address.to_string(),
-                                &oa.offer.tweakable_point,
-                                &oa.offer.tweak_chain_code,
-                            );
-                            let mut book = offerbook.write().unwrap();
-                            match verified {
-                                Ok(_) => {
-                                    book.mark_success(&oa.address, oa.offer, oa.protocol, now);
-                                }
-                                Err(e) => {
-                                    log::warn!(
-                                        "Fidelity verification failed for {}: {:?}",
-                                        oa.address,
-                                        e
-                                    );
-                                    book.mark_failure(&oa.address, now);
-                                }
-                            }
-                            if let Err(e) = book.write_to_disk(&offerbook_path) {
-                                log::warn!("Failed to persist offerbook: {:?}", e);
-                            }
-                        }
-                        None => {
-                            let mut book = offerbook.write().unwrap();
-                            book.mark_failure(&addr, now);
-                            if let Err(e) = book.write_to_disk(&offerbook_path) {
-                                log::warn!("Failed to persist offerbook: {:?}", e);
-                            }
-                        }
-                    }
+                    Self::fetch_and_record_one(
+                        addr,
+                        socks_port,
+                        &rest_backend,
+                        &offerbook,
+                        &offerbook_path,
+                        now,
+                    );
                 })
                 .expect("failed to spawn offer-fetch-worker");
 
@@ -587,6 +704,11 @@ impl OfferSyncService {
                                 let _ = done_tx.send(());
                                 Self::drain_and_ack(&cmd_rx);
                                 break;
+                            }
+                            Ok(SyncCommand::PollMaker { address, done }) => {
+                                log::info!("Manual maker poll requested: {}", address);
+                                let result = self.poll_one(address);
+                                let _ = done.send(result);
                             }
                             Err(mpsc::TryRecvError::Empty) => {}
                             Err(mpsc::TryRecvError::Disconnected) => return,

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -49,7 +49,7 @@ enum SyncCommand {
     SyncNow(mpsc::Sender<()>),
     PollMaker {
         address: MakerAddress,
-        done: mpsc::Sender<MakerOfferCandidate>,
+        done: mpsc::Sender<Option<MakerOfferCandidate>>,
     },
 }
 
@@ -421,14 +421,21 @@ impl OfferSyncClient {
 
     /// Run a single-maker offer fetch + fidelity verification cycle for `address`
     /// and block until it completes. If the address is not already in the offerbook
-    /// it is inserted. Returns the maker's final state after the poll.
+    /// it is inserted. Returns the maker's final state after the poll, or an error
+    /// if a concurrent `remove_maker` evicted the entry before its state could be
+    /// captured.
     pub fn poll_maker(&self, address: MakerAddress) -> Result<MakerOfferCandidate, TakerError> {
         let (done_tx, done_rx) = mpsc::channel();
+        let address_str = address.to_string();
         self.cmd_tx.send(SyncCommand::PollMaker {
             address,
             done: done_tx,
         })?;
-        Ok(done_rx.recv()?)
+        done_rx.recv()?.ok_or_else(|| {
+            TakerError::General(format!(
+                "Maker {address_str} was removed before the poll could record a result"
+            ))
+        })
     }
 }
 
@@ -461,15 +468,22 @@ impl OfferSyncHandle {
 
     /// Run a single-maker offer fetch + fidelity verification cycle for `address`
     /// and block until it completes. If the address is not already in the offerbook
-    /// it is inserted. Returns the maker's final state after the poll.
+    /// it is inserted. Returns the maker's final state after the poll, or an error
+    /// if a concurrent `remove_maker` evicted the entry before its state could be
+    /// captured.
     #[hotpath::measure]
     pub fn poll_maker(&self, address: MakerAddress) -> Result<MakerOfferCandidate, TakerError> {
         let (done_tx, done_rx) = mpsc::channel();
+        let address_str = address.to_string();
         self.cmd_tx.send(SyncCommand::PollMaker {
             address,
             done: done_tx,
         })?;
-        Ok(done_rx.recv()?)
+        done_rx.recv()?.ok_or_else(|| {
+            TakerError::General(format!(
+                "Maker {address_str} was removed before the poll could record a result"
+            ))
+        })
     }
 }
 
@@ -545,7 +559,9 @@ impl OfferSyncService {
     /// Fetches an offer from a single maker, verifies its fidelity proof, and
     /// updates the offerbook with the result (mark_success or mark_failure),
     /// then persists the offerbook to disk. Shared by the periodic worker pool
-    /// and the manual `poll_one` path.
+    /// and the manual `poll_one` path. Returns the recorded maker captured under
+    /// the write lock, or `None` if no entry exists for `addr` after the update
+    /// (e.g. a concurrent `remove` raced the poll).
     fn fetch_and_record_one(
         addr: MakerAddress,
         socks_port: u16,
@@ -553,7 +569,7 @@ impl OfferSyncService {
         offerbook: &Arc<RwLock<OfferBook>>,
         offerbook_path: &Path,
         now: u64,
-    ) {
+    ) -> Option<MakerOfferCandidate> {
         let downloaded = addr.clone().download_offer_with_retries(socks_port);
         let mut book = offerbook.write().unwrap();
         match downloaded {
@@ -578,15 +594,20 @@ impl OfferSyncService {
                 book.mark_failure(&addr, now);
             }
         }
+        // Capture the maker's final state while we still hold the write lock so
+        // a concurrent `remove` can't yank it out from under the caller.
+        let captured = book.makers.iter().find(|m| m.address == addr).cloned();
         if let Err(e) = book.write_to_disk(offerbook_path) {
             log::warn!("Failed to persist offerbook: {:?}", e);
         }
+        captured
     }
 
     /// Performs a single offer fetch + fidelity verification cycle for one maker,
     /// updating the offerbook with the result. The maker is inserted if absent.
-    /// Returns the maker's final state after the poll.
-    fn poll_one(&self, address: MakerAddress) -> MakerOfferCandidate {
+    /// Returns the maker's final state after the poll, or `None` if a concurrent
+    /// `remove` evicted the entry before the recorded state could be captured.
+    fn poll_one(&self, address: MakerAddress) -> Option<MakerOfferCandidate> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or(Duration::ZERO)
@@ -600,23 +621,13 @@ impl OfferSyncService {
             .upsert_address(address.clone());
 
         Self::fetch_and_record_one(
-            address.clone(),
+            address,
             self.socks_port,
             &self.rest_backend,
             &self.offerbook.inner,
             &self.offerbook.path,
             now,
-        );
-
-        self.offerbook
-            .inner
-            .read()
-            .unwrap()
-            .makers
-            .iter()
-            .find(|m| m.address == address)
-            .cloned()
-            .expect("maker was just upserted")
+        )
     }
 
     /// Spawns worker threads that fetch offers from makers and update the offerbook
@@ -655,7 +666,7 @@ impl OfferSyncService {
                         .unwrap_or(Duration::ZERO)
                         .as_secs();
 
-                    Self::fetch_and_record_one(
+                    let _ = Self::fetch_and_record_one(
                         addr,
                         socks_port,
                         &rest_backend,


### PR DESCRIPTION
Adds targeted offerbook operations to refresh a single maker or evict one from the registry without running a full sync. Exposes both as methods on Taker, wires PollMaker through OfferSyncService via a new SyncCommand variant, and adds matching CLI subcommands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: poll a specific maker and display its offer/fidelity details in human-readable form.
  * CLI: remove a maker from your local offerbook and report whether removal occurred.
  * Background sync: on-demand per-maker polling and cross-thread triggerable sync client for immediate updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->