### PR TITLE
reland: test: replacing `nostr-rs-relay` crate with github aciton

### DIFF
--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -23,6 +23,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      - name: Install nostr-rs-relay binary
+        uses: hulxv/nostr-relay-action@v1.0.0
+        with:
+          version: "0.9.0"
+          start: "false"
+
+      - name: Add nostr-rs-relay to PATH
+        run: echo "$HOME/.nostr-relay-bin" >> "$GITHUB_PATH"
+
       - name: Create metrics directory
         run: mkdir -p /tmp/metrics
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,18 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      # Download (and cache) the prebuilt relay binary only — each test spawns
+      # its own relay instance on a random port, so we do not start a shared
+      # server here (start: "false").
+      - name: Install nostr-rs-relay binary
+        uses: hulxv/nostr-relay-action@v1.0.0
+        with:
+          version: "0.9.0"
+          start: "false"
+
+      - name: Add nostr-rs-relay to PATH
+        run: echo "$HOME/.nostr-relay-bin" >> "$GITHUB_PATH"
+
       - name: Setup nextest config
         run: |
           mkdir -p .config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ hotpath = "0.15.0"
 [dev-dependencies]
 flate2 = {version = "1.0.35"}
 tar = {version = "0.4.43"}
-nostr-rs-relay = "0.8.12"
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -18,15 +18,14 @@ use std::{
     io::{BufReader, Read},
     net::TcpStream,
     path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
-        mpsc, Arc,
+        Arc, Mutex,
     },
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
-
-use nostr_rs_relay::{config, server::start_server};
 
 use flate2::read::GzDecoder;
 use tar::Archive;
@@ -382,8 +381,7 @@ pub struct TestFramework {
     pub(super) temp_dir: PathBuf,
     pub(super) nostr_relay_url: String,
     shutdown: AtomicBool,
-    nostr_relay_shutdown: mpsc::Sender<()>,
-    nostr_relay_handle: Option<JoinHandle<()>>,
+    nostr_relay: Mutex<Option<Child>>,
 }
 
 impl TestFramework {
@@ -433,7 +431,7 @@ impl TestFramework {
 
         let nostr_port = 8000 + rand::random::<u16>() % 1000;
         let nostr_relay_url = format!("ws://127.0.0.1:{nostr_port}");
-        let (nostr_relay_shutdown, nostr_relay_handle) = spawn_nostr_relay(&temp_dir, nostr_port);
+        let nostr_relay = spawn_nostr_relay(&temp_dir, nostr_port);
         wait_for_relay_healthy(nostr_port);
 
         let shutdown = AtomicBool::new(false);
@@ -442,8 +440,7 @@ impl TestFramework {
             temp_dir: temp_dir.clone(),
             nostr_relay_url: nostr_relay_url.clone(),
             shutdown,
-            nostr_relay_shutdown,
-            nostr_relay_handle: Some(nostr_relay_handle),
+            nostr_relay: Mutex::new(Some(nostr_relay)),
         });
 
         // Translate a RpcConfig from the test framework.
@@ -524,11 +521,19 @@ impl TestFramework {
         (test_framework, takers, makers, generate_blocks_handle)
     }
 
+    /// Terminate the per-test nostr relay child process, if still running.
+    fn kill_relay(&self) {
+        if let Some(mut child) = self.nostr_relay.lock().unwrap().take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
     /// Stop bitcoind, nostr relay, and clean up all test data.
     pub fn stop(&self) {
         log::info!("🛑 Stopping Test Framework");
         self.shutdown.store(true, Relaxed);
-        _ = self.nostr_relay_shutdown.send(());
+        self.kill_relay();
         let _ = self.bitcoind.client.stop().unwrap();
         std::thread::sleep(std::time::Duration::from_secs(3));
         if self.temp_dir.exists() {
@@ -540,12 +545,7 @@ impl TestFramework {
 impl Drop for TestFramework {
     fn drop(&mut self) {
         self.shutdown.store(true, Relaxed);
-        _ = self.nostr_relay_shutdown.send(());
-        if let Some(handle) = self.nostr_relay_handle.take() {
-            if let Err(e) = handle.join() {
-                log::error!("Nostr relay thread join failed: {:?}", e);
-            }
-        }
+        self.kill_relay();
         let _ = self.bitcoind.client.stop();
         std::thread::sleep(std::time::Duration::from_secs(3));
         if self.temp_dir.exists() {
@@ -615,25 +615,40 @@ pub fn spawn_tracker_logger(data_dir: PathBuf, interval: Duration) -> TrackerLog
     }
 }
 
-fn spawn_nostr_relay(temp_dir: &Path, port: u16) -> (mpsc::Sender<()>, JoinHandle<()>) {
+/// Spawns a dedicated `nostr-rs-relay` process for a single test.
+///
+/// Each test gets its own relay on its own random port with an in-memory
+/// database, so concurrently running tests never share nostr state. The relay
+/// binary is located via the `COINSWAP_TEST_NOSTR_RELAY_BIN` env var, falling
+/// back to `nostr-rs-relay` on `PATH`.
+fn spawn_nostr_relay(temp_dir: &Path, port: u16) -> Child {
     let data_dir = temp_dir.join("nostr-relay");
     std::fs::create_dir_all(&data_dir).unwrap();
 
-    let mut settings = config::Settings::default();
-    settings.network.address = "127.0.0.1".to_string();
-    settings.network.port = port;
-    settings.database.min_conn = 4;
-    settings.database.max_conn = 8;
-    settings.database.in_memory = true;
-    settings.diagnostics.tracing = true;
+    // Minimal per-test relay config: bind the random port and use an in-memory
+    // SQLite DB so nothing persists across or leaks between tests.
+    let config_path = data_dir.join("config.toml");
+    let config = format!(
+        "[network]\naddress = \"127.0.0.1\"\nport = {port}\n\n[database]\ndata_directory = \"{data_dir}\"\nin_memory = true\nmin_conn = 4\nmax_conn = 8\n\n[diagnostics]\ntracing = false\n",
+        data_dir = data_dir.display()
+    );
+    std::fs::write(&config_path, config).unwrap();
 
-    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+    let bin =
+        env::var("COINSWAP_TEST_NOSTR_RELAY_BIN").unwrap_or_else(|_| "nostr-rs-relay".to_string());
 
-    let handle = thread::spawn(move || {
-        start_server(&settings, shutdown_rx).expect("nostr relay crashed");
-    });
-
-    (shutdown_tx, handle)
+    Command::new(&bin)
+        .arg("--config")
+        .arg(&config_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to spawn nostr relay binary '{}': {}. Install it with `cargo install nostr-rs-relay` or set COINSWAP_TEST_NOSTR_RELAY_BIN.",
+                bin, e
+            )
+        })
 }
 
 fn wait_for_relay_healthy(port: u16) {


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->
Reland #791 with fixing the bug that causes conflict between tests


## Related Issue(s)
Closes #838

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [x] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows (test and hotpath profiling) to install a prebuilt Nostr relay binary and add it to PATH, preventing relay startup during workflow setup.
  * Removed the project’s direct Nostr relay dependency from the manifest.
* **Tests**
  * Improved integration testing by running a dedicated external relay per test with per-test configuration (local port, in-memory storage).
  * Strengthened relay termination and cleanup to reduce lingering processes and improve overall test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->