### PR TITLE
remove seed phrase from logs

### DIFF
--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -279,8 +279,6 @@ impl Wallet {
         // Generate Master key
         let master_key = {
             let mnemonic = Mnemonic::generate(12)?;
-            let words = mnemonic.words().collect::<Vec<_>>();
-            log::info!("Backup the Wallet Mnemonics. \n {words:?}");
             let seed = mnemonic.to_entropy();
             Xpriv::new_master(network, &seed)?
         };


### PR DESCRIPTION
fixes #903 Newly created wallets now keep the phrase only in memory, expose it via take_recovery_phrase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security**
  * Stopped automatic logging of the full wallet recovery phrase during wallet initialization, reducing the risk of exposing sensitive information in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->