### PR TITLE
fix(taker): derive fidelity bond conf_height from chain (#906)

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -552,7 +552,10 @@ impl MakerServer {
             #[cfg(feature = "integration-test")]
             let locktime = {
                 use super::handlers::MakerBehavior;
-                let offset = if self.behavior == MakerBehavior::InvalidFidelityTimelock {
+                let offset = if matches!(
+                    self.behavior,
+                    MakerBehavior::InvalidFidelityTimelock | MakerBehavior::LieFidelityConfHeight
+                ) {
                     log::warn!("Test behavior: using invalid (too short) fidelity timelock");
                     10
                 } else {
@@ -792,10 +795,22 @@ impl MakerTrait for MakerServer {
         let proof = self
             .highest_fidelity_proof
             .read()
-            .map_err(|_| MakerError::General("Failed to lock fidelity proof"))?;
-        proof
+            .map_err(|_| MakerError::General("Failed to lock fidelity proof"))?
             .clone()
-            .ok_or(MakerError::General("No fidelity proof available"))
+            .ok_or(MakerError::General("No fidelity proof available"))?;
+
+        #[cfg(feature = "integration-test")]
+        let proof = {
+            let mut proof = proof;
+            if self.behavior == super::handlers::MakerBehavior::LieFidelityConfHeight {
+                log::warn!("Test behavior: lying about fidelity bond conf_height");
+                let lock_time = proof.bond.lock_time.to_consensus_u32();
+                proof.bond.conf_height = Some(lock_time.saturating_sub(MIN_FIDELITY_TIMELOCK));
+            }
+            proof
+        };
+
+        Ok(proof)
     }
 
     fn get_config(&self) -> MakerConfig {

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -49,6 +49,8 @@ pub enum MakerBehavior {
     CloseAfterSweep,
     /// Use an invalid fidelity bond timelock (fidelity timelock violation test).
     InvalidFidelityTimelock,
+    /// Create a short-timelock bond but lie about conf_height (conf_height verification test).
+    LieFidelityConfHeight,
 }
 
 /// Minimum time required to react to contract broadcasts (in blocks).

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -33,7 +33,7 @@ use crate::{
         error::ProtocolError,
     },
     utill::{read_message, send_message},
-    wallet::verify_fidelity_checks,
+    wallet::{verify_fidelity_checks, FidelityError},
     watch_tower::{registry_storage::FileRegistry, rest_backend::BitcoinRest},
 };
 
@@ -783,12 +783,20 @@ fn verify_fidelity_with_backend(
     let txid = proof.bond.outpoint.txid;
     let transaction = rest_backend.get_raw_tx(&txid)?;
     let current_height = rest_backend.get_block_count()?;
+    let conf_height = rest_backend
+        .get_tx_confirmation_height(&txid)
+        .map_err(|_| {
+            TakerError::Wallet(crate::wallet::WalletError::Fidelity(
+                FidelityError::BondUncomfirmed,
+            ))
+        })?;
 
     verify_fidelity_checks(
         proof,
         onion_addr,
         transaction,
         current_height,
+        conf_height,
         tweakable_point,
         tweak_chain_code,
     )

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -34,7 +34,9 @@ use crate::{
     },
     utill::{read_message, send_message},
     wallet::{verify_fidelity_checks, FidelityError},
-    watch_tower::{registry_storage::FileRegistry, rest_backend::BitcoinRest},
+    watch_tower::{
+        registry_storage::FileRegistry, rest_backend::BitcoinRest, watcher_error::WatcherError,
+    },
 };
 
 /// Maximum number of attempts to connect to a maker.
@@ -785,10 +787,11 @@ fn verify_fidelity_with_backend(
     let current_height = rest_backend.get_block_count()?;
     let conf_height = rest_backend
         .get_tx_confirmation_height(&txid)
-        .map_err(|_| {
-            TakerError::Wallet(crate::wallet::WalletError::Fidelity(
-                FidelityError::BondUncomfirmed,
-            ))
+        .map_err(|e| match e {
+            WatcherError::UnconfirmedTransaction(_) => TakerError::Wallet(
+                crate::wallet::WalletError::Fidelity(FidelityError::BondUncomfirmed),
+            ),
+            other => TakerError::Watcher(other),
         })?;
 
     verify_fidelity_checks(

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -107,15 +107,20 @@ pub(crate) fn verify_fidelity_checks(
     addr: &str,
     tx: Transaction,
     current_height: u64,
+    conf_height: u32,
     tweakable_point: &PublicKey,
     tweak_chain_code: &bitcoin::bip32::ChainCode,
 ) -> Result<(), WalletError> {
+    if let Some(reported) = proof.bond.conf_height {
+        if reported != conf_height {
+            log::warn!(
+                "Maker-reported conf_height {reported} differs from chain conf_height {conf_height}"
+            );
+        }
+    }
+
     // Ensure fidelity bond timelock lies within allowed range
-    let bond_height = proof.bond.lock_time.to_consensus_u32()
-        - proof
-            .bond
-            .conf_height
-            .ok_or(WalletError::Fidelity(FidelityError::BondDoesNotExist))?;
+    let bond_height = proof.bond.lock_time.to_consensus_u32() - conf_height;
     if !(MIN_FIDELITY_TIMELOCK..=MAX_FIDELITY_TIMELOCK).contains(&bond_height) {
         log::warn!(
             "Invalid fidelity bond timelock: {} blocks. Accepted range is [{}-{}] blocks.",

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -120,7 +120,12 @@ pub(crate) fn verify_fidelity_checks(
     }
 
     // Ensure fidelity bond timelock lies within allowed range
-    let bond_height = proof.bond.lock_time.to_consensus_u32() - conf_height;
+    let bond_height = proof
+        .bond
+        .lock_time
+        .to_consensus_u32()
+        .checked_sub(conf_height)
+        .ok_or(FidelityError::InvalidBondLocktime)?;
     if !(MIN_FIDELITY_TIMELOCK..=MAX_FIDELITY_TIMELOCK).contains(&bond_height) {
         log::warn!(
             "Invalid fidelity bond timelock: {} blocks. Accepted range is [{}-{}] blocks.",

--- a/src/watch_tower/rest_backend.rs
+++ b/src/watch_tower/rest_backend.rs
@@ -4,7 +4,7 @@ use std::{fs, str::FromStr};
 
 use bitcoin::{consensus::deserialize, Block, BlockHash, Transaction, Txid};
 use bitcoind::bitcoincore_rpc::{json::GetBlockchainInfoResult, jsonrpc::base64, Auth};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::{
     wallet::RPCConfig,
@@ -14,6 +14,11 @@ use crate::{
 };
 
 const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Deserialize)]
+struct RestTxInfo {
+    confirmations: Option<u32>,
+}
 
 /// Lightweight wrapper around bitcoind REST endpoints used by the watchtower (no longer uses JSON-RPC).
 #[derive(Clone)]
@@ -107,6 +112,22 @@ impl BitcoinRest {
     /// Returns the current chain height.
     pub fn get_block_count(&self) -> Result<u64, WatcherError> {
         Ok(self.get_blockchain_info()?.blocks)
+    }
+
+    /// Returns the block height at which `txid` was confirmed.
+    ///
+    /// Uses `/rest/tx/<txid>.json` for confirmation count and the same height
+    /// formula as [`crate::wallet::Wallet::wait_for_tx_confirmation`].
+    pub fn get_tx_confirmation_height(&self, txid: &Txid) -> Result<u32, WatcherError> {
+        let tx_info: RestTxInfo = self.get_json(&format!("/rest/tx/{txid}.json"))?;
+        let confirmations = tx_info.confirmations.unwrap_or(0);
+        if confirmations < 1 {
+            return Err(WatcherError::General(format!(
+                "Transaction {txid} is unconfirmed"
+            )));
+        }
+        let current_height = self.get_block_count()? as u32;
+        Ok(current_height.saturating_sub(confirmations) + 1)
     }
 
     /// Fetches a block by hash.

--- a/src/watch_tower/rest_backend.rs
+++ b/src/watch_tower/rest_backend.rs
@@ -122,9 +122,7 @@ impl BitcoinRest {
         let tx_info: RestTxInfo = self.get_json(&format!("/rest/tx/{txid}.json"))?;
         let confirmations = tx_info.confirmations.unwrap_or(0);
         if confirmations < 1 {
-            return Err(WatcherError::General(format!(
-                "Transaction {txid} is unconfirmed"
-            )));
+            return Err(WatcherError::UnconfirmedTransaction(*txid));
         }
         let current_height = self.get_block_count()? as u32;
         Ok(current_height.saturating_sub(confirmations) + 1)

--- a/src/watch_tower/watcher_error.rs
+++ b/src/watch_tower/watcher_error.rs
@@ -2,6 +2,8 @@
 
 use std::sync::{MutexGuard, PoisonError};
 
+use bitcoin::Txid;
+
 /// Errors that can occur within the watchtower components.
 #[derive(Debug)]
 pub enum WatcherError {
@@ -42,6 +44,8 @@ pub enum WatcherError {
     MutexPoison,
     /// Represents a general error with a descriptive message.
     General(String),
+    /// Transaction exists but has no confirmations yet.
+    UnconfirmedTransaction(Txid),
 }
 
 impl From<std::io::Error> for WatcherError {
@@ -138,6 +142,7 @@ impl WatcherError {
             WatcherError::NostrParsingError(_) => "NostrParsingError",
             WatcherError::MutexPoison => "MutexPoison",
             WatcherError::General(_) => "General",
+            WatcherError::UnconfirmedTransaction(_) => "UnconfirmedTransaction",
         }
     }
 }

--- a/tests/integration/fidelity_conf_height_lie.rs
+++ b/tests/integration/fidelity_conf_height_lie.rs
@@ -1,0 +1,83 @@
+//! Regression test for issue #906: taker must not trust maker-supplied conf_height.
+//!
+//! A malicious maker creates a short-timelock fidelity bond on-chain but forges
+//! conf_height in its offer so the bond appears to meet MIN_FIDELITY_TIMELOCK.
+//! The taker should derive conf_height from the blockchain and reject the offer.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{error::TakerError, SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use log::{info, warn};
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+#[test]
+fn fidelity_conf_height_lie() {
+    warn!("Running Test: Fidelity conf_height lie rejection");
+
+    let makers_config_map = vec![(8303, None)];
+    let taker_behavior = vec![TakerBehavior::Normal];
+    let maker_behaviors = vec![MakerBehavior::LieFidelityConfHeight];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+    let maker = &makers[0];
+
+    info!("Funding taker and maker");
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    info!("Initiating Maker server with LieFidelityConfHeight behavior");
+    let maker_thread = {
+        let maker_clone = maker.clone();
+        thread::spawn(move || start_server(maker_clone).unwrap())
+    };
+
+    wait_for_makers_setup(std::slice::from_ref(maker), 120);
+    maker.wallet.write().unwrap().sync_and_save().unwrap();
+
+    info!("Initiating coinswap (should fail: maker lied about conf_height)");
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 1)
+        .with_tx_count(2)
+        .with_required_confirms(1);
+
+    let err = taker
+        .prepare_coinswap(swap_params)
+        .expect_err("Swap should have failed due to NotEnoughMakersInOfferBook");
+    assert!(
+        matches!(err, TakerError::NotEnoughMakersInOfferBook),
+        "Expected NotEnoughMakersInOfferBook, got: {:?}",
+        err
+    );
+    info!("Coinswap failed as expected: {err:?}");
+
+    maker.shutdown.store(true, Relaxed);
+    maker_thread.join().unwrap();
+
+    info!("Fidelity conf_height lie test passed");
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod abort3_case1;
 mod abort3_case2;
 mod abort3_case3;
 mod fidelity;
+mod fidelity_conf_height_lie;
 mod fidelity_renewal;
 mod malice1;
 mod malice2;


### PR DESCRIPTION
## Description

Fixes a sybil-resistance bug where the taker trusted maker-supplied `conf_height` when validating fidelity bond timelocks during offerbook sync.

A malicious maker could create a short-timelock bond on-chain but lie about `conf_height` so `bond_height = lock_time - conf_height` appeared valid. The taker now derives confirmation height from bitcoind REST (`/rest/tx/<txid>.json`) and passes that value into `verify_fidelity_checks`, ignoring the maker-reported field for security decisions.

Closes #906

## Related Issue(s)

Closes #906

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Protocol Version(s) Affected

- [x] Both (offerbook fidelity verification is protocol-agnostic)

## Affected Component(s)

- [ ] makerd
- [x] taker (offerbook fidelity verification)
- [ ] maker-cli
- [x] Core protocol / cryptography / library (`verify_fidelity_checks`)
- [x] watch_tower (`BitcoinRest::get_tx_confirmation_height`)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation
- [ ] Other

## Checklist

### Code Quality

- [x] `cargo fmt --all` (or `cargo +nightly fmt --all`)
- [x] `cargo clippy --all-features --lib --bins --tests -- -D warnings`
- [x] `cargo clippy --examples -- -D warnings`
- [ ] `RUSTDOCFLAGS="-D warnings" cargo +nightly doc ...` (optional before merge)
- [ ] Pre-commit hook

### Testing

- [x] Unit tests: `cargo test`
- [x] Integration: `fidelity_conf_height_lie` + `fidelity_limit_violation`
- [x] Manually tested on regtest via integration test harness
- [ ] Full integration suite (optional; targeted tests cover this change)
- [x] Test-only malice behavior gated behind `integration-test` feature

### Documentation

- [ ] `docs/` updated (not required — behavior fix, no user-facing API change)

### Security & Privacy

- [x] Preserves trustlessness and atomic swap guarantees
- [x] **Improves** sybil resistance / fidelity bond verification
- [x] No new trust assumptions; removes trust in maker `conf_height`
- [x] Edge case: unconfirmed bonds rejected via `BondUncomfirmed`
- [x] ZMQ unaffected
- [x] `LieFidelityConfHeight` only in `integration-test` builds

## ScreenShot
<img width="3072" height="1920" alt="Screenshot From 2026-06-23 11-19-30" src="https://github.com/user-attachments/assets/1a38a882-5bd0-4c22-baf4-c82148508bd3" />
---
<img width="1902" height="950" alt="Screenshot From 2026-06-23 11-21-23" src="https://github.com/user-attachments/assets/5b8f8df9-6555-43e6-b268-b2abcb9f42f5" />

## Test I ran locally 

```bash
# Lint
cargo fmt --all
cargo clippy --all-features --lib --bins --tests -- -D warnings
cargo clippy --examples -- -D warnings

# Unit tests
cargo test

# Regression test for #906 (lying maker)
cargo test --test integration fidelity_conf_height_lie --features integration-test -- --nocapture

# Existing fidelity timelock test (still passes)
cargo test --test integration fidelity_limit_violation --features integration-test -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Fidelity bond verification now uses the transaction’s actual confirmation height from the backend rather than relying on maker-provided values, reducing the risk of dishonest timelock/maturity handling.
  * Improves error handling when the required transaction is not yet confirmed.

* **Tests**
  * Added a new integration regression test covering a misreported confirmation-height scenario, asserting that the taker rejects the coinswap preparation when verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->