### PR TITLE
fix(swap_report):maker swap time

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -66,6 +66,8 @@ struct SwapState {
     reserve_utxo: Vec<OutPoint>,
     /// Last activity timestamp.
     last_activity: Instant,
+    /// Time when this swap was accepted by the maker.
+    swap_start_time: Instant,
 }
 
 impl Default for SwapState {
@@ -82,6 +84,7 @@ impl Default for SwapState {
             contract_feerate: 0.0,
             reserve_utxo: Vec::new(),
             last_activity: Instant::now(),
+            swap_start_time: Instant::now(),
         }
     }
 }
@@ -1115,6 +1118,7 @@ impl MakerTrait for MakerServer {
         swap_state.contract_feerate = state.contract_feerate;
         swap_state.reserve_utxo = state.reserve_utxo.clone();
         swap_state.last_activity = Instant::now();
+        swap_state.swap_start_time = state.swap_start_time;
         log::debug!(
             "[{}] Stored connection state for {}: amount={}, timelock={}, protocol={:?}, outgoing_count={}",
             self.config.network_port,
@@ -1142,6 +1146,7 @@ impl MakerTrait for MakerServer {
             state.funding_broadcast = s.funding_broadcast;
             state.contract_feerate = s.contract_feerate;
             state.reserve_utxo = s.reserve_utxo.clone();
+            state.swap_start_time = s.swap_start_time;
             state
         })
     }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -478,6 +478,7 @@ fn handle_swap_details<M: Maker>(
     state.timelock = details.timelock;
     state.refund_locktime_offset = details.refund_locktime_offset;
     state.protocol = details.protocol_version;
+    state.swap_start_time = Instant::now();
     state.phase = SwapPhase::AwaitingContractData;
 
     maker.store_connection_state(&details.id, state)?;
@@ -528,6 +529,7 @@ fn restore_state_if_needed<M: Maker>(maker: &Arc<M>, state: &mut ConnectionState
             state.pending_funding_txes = stored.pending_funding_txes;
             state.funding_broadcast = stored.funding_broadcast;
             state.contract_feerate = stored.contract_feerate;
+            state.swap_start_time = stored.swap_start_time;
         }
     }
 }


### PR DESCRIPTION
Fixes #891 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap timing consistency and accuracy by implementing persistent tracking of swap start times through connection state transitions, ensuring that swap duration information remains reliable when reconnecting to active swaps during connection interruptions or network disruptions.

* **Refactor**
  * Enhanced state management to better handle swap timing information across connection handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->