### PR TITLE
mark maker as good after successful manual poll

### DIFF
--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -119,9 +119,7 @@ impl MakerOfferCandidate {
         self.protocol = Some(protocol);
         self.last_offer_update_ts = Some(now_ts);
         self.next_offer_check_ts = None;
-        if self.state != MakerState::Bad {
-            self.state = MakerState::Good;
-        }
+        self.state = MakerState::Good;
     }
 
     fn mark_failure(&mut self, now_ts: u64) {
@@ -1187,7 +1185,7 @@ mod tests {
     }
 
     #[test]
-    fn mark_success_does_not_unstick_bad_state() {
+    fn mark_success_rehabilitates_bad_state() {
         let now_ts = 170000;
         let mut candidate = MakerOfferCandidate {
             address: addr("6105"),
@@ -1203,7 +1201,9 @@ mod tests {
             MakerProtocol::Taproot,
             now_ts,
         );
-        assert_eq!(candidate.state, MakerState::Bad);
+        assert_eq!(candidate.state, MakerState::Good);
+        assert_eq!(candidate.next_offer_check_ts, None);
+        assert_eq!(candidate.last_offer_update_ts, Some(now_ts));
     }
 
     #[test]


### PR DESCRIPTION
There was a bug, where even after successful manual poll, the maker was staying marked as bad maker. This pr resolves that issue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed maker state transitions: Successful offer completions now correctly update maker status, preventing states from remaining stuck in error conditions and improving overall offer management reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->