### PR TITLE
feat(maker-rpc): authenticate RPC with local cookie token (#877)

### DIFF
--- a/docker-setup
+++ b/docker-setup
@@ -728,10 +728,12 @@ run_command() {
         docker_args+=(-v coinswap_maker-data:/home/coinswap/.coinswap)
         local has_data_dir=false
         for arg in "$@"; do
-            if [ "$arg" = "-d" ] || [ "$arg" = "--data-directory" ]; then
-                has_data_dir=true
-                break
-            fi
+            case "$arg" in
+                -d|--data-directory|-d=*|--data-directory=*)
+                    has_data_dir=true
+                    break
+                    ;;
+            esac
         done
         if [ "$has_data_dir" = false ]; then
             set -- -d /home/coinswap/.coinswap/maker "$@"

--- a/docker-setup
+++ b/docker-setup
@@ -723,7 +723,21 @@ run_command() {
     local cmd="$1"
     shift
     setup_env
-    docker run --rm -it --network coinswap-network "${IMAGE_NAME}:latest" "$cmd" "$@"
+    local docker_args=(--rm -it --network coinswap-network)
+    if [ "$cmd" = "maker-cli" ]; then
+        docker_args+=(-v coinswap_maker-data:/home/coinswap/.coinswap)
+        local has_data_dir=false
+        for arg in "$@"; do
+            if [ "$arg" = "-d" ] || [ "$arg" = "--data-directory" ]; then
+                has_data_dir=true
+                break
+            fi
+        done
+        if [ "$has_data_dir" = false ]; then
+            set -- -d /home/coinswap/.coinswap/maker "$@"
+        fi
+    fi
+    docker run "${docker_args[@]}" "${IMAGE_NAME}:latest" "$cmd" "$@"
 }
 
 show_help() {

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -162,19 +162,22 @@ docker run -d \
 
 ### Maker CLI
 
-Control the maker daemon:
+Control the maker daemon. `maker-cli` reads `rpc_cookie` from the maker data directory for RPC authentication. When using Docker, the maker data volume must be mounted so the CLI can access the same cookie file as `makerd`:
 
 ```bash
-# Using the setup script
-./docker-setup maker-cli ping
-./docker-setup maker-cli wallet-balance
+# Using the setup script (mounts maker-data volume automatically)
+./docker-setup maker-cli send-ping
+./docker-setup maker-cli get-balances
 ./docker-setup maker-cli stop
 
-# Or manually
-docker run --rm --network coinswap-network coinswap:latest maker-cli ping
-docker run --rm --network coinswap-network coinswap:latest maker-cli wallet-balance
-docker run --rm --network coinswap-network coinswap:latest maker-cli stop
+# Or manually (mount the maker-data volume and pass -d)
+docker run --rm \
+  -v coinswap_maker-data:/home/coinswap/.coinswap \
+  --network coinswap-network \
+  coinswap:latest maker-cli -d /home/coinswap/.coinswap/maker send-ping
 ```
+
+> **Note:** This is a breaking wire-format change. Third-party RPC clients (such as [maker-dashboard](https://github.com/citadel-tech/maker-dashboard)) must send authenticated `RpcAuthEnvelope` messages and read `rpc_cookie` from the maker data directory.
 
 ### Taker
 

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -66,8 +66,7 @@ OPTIONS:
     -d, --data-directory <DATA_DIRECTORY>
             Maker data directory (must match the running makerd instance).
             Used to read rpc_cookie for RPC authentication.
-
-            [default: ~/.coinswap/maker]
+            If omitted, defaults to ~/.coinswap/maker at runtime.
 
     -V, --version
             Print version information

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -13,6 +13,14 @@ In this guide, we'll walk you through how to use `maker-cli` to get the most out
 > 👉 **Before starting this tutorial**, ensure your `makerd` setup is complete.  
 > If you're unsure how to set it up, check out our [Makerd Setup Guide](./makerd.md) first, and then return to this tutorial.
 
+> ### **RPC Authentication**
+>
+> `maker-cli` reads the `rpc_cookie` file from the maker data directory automatically on each invocation and includes the token with every RPC request. By default this is `~/.coinswap/maker/rpc_cookie`.
+>
+> If you started `makerd` with a custom data directory (`makerd -d /path/to/data`), pass the same path to `maker-cli` with `-d /path/to/data`. Both `-p` (RPC port) and `-d` (data directory) must match the running `makerd` instance.
+>
+> After restarting `makerd`, run `maker-cli` again — it reads the fresh cookie each time.
+
 ---
 
 ## Getting Started with `maker-cli`
@@ -54,6 +62,12 @@ OPTIONS:
             Sets the rpc-port of Makerd
 
             [default: 127.0.0.1:6103]
+
+    -d, --data-directory <DATA_DIRECTORY>
+            Maker data directory (must match the running makerd instance).
+            Used to read rpc_cookie for RPC authentication.
+
+            [default: ~/.coinswap/maker]
 
     -V, --version
             Print version information

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -59,6 +59,12 @@ The default wallet directory is `$HOME/.coinswap/maker/wallets`.
 
 The log file for `makerd`, where debug information is stored for troubleshooting and monitoring.
 
+### 4. **rpc_cookie**
+
+When the RPC server starts (after fidelity bond setup completes), `makerd` writes a random authentication token to `rpc_cookie` in the maker data directory. The file is created with mode `0600` (owner read/write only) and is **regenerated each time the RPC server starts** (for example, when `makerd` restarts).
+
+All RPC requests from `maker-cli` must include this token. Only processes running as the same user who can read `rpc_cookie` can authenticate to the maker RPC control plane (same threat model as Bitcoin Core's `.cookie` file).
+
 ---
 
 ## Maker Tutorial

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -61,7 +61,7 @@ The log file for `makerd`, where debug information is stored for troubleshooting
 
 ### 4. **rpc_cookie**
 
-When the RPC server starts (after fidelity bond setup completes), `makerd` writes a random authentication token to `rpc_cookie` in the maker data directory. The file is created with mode `0600` (owner read/write only) and is **regenerated each time the RPC server starts** (for example, when `makerd` restarts).
+When the RPC server starts (after fidelity bond setup completes), `makerd` writes a random authentication token to `rpc_cookie` in the maker data directory. On Unix, the file is created with mode `0600` (owner read/write only). It is **regenerated each time the RPC server starts** (for example, when `makerd` restarts).
 
 All RPC requests from `maker-cli` must include this token. Only processes running as the same user who can read `rpc_cookie` can authenticate to the maker RPC control plane (same threat model as Bitcoin Core's `.cookie` file).
 

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -139,7 +139,9 @@ fn main() -> Result<(), MakerError> {
 }
 
 fn send_rpc_req(mut stream: TcpStream, token: &str, req: RpcMsgReq) -> Result<(), MakerError> {
-    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
+    let timeout = Duration::from_secs(20);
+    stream.set_write_timeout(Some(timeout))?;
+    stream.set_read_timeout(Some(timeout))?;
 
     let envelope = RpcAuthEnvelope {
         token: token.to_string(),

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -1,9 +1,9 @@
-use std::{net::TcpStream, time::Duration};
+use std::{net::TcpStream, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use coinswap::{
-    maker::{MakerError, RpcMsgReq, RpcMsgResp},
-    utill::{read_message, send_message, MIN_FEE_RATE},
+    maker::{load_rpc_cookie, MakerError, RpcAuthEnvelope, RpcMsgReq, RpcMsgResp},
+    utill::{get_maker_dir, read_message, send_message, MIN_FEE_RATE},
 };
 
 /// A simple command line app to operate the makerd server.
@@ -20,6 +20,9 @@ struct App {
     /// Sets the rpc-port of Makerd
     #[arg(long, short = 'p', default_value = "127.0.0.1:6103")]
     rpc_port: String,
+    /// Optional maker data directory (must match the running makerd instance)
+    #[arg(long, short = 'd')]
+    data_directory: Option<PathBuf>,
     /// The command to execute
     #[command(subcommand)]
     command: Commands,
@@ -73,29 +76,32 @@ enum Commands {
 fn main() -> Result<(), MakerError> {
     let cli = App::parse();
 
+    let data_dir = cli.data_directory.clone().unwrap_or_else(get_maker_dir);
+    let token = load_rpc_cookie(&data_dir)?;
+
     let stream = TcpStream::connect(cli.rpc_port)?;
 
     match cli.command {
         Commands::SendPing => {
-            send_rpc_req(stream, RpcMsgReq::Ping)?;
+            send_rpc_req(stream, &token, RpcMsgReq::Ping)?;
         }
         Commands::ListUtxoContract => {
-            send_rpc_req(stream, RpcMsgReq::ContractUtxo)?;
+            send_rpc_req(stream, &token, RpcMsgReq::ContractUtxo)?;
         }
         Commands::ListUtxoFidelity => {
-            send_rpc_req(stream, RpcMsgReq::FidelityUtxo)?;
+            send_rpc_req(stream, &token, RpcMsgReq::FidelityUtxo)?;
         }
         Commands::GetBalances => {
-            send_rpc_req(stream, RpcMsgReq::Balances)?;
+            send_rpc_req(stream, &token, RpcMsgReq::Balances)?;
         }
         Commands::ListUtxo => {
-            send_rpc_req(stream, RpcMsgReq::Utxo)?;
+            send_rpc_req(stream, &token, RpcMsgReq::Utxo)?;
         }
         Commands::ListUtxoSwap => {
-            send_rpc_req(stream, RpcMsgReq::SwapUtxo)?;
+            send_rpc_req(stream, &token, RpcMsgReq::SwapUtxo)?;
         }
         Commands::GetNewAddress => {
-            send_rpc_req(stream, RpcMsgReq::NewAddress)?;
+            send_rpc_req(stream, &token, RpcMsgReq::NewAddress)?;
         }
         Commands::SendToAddress {
             address,
@@ -104,6 +110,7 @@ fn main() -> Result<(), MakerError> {
         } => {
             send_rpc_req(
                 stream,
+                &token,
                 RpcMsgReq::SendToAddress {
                     address,
                     amount,
@@ -112,30 +119,34 @@ fn main() -> Result<(), MakerError> {
             )?;
         }
         Commands::ShowTorAddress => {
-            send_rpc_req(stream, RpcMsgReq::GetTorAddress)?;
+            send_rpc_req(stream, &token, RpcMsgReq::GetTorAddress)?;
         }
         Commands::ShowDataDir => {
-            send_rpc_req(stream, RpcMsgReq::GetDataDir)?;
+            send_rpc_req(stream, &token, RpcMsgReq::GetDataDir)?;
         }
         Commands::Stop => {
-            send_rpc_req(stream, RpcMsgReq::Stop)?;
+            send_rpc_req(stream, &token, RpcMsgReq::Stop)?;
         }
         Commands::ShowFidelity => {
-            send_rpc_req(stream, RpcMsgReq::ListFidelity)?;
+            send_rpc_req(stream, &token, RpcMsgReq::ListFidelity)?;
         }
         Commands::SyncWallet => {
-            send_rpc_req(stream, RpcMsgReq::SyncWallet)?;
+            send_rpc_req(stream, &token, RpcMsgReq::SyncWallet)?;
         }
     }
 
     Ok(())
 }
 
-fn send_rpc_req(mut stream: TcpStream, req: RpcMsgReq) -> Result<(), MakerError> {
-    // stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+fn send_rpc_req(mut stream: TcpStream, token: &str, req: RpcMsgReq) -> Result<(), MakerError> {
     stream.set_write_timeout(Some(Duration::from_secs(20)))?;
 
-    send_message(&mut stream, &req)?;
+    let envelope = RpcAuthEnvelope {
+        token: token.to_string(),
+        msg: req,
+    };
+
+    send_message(&mut stream, &envelope)?;
 
     let response_bytes = read_message(&mut stream)?;
     let response: RpcMsgResp = serde_cbor::from_slice(&response_bytes)?;

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -24,7 +24,7 @@ pub mod server;
 pub mod swap_tracker;
 
 pub use error::MakerError;
-pub use rpc::{RpcMsgReq, RpcMsgResp};
+pub use rpc::{load_rpc_cookie, write_rpc_cookie, RpcAuthEnvelope, RpcMsgReq, RpcMsgResp};
 
 #[cfg(feature = "integration-test")]
 pub use api::MakerBehavior;

--- a/src/maker/rpc/cookie.rs
+++ b/src/maker/rpc/cookie.rs
@@ -25,14 +25,19 @@ fn cookie_tmp_path(data_dir: &Path) -> PathBuf {
 }
 
 fn write_cookie_tmp(path: &Path, contents: &[u8]) -> Result<(), MakerError> {
+    if let Err(e) = fs::remove_file(path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(MakerError::IO(e));
+        }
+    }
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
 
         let mut file = OpenOptions::new()
             .write(true)
-            .create(true)
-            .truncate(true)
+            .create_new(true)
             .mode(0o600)
             .open(path)
             .map_err(MakerError::IO)?;

--- a/src/maker/rpc/cookie.rs
+++ b/src/maker/rpc/cookie.rs
@@ -1,5 +1,6 @@
 use std::{
-    fs,
+    fs::{self, OpenOptions},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -23,6 +24,30 @@ fn cookie_tmp_path(data_dir: &Path) -> PathBuf {
     data_dir.join(RPC_COOKIE_TMP_FILENAME)
 }
 
+fn write_cookie_tmp(path: &Path, contents: &[u8]) -> Result<(), MakerError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(MakerError::IO)?;
+        file.write_all(contents).map_err(MakerError::IO)?;
+        file.sync_all().map_err(MakerError::IO)?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents).map_err(MakerError::IO)?;
+    }
+
+    Ok(())
+}
+
 /// Generates a fresh RPC cookie and writes it to the maker data directory.
 ///
 /// Called when the RPC server starts. Overwrites any existing file (Bitcoin Core `.cookie` pattern).
@@ -36,19 +61,15 @@ pub fn write_rpc_cookie(data_dir: &Path) -> Result<String, MakerError> {
     let tmp_path = cookie_tmp_path(data_dir);
     let final_path = cookie_path(data_dir);
 
-    // Atomic flush: write to tmp file, then rename over original.
-    fs::write(&tmp_path, token.as_bytes())?;
+    // Atomic flush: write to tmp file with restrictive mode, then rename over original.
+    let write_result = write_cookie_tmp(&tmp_path, token.as_bytes())
+        .and_then(|()| fs::rename(&tmp_path, &final_path).map_err(MakerError::IO));
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = fs::Permissions::from_mode(0o600);
-        fs::set_permissions(&tmp_path, perms)?;
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
     }
 
-    fs::rename(&tmp_path, &final_path)?;
-
-    Ok(token)
+    write_result.map(|()| token)
 }
 
 /// Loads the RPC cookie from the maker data directory (for RPC clients such as `maker-cli`).

--- a/src/maker/rpc/cookie.rs
+++ b/src/maker/rpc/cookie.rs
@@ -1,0 +1,199 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use bitcoin::secp256k1::rand::{rngs::OsRng, RngCore};
+
+use super::messages::{RpcAuthEnvelope, RpcMsgReq};
+use crate::maker::error::MakerError;
+
+/// Filename for the maker RPC authentication cookie in the data directory.
+pub const RPC_COOKIE_FILENAME: &str = "rpc_cookie";
+
+const RPC_COOKIE_TMP_FILENAME: &str = "rpc_cookie.tmp";
+const RPC_COOKIE_BYTES: usize = 32;
+
+/// Returns the path to the RPC cookie file for a maker data directory.
+pub fn cookie_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(RPC_COOKIE_FILENAME)
+}
+
+fn cookie_tmp_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(RPC_COOKIE_TMP_FILENAME)
+}
+
+/// Generates a fresh RPC cookie and writes it to the maker data directory.
+///
+/// Called when the RPC server starts. Overwrites any existing file (Bitcoin Core `.cookie` pattern).
+pub fn write_rpc_cookie(data_dir: &Path) -> Result<String, MakerError> {
+    fs::create_dir_all(data_dir)?;
+
+    let mut bytes = [0u8; RPC_COOKIE_BYTES];
+    OsRng.fill_bytes(&mut bytes);
+    let token = bytes_to_hex(&bytes);
+
+    let tmp_path = cookie_tmp_path(data_dir);
+    let final_path = cookie_path(data_dir);
+
+    // Atomic flush: write to tmp file, then rename over original.
+    fs::write(&tmp_path, token.as_bytes())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&tmp_path, perms)?;
+    }
+
+    fs::rename(&tmp_path, &final_path)?;
+
+    Ok(token)
+}
+
+/// Loads the RPC cookie from the maker data directory (for RPC clients such as `maker-cli`).
+pub fn load_rpc_cookie(data_dir: &Path) -> Result<String, MakerError> {
+    let path = cookie_path(data_dir);
+    let token = fs::read_to_string(&path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to read {}: is makerd running and is --data-directory correct?",
+                    path.display()
+                ),
+            )
+        } else {
+            e
+        }
+    })?;
+    Ok(token.trim().to_string())
+}
+
+fn bytes_to_hex(bytes: &[u8; RPC_COOKIE_BYTES]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn parse_token_hex(token: &str) -> Result<[u8; RPC_COOKIE_BYTES], MakerError> {
+    let hex = token.trim();
+    if hex.len() != RPC_COOKIE_BYTES * 2 {
+        return Err(MakerError::General("unauthorized"));
+    }
+
+    let mut arr = [0u8; RPC_COOKIE_BYTES];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let s = std::str::from_utf8(chunk).map_err(|_| MakerError::General("unauthorized"))?;
+        arr[i] = u8::from_str_radix(s, 16).map_err(|_| MakerError::General("unauthorized"))?;
+    }
+    Ok(arr)
+}
+
+fn tokens_equal(provided: &[u8; RPC_COOKIE_BYTES], expected: &[u8; RPC_COOKIE_BYTES]) -> bool {
+    let mut diff = 0u8;
+    for (a, b) in provided.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Verifies an authenticated RPC envelope and returns the inner request on success.
+pub fn verify_rpc_auth(
+    envelope: &RpcAuthEnvelope,
+    expected_hex: &str,
+) -> Result<RpcMsgReq, MakerError> {
+    let provided = parse_token_hex(&envelope.token)?;
+    let expected = parse_token_hex(expected_hex)?;
+
+    if tokens_equal(&provided, &expected) {
+        Ok(envelope.msg.clone())
+    } else {
+        Err(MakerError::General("unauthorized"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn temp_data_dir(suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "coinswap_rpc_cookie_test_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn write_rpc_cookie_creates_hex_token() {
+        let data_dir = temp_data_dir("creates_hex");
+        let token = write_rpc_cookie(&data_dir).unwrap();
+
+        assert_eq!(token.len(), RPC_COOKIE_BYTES * 2);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+
+        let loaded = load_rpc_cookie(&data_dir).unwrap();
+        assert_eq!(loaded, token);
+
+        let _ = fs::remove_dir_all(&data_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_rpc_cookie_sets_restrictive_permissions() {
+        let data_dir = temp_data_dir("permissions");
+        write_rpc_cookie(&data_dir).unwrap();
+
+        let perms = fs::metadata(cookie_path(&data_dir)).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+
+        let _ = fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn write_rpc_cookie_overwrites_previous() {
+        let data_dir = temp_data_dir("overwrites");
+        let first = write_rpc_cookie(&data_dir).unwrap();
+        let second = write_rpc_cookie(&data_dir).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(load_rpc_cookie(&data_dir).unwrap(), second);
+
+        let _ = fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn verify_rpc_auth_accepts_valid_rejects_invalid() {
+        let mut bytes = [0u8; RPC_COOKIE_BYTES];
+        bytes[0] = 0xab;
+        let token = bytes_to_hex(&bytes);
+
+        let envelope = RpcAuthEnvelope {
+            token: token.clone(),
+            msg: RpcMsgReq::Ping,
+        };
+
+        assert!(matches!(
+            verify_rpc_auth(&envelope, &token),
+            Ok(RpcMsgReq::Ping)
+        ));
+        assert!(matches!(
+            verify_rpc_auth(&envelope, "00".repeat(RPC_COOKIE_BYTES * 2).as_str()),
+            Err(MakerError::General("unauthorized"))
+        ));
+        assert!(matches!(
+            verify_rpc_auth(
+                &RpcAuthEnvelope {
+                    token: "not-hex".to_string(),
+                    msg: RpcMsgReq::Ping,
+                },
+                &token
+            ),
+            Err(MakerError::General("unauthorized"))
+        ));
+    }
+}

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -8,11 +8,22 @@ use std::path::PathBuf;
 
 use crate::wallet::Balances;
 
+/// Authenticated wrapper for RPC requests.
+///
+/// Every RPC call must include the daemon-owned cookie token read from the maker data directory.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RpcAuthEnvelope {
+    /// Cookie token matching `rpc_cookie` in the maker data directory.
+    pub token: String,
+    /// The underlying RPC command.
+    pub msg: RpcMsgReq,
+}
+
 /// Enum representing RPC message requests.
 ///
 /// These messages are used for various operations in the Maker-rpc communication.
 /// Each variant corresponds to a specific action or query in the RPC protocol.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RpcMsgReq {
     /// Ping request to check connectivity.
     Ping,

--- a/src/maker/rpc/mod.rs
+++ b/src/maker/rpc/mod.rs
@@ -1,4 +1,6 @@
+mod cookie;
 mod messages;
 pub mod server;
 
-pub use messages::{RpcMsgReq, RpcMsgResp};
+pub use cookie::{load_rpc_cookie, write_rpc_cookie};
+pub use messages::{RpcAuthEnvelope, RpcMsgReq, RpcMsgResp};

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -11,7 +11,8 @@ use std::{
 
 use bitcoin::Amount;
 
-use super::messages::RpcMsgReq;
+use super::cookie::{verify_rpc_auth, write_rpc_cookie};
+use super::messages::{RpcAuthEnvelope, RpcMsgReq};
 use crate::{
     maker::{api::MakerServerConfig, error::MakerError, rpc::messages::RpcMsgResp},
     utill::{
@@ -30,10 +31,29 @@ pub trait MakerRpc {
 }
 
 #[hotpath::measure]
-fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result<(), MakerError> {
+fn handle_request<M: MakerRpc>(
+    maker: &Arc<M>,
+    socket: &mut TcpStream,
+    expected_token: &str,
+) -> Result<(), MakerError> {
     let msg_bytes = read_message(socket)?;
-    let rpc_request: RpcMsgReq = serde_cbor::from_slice(&msg_bytes)?;
-    log::info!("RPC request received: {rpc_request:?}");
+    let envelope: RpcAuthEnvelope = serde_cbor::from_slice(&msg_bytes)?;
+
+    let rpc_request = match verify_rpc_auth(&envelope, expected_token) {
+        Ok(req) => req,
+        Err(MakerError::General("unauthorized")) => {
+            log::warn!("RPC auth failed from {:?}", socket.peer_addr());
+            if let Err(e) =
+                send_message(socket, &RpcMsgResp::ServerError("unauthorized".to_string()))
+            {
+                log::error!("Error sending unauthorized response {e:?}");
+            }
+            return Ok(());
+        }
+        Err(e) => return Err(e),
+    };
+
+    log::info!("Authenticated RPC request: {rpc_request:?}");
 
     let resp = match rpc_request {
         RpcMsgReq::Ping => RpcMsgResp::Pong,
@@ -161,6 +181,7 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
 
 #[hotpath::measure]
 pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerError> {
+    let expected_token = Arc::new(write_rpc_cookie(maker.data_dir())?);
     let rpc_port = maker.config().rpc_port;
     let listener = TcpListener::bind(("127.0.0.1", rpc_port))?;
     let rpc_socket = format!("127.0.0.1:{rpc_port}");
@@ -180,7 +201,7 @@ pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerEr
                 stream.set_read_timeout(Some(Duration::from_secs(20)))?;
                 stream.set_write_timeout(Some(Duration::from_secs(20)))?;
                 // Do not cause hard error if a rpc request fails
-                if let Err(e) = handle_request(&maker, &mut stream) {
+                if let Err(e) = handle_request(&maker, &mut stream, &expected_token) {
                     log::error!("Error processing RPC Request: {e:?}");
                     // Send the error back to client.
                     if let Err(e) =


### PR DESCRIPTION
## Summary

This adds Bitcoin Core-style cookie authentication for the `makerd` RPC control plane.

- `makerd` writes `rpc_cookie` (32-byte hex, file mode 600) when the RPC server starts
- `maker-cli` reads that file from the maker data directory and sends `RpcAuthEnvelope { token, msg }` on every request
- The server checks the token before running any RPC handler

Closes #877

## Breaking change

RPC clients must send `RpcAuthEnvelope` instead of a bare `RpcMsgReq`. The maker-dashboard will need the same update.

## Test plan

- [x] `cargo test maker::rpc::cookie`
- [x] `cargo test`
- [x] Manual: `maker-cli send-ping` with valid cookie → `success`
- [x] Manual: corrupt `rpc_cookie` → `unauthorized`
- [x] Manual: restart `makerd` → new cookie → `send-ping` → `success`

---

## Screenshot 1 — Automated tests pass
<img width="1570" height="985" alt="Screenshot From 2026-06-23 13-49-48" src="https://github.com/user-attachments/assets/2a877fef-02e2-4bce-8480-5a6050f59657" />


---

## Screenshot 2 — makerd starts and RPC auth works
<img width="1556" height="1112" alt="Screenshot From 2026-06-23 13-49-21" src="https://github.com/user-attachments/assets/1c4f2020-74d6-43c8-844f-717c5afe85ae" />


---

## Screenshot 3 — RPC cookie file created
<img width="1068" height="301" alt="Screenshot From 2026-06-23 13-47-29" src="https://github.com/user-attachments/assets/5e47d617-1972-4690-b9bd-f77b3c54efa5" />

---

## Screenshot 4 — maker-cli ping succeeds with valid cookie
<img width="867" height="131" alt="Screenshot From 2026-06-23 13-53-37" src="https://github.com/user-attachments/assets/90e1100c-f72f-45d7-9252-62d19fdc6ad9" />

---

## Notes for reviewers

- Cookie is regenerated on each RPC server start (same idea as Bitcoin Core `.cookie`)
- Token comparison uses constant-time byte comparison
- `maker-cli` gained `-d/--data-directory` so it can read `rpc_cookie` from the correct maker data dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Maker RPC now requires authenticated requests; the wire format changed and third-party RPC clients must send requests wrapped with the `rpc_cookie` token.

* **New Features**
  * `maker-cli` adds optional `--data-directory` to load the correct `rpc_cookie`, and RPC auth is applied to each request.
  * Docker setup now mounts the maker data volume and ensures `maker-cli` uses the matching data directory automatically.

* **Documentation**
  * Updated `maker-cli`, `makerd`, and Docker docs with the new authenticated RPC workflow, including cookie creation/permissions and “match `-p`/`-d`” guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->