### PR TITLE
fix(maker): require Taproot incoming contract confirmation before funding (#882)

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -932,39 +932,59 @@ impl MakerTrait for MakerServer {
 
     #[hotpath::measure]
     fn verify_contract_tx_on_chain(&self, txid: &bitcoin::Txid) -> Result<(), MakerError> {
-        // The taker broadcasts the contract tx before sending us the contract
-        // data, but there can be a brief delay before our bitcoind sees it in
-        // the mempool. Retry a few times before giving up.
+        use bitcoind::bitcoincore_rpc::RpcApi;
+
+        // SAFETY: required_confirms=0 would allow 0-conf maker funding; enforce at least 1.
+        let effective_confirms = self.config.required_confirms.max(1);
+
         const MAX_ATTEMPTS: u32 = 12;
         const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
         for attempt in 0..MAX_ATTEMPTS {
-            let seen = {
+            if self.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                return Err(MakerError::General("Maker shutting down"));
+            }
+
+            let confirms = {
                 let wallet = self
                     .wallet
                     .read()
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?;
-                wallet.rpc.get_raw_transaction(txid, None).is_ok()
+                wallet
+                    .rpc
+                    .get_raw_transaction_info(txid, None)
+                    .ok()
+                    .and_then(|info| info.confirmations)
+                    .unwrap_or(0)
             };
 
-            if seen {
+            if confirms >= effective_confirms {
+                log::info!(
+                    "[{}] Contract tx {} confirmed ({} >= {} required)",
+                    self.config.network_port,
+                    txid,
+                    confirms,
+                    effective_confirms
+                );
                 return Ok(());
             }
 
             if attempt + 1 < MAX_ATTEMPTS {
                 log::info!(
-                    "Contract tx {} not yet visible (attempt {}/{}), retrying in {}s",
+                    "[{}] Contract tx {} has {} conf(s), need {} (attempt {}/{})",
+                    self.config.network_port,
                     txid,
+                    confirms,
+                    effective_confirms,
                     attempt + 1,
-                    MAX_ATTEMPTS,
-                    RETRY_INTERVAL.as_secs()
+                    MAX_ATTEMPTS
                 );
                 std::thread::sleep(RETRY_INTERVAL);
             }
         }
 
         Err(MakerError::General(
-            "Incoming contract tx not found on-chain",
+            "Incoming contract tx not confirmed to required depth",
         ))
     }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -258,7 +258,9 @@ pub trait Maker: Send + Sync {
     /// Get the current block height from the Bitcoin node.
     fn get_current_height(&self) -> Result<u32, MakerError>;
 
-    /// Verify that a contract transaction is on-chain or in the mempool.
+    /// Verify the incoming Taproot contract tx has at least `max(1, required_confirms)`
+    /// confirmations before the maker funds its outgoing side. Retries until confirmed,
+    /// shutdown, or attempt limit. Rejects funding against unconfirmed mempool txs.
     fn verify_contract_tx_on_chain(&self, txid: &bitcoin::Txid) -> Result<(), MakerError>;
 
     /// Verify and sign sender's contract transactions.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -2457,4 +2457,7 @@ pub enum TakerBehavior {
     CloseAtSendersContract,
     /// Close connection when receiving maker's contract data response (taproot taker abort).
     CloseAtSendersContractFromMaker,
+    /// Broadcast Taproot contract txs and send contract data without waiting for
+    /// confirmation (integration test: maker must reject mempool incoming contract).
+    SendMempoolTaprootContract,
 }

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -638,8 +638,7 @@ impl Taker {
         self.net_handshake(&mut stream)?;
 
         #[cfg(feature = "integration-test")]
-        let skip_confirm =
-            self.behavior == super::api::TakerBehavior::SendMempoolTaprootContract;
+        let skip_confirm = self.behavior == super::api::TakerBehavior::SendMempoolTaprootContract;
 
         #[cfg(not(feature = "integration-test"))]
         let skip_confirm = false;

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -637,12 +637,25 @@ impl Taker {
         let mut stream = self.net_connect(&maker0_address)?;
         self.net_handshake(&mut stream)?;
 
-        self.wait_for_funding_with_keepalive(
-            &mut stream,
-            &contract_txids,
-            required_confirms,
-            &swap_id,
-        )?;
+        #[cfg(feature = "integration-test")]
+        let skip_confirm =
+            self.behavior == super::api::TakerBehavior::SendMempoolTaprootContract;
+
+        #[cfg(not(feature = "integration-test"))]
+        let skip_confirm = false;
+
+        if skip_confirm {
+            log::warn!(
+                "SendMempoolTaprootContract: skipping Taproot contract confirmation wait (test only)"
+            );
+        } else {
+            self.wait_for_funding_with_keepalive(
+                &mut stream,
+                &contract_txids,
+                required_confirms,
+                &swap_id,
+            )?;
+        }
 
         log::info!("Contract transactions broadcast and confirmed");
         Ok(stream)

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -23,11 +23,11 @@ mod taproot_maker_abort2;
 mod taproot_maker_abort3;
 mod taproot_multi_maker;
 mod taproot_multi_taker;
+mod taproot_rbf_rejection;
 mod taproot_swap;
 mod taproot_taker_abort1;
 mod taproot_taker_abort2;
 mod taproot_taker_abort3;
-mod taproot_rbf_rejection;
 mod taproot_timelock_recovery;
 mod wallet_backup;
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -27,6 +27,7 @@ mod taproot_swap;
 mod taproot_taker_abort1;
 mod taproot_taker_abort2;
 mod taproot_taker_abort3;
+mod taproot_rbf_rejection;
 mod taproot_timelock_recovery;
 mod wallet_backup;
 

--- a/tests/integration/taproot_rbf_rejection.rs
+++ b/tests/integration/taproot_rbf_rejection.rs
@@ -1,0 +1,105 @@
+//! Integration test: maker rejects Taproot contract data while incoming contract
+//! tx is still unconfirmed in mempool (issue #882 regression).
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use log::{info, warn};
+use std::{
+    sync::atomic::Ordering::Relaxed,
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn test_maker_rejects_mempool_taproot_contract() {
+    warn!("Running Test: Taproot RBF rejection — maker confirmation gate");
+
+    // Ports verified unused (7102/17102=taproot_swap, 7202/17202=taproot_maker_abort2)
+    let makers_config_map = vec![(8502, Some(21051)), (18502, Some(21052))];
+    let taker_behavior = vec![TakerBehavior::SendMempoolTaprootContract];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads: Vec<_> = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+
+    let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
+
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+
+    generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_coinswap(swap_params)
+        .expect("prepare_coinswap should succeed");
+
+    // Stop the background block generator so the taker contract tx stays
+    // unconfirmed while the maker runs verify_contract_tx_on_chain.
+    test_framework.pause_block_generation();
+    thread::sleep(Duration::from_secs(4));
+
+    let swap_result = taker.start_coinswap(&summary.swap_id);
+    assert!(
+        swap_result.is_err(),
+        "Swap must fail: maker should reject unconfirmed incoming contract"
+    );
+    info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
+
+    makers.iter().for_each(|m| m.shutdown.store(true, Relaxed));
+    for t in maker_threads {
+        t.join().unwrap();
+    }
+
+    for (i, (maker, original)) in makers.iter().zip(maker_spendable_balance).enumerate() {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+        let spendable = maker.wallet.read().unwrap().get_balances().unwrap().spendable;
+        assert_eq!(
+            spendable, original,
+            "Maker {} spendable balance changed — outgoing side may have been funded",
+            i
+        );
+    }
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/taproot_rbf_rejection.rs
+++ b/tests/integration/taproot_rbf_rejection.rs
@@ -12,11 +12,7 @@ use coinswap::{
 use super::test_framework::*;
 
 use log::{info, warn};
-use std::{
-    sync::atomic::Ordering::Relaxed,
-    thread,
-    time::Duration,
-};
+use std::{sync::atomic::Ordering::Relaxed, thread, time::Duration};
 
 #[test]
 fn test_maker_rejects_mempool_taproot_contract() {
@@ -92,7 +88,13 @@ fn test_maker_rejects_mempool_taproot_contract() {
 
     for (i, (maker, original)) in makers.iter().zip(maker_spendable_balance).enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
-        let spendable = maker.wallet.read().unwrap().get_balances().unwrap().spendable;
+        let spendable = maker
+            .wallet
+            .read()
+            .unwrap()
+            .get_balances()
+            .unwrap()
+            .spendable;
         assert_eq!(
             spendable, original,
             "Maker {} spendable balance changed — outgoing side may have been funded",

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -524,6 +524,14 @@ impl TestFramework {
         (test_framework, takers, makers, generate_blocks_handle)
     }
 
+    /// Pause the background block generation thread.
+    ///
+    /// Used when a test must keep transactions unconfirmed (e.g. maker
+    /// confirmation-gate regression tests).
+    pub fn pause_block_generation(&self) {
+        self.shutdown.store(true, Relaxed);
+    }
+
     /// Stop bitcoind, nostr relay, and clean up all test data.
     pub fn stop(&self) {
         log::info!("🛑 Stopping Test Framework");


### PR DESCRIPTION
## Description

Fixes a security issue where the maker would accept a taker’s Taproot incoming contract transaction as soon as it appeared in the mempool (0 confirmations), then fund its outgoing side. A malicious taker could RBF-replace that mempool tx and reclaim funds after the maker had already committed.

**What changed:** `verify_contract_tx_on_chain` now waits for `confirmations >= max(1, required_confirms)` via `get_raw_transaction_info`, with bounded retries and shutdown polling. Brief wallet lock per RPC call — not held across sleep.

**What did not change:** Legacy swap path (already enforced confirmations via `verify_proof_of_funding`).

Added integration test `taproot_rbf_rejection` with `TakerBehavior::SendMempoolTaprootContract` to verify the maker rejects unconfirmed contracts and does not fund outgoing side.

## Related Issue(s)
Closes #882

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [x] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

## Affected Component(s)
- [x] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo fmt --all` and committed the result (stable rustfmt; nightly-only fmt options ignored with warnings)
- [x] I ran `cargo clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (targeted: `taproot_swap`, `taproot_rbf_rejection`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths

## ScreenShot
<img width="1716" height="487" alt="image" src="https://github.com/user-attachments/assets/81c46bd0-52a5-4254-abe2-c80bd5358722" />


## How to Test

```bash
# Regression: honest Taproot swap still works
cargo test --test integration taproot_swap --features integration-test -- --nocapture

# New: maker rejects mempool/unconfirmed incoming contract
cargo test --test integration taproot_rbf_rejection --features integration-test -- --nocapture

# Unit tests
cargo test

# Lint
cargo fmt --all
cargo clippy --all-features --lib --bins --tests -- -D warnings
cargo clippy --examples -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Makers now wait for Taproot contract transactions to reach the required confirmation depth before accepting funding, rejecting attempts based on unconfirmed mempool transactions.

* **Tests**
  * Added an integration test covering maker rejection of unconfirmed Taproot contract transactions.
  * Extended the integration test framework with a way to pause block generation to keep transactions unconfirmed during scenarios.
  * Added an integration-test-only taker behavior to broadcast Taproot contract transactions without waiting for confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->