### PR TITLE
[Loupe] Verify legacy maker funding output before taker signing

### DIFF
--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -49,6 +49,8 @@ pub enum MakerBehavior {
     CloseAfterSweep,
     /// Use an invalid fidelity bond timelock (fidelity timelock violation test).
     InvalidFidelityTimelock,
+    /// Point a Legacy sender contract at a funding output that is not the advertised multisig.
+    MalformedLegacyFundingOutput,
 }
 
 /// Minimum time required to react to contract broadcasts (in blocks).

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -332,9 +332,38 @@ fn process_proof_of_funding<M: Maker>(
                 osc.contract_redeemscript.clone().unwrap_or_default()
             };
 
+        let funding_tx = funding_txes[i].clone();
+        #[cfg(not(feature = "integration-test"))]
+        let contract_tx = osc.contract_tx.clone();
+        #[cfg(feature = "integration-test")]
+        let mut contract_tx = osc.contract_tx.clone();
+
+        #[cfg(feature = "integration-test")]
+        if maker.behavior() == super::handlers::MakerBehavior::MalformedLegacyFundingOutput {
+            let multisig_spk =
+                redeemscript_to_scriptpubkey(&multisig_redeemscript).map_err(|e| {
+                    MakerError::General(format!("Failed to convert redeemscript: {:?}", e).leak())
+                })?;
+            if let Some((bad_vout, _)) = funding_tx
+                .output
+                .iter()
+                .enumerate()
+                .find(|(_, output)| output.script_pubkey != multisig_spk)
+            {
+                contract_tx.input[0].previous_output = bitcoin::OutPoint {
+                    txid: funding_tx.compute_txid(),
+                    vout: bad_vout as u32,
+                };
+                log::warn!(
+                    "[{}] Test behavior: legacy sender contract spends non-multisig funding output",
+                    maker.network_port()
+                );
+            }
+        }
+
         senders_contract_txs_info.push(crate::protocol::legacy_messages::SenderContractTxInfo {
-            funding_tx: funding_txes[i].clone(),
-            contract_tx: osc.contract_tx.clone(),
+            funding_tx,
+            contract_tx,
             timelock_pubkey,
             multisig_redeemscript,
             contract_redeemscript: osc.contract_redeemscript.clone().unwrap_or_default(),

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1030,6 +1030,7 @@ impl Taker {
 
         // Success path: sweep + report (shared by both protocols)
         let swap_id_owned = swap_id.to_string();
+        let expected_incoming_swapcoins = self.swap_state()?.incoming_swapcoins.len();
         let swept = {
             let mut wallet = self.write_wallet()?;
             let swept = wallet.sweep_incoming_swapcoins(2.0)?;
@@ -1037,6 +1038,19 @@ impl Taker {
             wallet.sync_and_save()?;
             swept
         };
+        if expected_incoming_swapcoins == 0 || swept.resolved.len() < expected_incoming_swapcoins {
+            let err = TakerError::General(format!(
+                "Swap finalization swept {}/{} incoming swapcoins",
+                swept.resolved.len(),
+                expected_incoming_swapcoins
+            ));
+            self.emit_failure_report(&initial_utxos, swap_start_time, &err);
+            self.persist_failure(SwapPhase::Finalizing, &err);
+            if let Err(re) = self.recover_active_swap() {
+                log::error!("Recovery failed: {:?}", re);
+            }
+            return Err(err);
+        }
 
         self.populate_success_outcomes(&swap_id_owned, &swept)?;
 

--- a/src/taker/legacy_verification.rs
+++ b/src/taker/legacy_verification.rs
@@ -9,13 +9,16 @@ use bitcoin::{
     Amount, PublicKey, ScriptBuf, Transaction,
 };
 
-use crate::protocol::{
-    contract::{
-        check_reedemscript_is_multisig, read_contract_locktime, read_hashlock_pubkey_from_contract,
-        read_hashvalue_from_contract, read_pubkeys_from_multisig_redeemscript,
-        validate_contract_tx, verify_contract_tx_sig,
+use crate::{
+    protocol::{
+        contract::{
+            check_reedemscript_is_multisig, read_contract_locktime,
+            read_hashlock_pubkey_from_contract, read_hashvalue_from_contract,
+            read_pubkeys_from_multisig_redeemscript, validate_contract_tx, verify_contract_tx_sig,
+        },
+        legacy_messages::SenderContractTxInfo,
     },
-    legacy_messages::SenderContractTxInfo,
+    utill::redeemscript_to_scriptpubkey,
 };
 
 use super::{api::Taker, error::TakerError};
@@ -201,6 +204,30 @@ impl Taker {
                 return Err(TakerError::General(format!(
                     "Sender contract {} contract_tx references wrong funding tx: expected {}, got {}",
                     i, expected_funding_txid, contract_input_txid
+                )));
+            }
+            // QA: A malicious Legacy maker can provide a real funding tx while
+            // making the contract spend a different output than the advertised
+            // 2-of-2 multisig. Bind the contract input to the exact funding
+            // output script and value before accepting maker sender data.
+            let funding_vout = info.contract_tx.input[0].previous_output.vout as usize;
+            let funding_output = info.funding_tx.output.get(funding_vout).ok_or_else(|| {
+                TakerError::General(format!(
+                    "Sender contract {} references missing funding output {}",
+                    i, funding_vout
+                ))
+            })?;
+            let expected_multisig_spk = redeemscript_to_scriptpubkey(&info.multisig_redeemscript)?;
+            if funding_output.script_pubkey != expected_multisig_spk {
+                return Err(TakerError::General(format!(
+                    "Sender contract {} funding output does not pay to advertised multisig",
+                    i
+                )));
+            }
+            if funding_output.value != info.funding_amount {
+                return Err(TakerError::General(format!(
+                    "Sender contract {} funding output value {} does not match advertised amount {}",
+                    i, funding_output.value, info.funding_amount
                 )));
             }
 

--- a/tests/integration/legacy_malformed_contract.rs
+++ b/tests/integration/legacy_malformed_contract.rs
@@ -1,0 +1,101 @@
+//! Legacy malicious-maker test: reject sender contract data whose funding output
+//! is not the advertised 2-of-2 multisig output.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+#[test]
+fn test_legacy_taker_rejects_malformed_maker_funding_output() {
+    let makers_config_map = vec![(6102, Some(19051)), (16102, Some(19052))];
+    let taker_behavior = vec![TakerBehavior::Normal];
+    // First maker returns Legacy sender contract data whose contract input points
+    // at a real funding tx output, but not the advertised 2-of-2 multisig output.
+    let maker_behaviors = vec![
+        MakerBehavior::MalformedLegacyFundingOutput,
+        MakerBehavior::Normal,
+    ];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+
+    let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_coinswap(swap_params)
+        .expect("prepare_coinswap should succeed");
+
+    // The taker must reject before signing/finalizing; otherwise it can later
+    // report success while the incoming sweep is unspendable.
+    let result = taker.start_coinswap(&summary.swap_id);
+    assert!(
+        result.is_err(),
+        "taker must reject malformed maker sender contract data"
+    );
+
+    let error = format!("{:?}", result.unwrap_err());
+    assert!(
+        error.contains("funding output does not pay to advertised multisig"),
+        "unexpected taker error: {}",
+        error
+    );
+
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    // Pin the operator-visible rejection, not just the returned Rust error.
+    test_framework.assert_log(
+        "funding output does not pay to advertised multisig",
+        &log_path,
+    );
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -35,6 +35,7 @@ mod fidelity_timelock_violation;
 mod funding_dynamic_splits;
 #[cfg(feature = "hotpath")]
 mod hotpath_profile;
+mod legacy_malformed_contract;
 mod liquidity_test;
 mod offerbook_sync_race;
 mod taker_cli;


### PR DESCRIPTION
# Pull Request

## Description
In `src/taker/legacy_verification.rs`, legacy maker sender-contract verification now checks that the contract input’s vout points to an actual output in the maker’s provided funding tx, and that exact funding output:
1. pays to the advertised 2-of-2 multisig redeemscript
2. has the advertised funding_amount.

## Related Issue(s)

Fixes #883 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of legacy swap funding data to verify that maker-provided funding outputs correctly match the advertised multisig and funding amount, preventing acceptance of mismatched or malformed data.

* **Tests**
  * Added integration test to verify proper rejection of malformed legacy maker funding output configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->