### PR TITLE
chore:add more verbose debug logs

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1115,7 +1115,7 @@ impl MakerTrait for MakerServer {
             || swap_state.reserve_utxo.len() != state.reserve_utxo.len()
         {
             log::debug!(
-                "[SWAP_STATE] Role: Maker | SwapID: {} | Phase: {:?} | FundingBroadcast: {} | Incoming: {} | Outgoing: {} | ReservedUtxos: {}",
+                "[SWAP_STATE] Source: maker::api::store_connection_state | Role: Maker | SwapID: {} | Phase: {:?} | FundingBroadcast: {} | Incoming: {} | Outgoing: {} | ReservedUtxos: {}",
                 swap_id,
                 state.phase,
                 state.funding_broadcast,

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1107,6 +1107,23 @@ impl MakerTrait for MakerServer {
         }
 
         let swap_state = swaps.entry(swap_id.to_string()).or_default();
+        #[cfg(debug_assertions)]
+        if swap_state.phase != state.phase
+            || swap_state.funding_broadcast != state.funding_broadcast
+            || swap_state.incoming_swapcoins.len() != state.incoming_swapcoins.len()
+            || swap_state.outgoing_swapcoins.len() != state.outgoing_swapcoins.len()
+            || swap_state.reserve_utxo.len() != state.reserve_utxo.len()
+        {
+            log::debug!(
+                "[SWAP_STATE] Role: Maker | SwapID: {} | Phase: {:?} | FundingBroadcast: {} | Incoming: {} | Outgoing: {} | ReservedUtxos: {}",
+                swap_id,
+                state.phase,
+                state.funding_broadcast,
+                state.incoming_swapcoins.len(),
+                state.outgoing_swapcoins.len(),
+                state.reserve_utxo.len()
+            );
+        }
         swap_state.swap_amount = state.swap_amount;
         swap_state.timelock = state.timelock;
         swap_state.protocol = state.protocol;

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -708,7 +708,7 @@ fn process_legacy_handover<M: Maker>(
     state.phase = SwapPhase::Completed;
     #[cfg(debug_assertions)]
     log::debug!(
-        "[SWAP_STATE] SwapID: {} | Protocol: Legacy | Phase: Completed | Incoming: {} | Outgoing: {}",
+        "[SWAP_STATE] Source: maker::legacy_handlers::process_legacy_handover | SwapID: {} | Protocol: Legacy | Phase: Completed | Incoming: {} | Outgoing: {}",
         handover.id,
         state.incoming_swapcoins.len(),
         state.outgoing_swapcoins.len()

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -151,6 +151,14 @@ fn process_proof_of_funding<M: Maker>(
     );
 
     let hashvalue = maker.verify_proof_of_funding(&pof)?;
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[CONTRACT_STATE] Role: Maker | Protocol: Legacy | SwapID: {} | ProofFundingTxs: {} | NextHopKeys: {} | RefundLocktime: {} | Status: verified",
+        pof.id,
+        pof.confirmed_funding_txes.len(),
+        pof.next_coinswap_info.len(),
+        pof.refund_locktime
+    );
 
     log::info!(
         "[{}] Verified proof of funding, hashvalue: {:?}",
@@ -410,6 +418,13 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
         &state.outgoing_swapcoins,
         maker.network_port(),
     )?;
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[CONTRACT_STATE] Role: Maker | Protocol: Legacy | SwapID: {} | ReceiverSigs: {} | SenderSigs: {} | Status: verified",
+        resp.id,
+        resp.receivers_sigs.len(),
+        resp.senders_sigs.len()
+    );
 
     for (sig, incoming) in resp
         .receivers_sigs
@@ -417,10 +432,6 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
         .zip(state.incoming_swapcoins.iter_mut())
     {
         incoming.others_contract_sig = Some(*sig);
-        log::debug!(
-            "[{}] Stored receiver signature in incoming swapcoin",
-            maker.network_port()
-        );
     }
 
     for (sig, outgoing) in resp
@@ -429,10 +440,6 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
         .zip(state.outgoing_swapcoins.iter_mut())
     {
         outgoing.others_contract_sig = Some(*sig);
-        log::debug!(
-            "[{}] Stored sender signature in outgoing swapcoin",
-            maker.network_port()
-        );
     }
 
     #[cfg(feature = "integration-test")]
@@ -699,6 +706,13 @@ fn process_legacy_handover<M: Maker>(
     // Mark swap as completed — sweep happens in the server loop after the
     // response is delivered to the taker.
     state.phase = SwapPhase::Completed;
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[SWAP_STATE] SwapID: {} | Protocol: Legacy | Phase: Completed | Incoming: {} | Outgoing: {}",
+        handover.id,
+        state.incoming_swapcoins.len(),
+        state.outgoing_swapcoins.len()
+    );
 
     // Generate and save maker success report
     emit_maker_success_report(maker, state, &handover.id);

--- a/src/maker/swap_tracker.rs
+++ b/src/maker/swap_tracker.rs
@@ -175,6 +175,21 @@ impl MakerSwapTracker {
             MakerSwapTrackerData::default()
         };
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_TRACKER] Role: Maker | Action: load | Records: {} | Incomplete: {}",
+            data.swaps.len(),
+            data.swaps
+                .values()
+                .filter(|r| {
+                    !matches!(
+                        r.phase,
+                        MakerSwapPhase::Recovered | MakerSwapPhase::Completed
+                    ) || r.recovery.phase < MakerRecoveryPhase::CleanedUp
+                })
+                .count()
+        );
+
         Ok(Self { path, data })
     }
 
@@ -202,6 +217,22 @@ impl MakerSwapTracker {
     /// Upsert a swap record and flush to disk.
     #[hotpath::measure]
     pub fn save_record(&mut self, record: &MakerSwapRecord) -> Result<(), MakerError> {
+        #[cfg(debug_assertions)]
+        if self.data.swaps.get(&record.swap_id).is_none_or(|old| {
+            old.phase != record.phase
+                || old.recovery.phase != record.recovery.phase
+                || old.funding_broadcast != record.funding_broadcast
+        }) {
+            log::debug!(
+                "[SWAP_TRACKER] Role: Maker | SwapID: {} | Phase: {} | Recovery: {} | FundingBroadcast: {} | Incoming: {} | Outgoing: {}",
+                record.swap_id,
+                record.phase,
+                record.recovery.phase,
+                record.funding_broadcast,
+                record.incoming_count,
+                record.outgoing_count
+            );
+        }
         self.data
             .swaps
             .insert(record.swap_id.clone(), record.clone());

--- a/src/maker/swap_tracker.rs
+++ b/src/maker/swap_tracker.rs
@@ -177,7 +177,7 @@ impl MakerSwapTracker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_TRACKER] Role: Maker | Action: load | Records: {} | Incomplete: {}",
+            "[SWAP_TRACKER] Source: maker::swap_tracker::load_or_create | Role: Maker | Action: load | Records: {} | Incomplete: {}",
             data.swaps.len(),
             data.swaps
                 .values()
@@ -224,7 +224,7 @@ impl MakerSwapTracker {
                 || old.funding_broadcast != record.funding_broadcast
         }) {
             log::debug!(
-                "[SWAP_TRACKER] Role: Maker | SwapID: {} | Phase: {} | Recovery: {} | FundingBroadcast: {} | Incoming: {} | Outgoing: {}",
+                "[SWAP_TRACKER] Source: maker::swap_tracker::save_record | Role: Maker | SwapID: {} | Phase: {} | Recovery: {} | FundingBroadcast: {} | Incoming: {} | Outgoing: {}",
                 record.swap_id,
                 record.phase,
                 record.recovery.phase,

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -97,6 +97,14 @@ fn process_taproot_contract<M: Maker>(
         state.timelock,
         maker.network_port(),
     )?;
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | ContractTxs: {} | Amounts: {} | Timelock: {} | Status: verified",
+        data.id,
+        data.contract_txs.len(),
+        data.amounts.len(),
+        state.timelock
+    );
 
     let incoming_contract_tx = data
         .contract_txs
@@ -249,6 +257,14 @@ fn process_taproot_contract<M: Maker>(
     // Store in connection state
     state.incoming_swapcoins.push(incoming_swapcoin.clone());
     state.outgoing_swapcoins.push(outgoing_swapcoin.clone());
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | IncomingAmount: {} | OutgoingAmount: {} | ReservedUtxos: {}",
+        data.id,
+        incoming_funding_amount.to_sat(),
+        contract_output_amount.to_sat(),
+        state.reserve_utxo.len()
+    );
 
     #[cfg(feature = "integration-test")]
     {
@@ -400,6 +416,13 @@ fn process_taproot_handover<M: Maker>(
     // Mark swap as completed — sweep happens in the server loop after the
     // response is delivered to the taker.
     state.phase = SwapPhase::Completed;
+    #[cfg(debug_assertions)]
+    log::debug!(
+        "[SWAP_STATE] SwapID: {} | Protocol: Taproot | Phase: Completed | Incoming: {} | Outgoing: {}",
+        handover.id,
+        state.incoming_swapcoins.len(),
+        state.outgoing_swapcoins.len()
+    );
 
     // Generate and save maker success report
     emit_maker_success_report(maker, state, &handover.id);

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -418,7 +418,7 @@ fn process_taproot_handover<M: Maker>(
     state.phase = SwapPhase::Completed;
     #[cfg(debug_assertions)]
     log::debug!(
-        "[SWAP_STATE] SwapID: {} | Protocol: Taproot | Phase: Completed | Incoming: {} | Outgoing: {}",
+        "[SWAP_STATE] Source: maker::taproot_handlers::process_taproot_handover | SwapID: {} | Protocol: Taproot | Phase: Completed | Incoming: {} | Outgoing: {}",
         handover.id,
         state.incoming_swapcoins.len(),
         state.outgoing_swapcoins.len()

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1202,6 +1202,15 @@ impl Taker {
         let swap = self.swap_state_mut()?;
         swap.makers = selected_makers;
         swap.spare_makers = spares;
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_ROUTE] SwapID: {} | Protocol: {:?} | SelectedMakers: {} | SpareMakers: {} | Amount: {}",
+            swap.id,
+            swap.params.protocol,
+            swap.makers.len(),
+            swap.spare_makers.len(),
+            swap.params.send_amount.to_sat()
+        );
         Ok(())
     }
 
@@ -1278,6 +1287,15 @@ impl Taker {
             }
         }
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_ROUTE] SwapID: {} | NegotiatedMakers: {} | Protocol: {:?} | ReferenceHeight: {} | TxCount: {}",
+            swap_id,
+            maker_count,
+            protocol,
+            reference_height,
+            tx_count
+        );
         Ok(())
     }
 
@@ -1504,7 +1522,16 @@ impl Taker {
             tx_count,
             maker_count,
             reference_height,
-        )
+        )?;
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_ROUTE] SwapID: {} | Action: substitute_maker | MakerIndex: {} | Address: {} | ReferenceHeight: {}",
+            swap_id,
+            target_idx,
+            self.swap_state()?.makers[target_idx].address,
+            reference_height
+        );
+        Ok(())
     }
 
     /// Re-initialize funding after substituting the first maker.
@@ -1520,6 +1547,12 @@ impl Taker {
         {
             let mut wallet = self.write_wallet()?;
             let old_keys = wallet.outgoing_keys_for_swap(&swap_id);
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[FUNDING_STATE] SwapID: {} | Action: reset_after_substitution | OutgoingSwapcoinsRemoved: {}",
+                swap_id,
+                old_keys.len()
+            );
             for key in &old_keys {
                 wallet.remove_outgoing_swapcoin(key);
             }
@@ -1633,6 +1666,19 @@ impl Taker {
         let num_swapcoins = swapcoins.len();
         swap.outgoing_swapcoins = swapcoins;
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[FUNDING_STATE] SwapID: {} | Protocol: {:?} | OutgoingSwapcoins: {} | SendAmount: {} | ManualUtxos: {}",
+            swap.id,
+            protocol,
+            num_swapcoins,
+            send_amount.to_sat(),
+            swap.params
+                .manually_selected_outpoints
+                .as_ref()
+                .map(Vec::len)
+                .unwrap_or_default()
+        );
         log::info!("Created {} outgoing swapcoins for funding", num_swapcoins);
         Ok(())
     }
@@ -1814,6 +1860,13 @@ impl Taker {
             self.swap_state_mut()?.makers[i]
                 .finalization
                 .privkey_forwarded = true;
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[FINALIZATION] SwapID: {} | MakerIndex: {} | MakersTotal: {} | PrivkeyReceived: true | PrivkeyForwarded: true",
+                swap_id,
+                i,
+                num_makers
+            );
 
             // For the last maker: validate and set their privkey on taker's incoming swapcoin.
             // Derive the public key from the received private key and verify it matches
@@ -1857,11 +1910,18 @@ impl Taker {
     #[hotpath::measure]
     fn finalize_persist_incoming(&mut self) -> Result<(), TakerError> {
         let mut wallet = self.write_wallet()?;
-        if let Some(incoming) = self.swap_state()?.incoming_swapcoins.last() {
+        let incoming = self.swap_state()?.incoming_swapcoins.last().cloned();
+        if let Some(incoming) = &incoming {
             wallet.add_incoming_swapcoin(incoming);
         }
 
         wallet.save_to_disk()?;
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[WALLET_STATE] Action: persist_final_incoming | Added: {} | IncomingStored: {}",
+            usize::from(incoming.is_some()),
+            wallet.get_incoming_swapcoins_count()
+        );
         Ok(())
     }
 
@@ -2308,6 +2368,11 @@ impl Taker {
                 record.phase = SwapPhase::Failed;
             })?;
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_STATE] SwapID: {} | Action: clear_active_for_recovery",
+            swap_id
+        );
         self.ongoing_swap = None;
 
         log::info!("Spawning recovery loop for swap {}", swap_id);

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1204,7 +1204,7 @@ impl Taker {
         swap.spare_makers = spares;
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_ROUTE] SwapID: {} | Protocol: {:?} | SelectedMakers: {} | SpareMakers: {} | Amount: {}",
+            "[SWAP_ROUTE] Source: taker::api::discover_makers | SwapID: {} | Protocol: {:?} | SelectedMakers: {} | SpareMakers: {} | Amount: {}",
             swap.id,
             swap.params.protocol,
             swap.makers.len(),
@@ -1289,7 +1289,7 @@ impl Taker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_ROUTE] SwapID: {} | NegotiatedMakers: {} | Protocol: {:?} | ReferenceHeight: {} | TxCount: {}",
+            "[SWAP_ROUTE] Source: taker::api::negotiate_swap_details | SwapID: {} | NegotiatedMakers: {} | Protocol: {:?} | ReferenceHeight: {} | TxCount: {}",
             swap_id,
             maker_count,
             protocol,
@@ -1525,7 +1525,7 @@ impl Taker {
         )?;
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_ROUTE] SwapID: {} | Action: substitute_maker | MakerIndex: {} | Address: {} | ReferenceHeight: {}",
+            "[SWAP_ROUTE] Source: taker::api::substitute_and_negotiate_spare | SwapID: {} | Action: substitute_maker | MakerIndex: {} | Address: {} | ReferenceHeight: {}",
             swap_id,
             target_idx,
             self.swap_state()?.makers[target_idx].address,
@@ -1549,7 +1549,7 @@ impl Taker {
             let old_keys = wallet.outgoing_keys_for_swap(&swap_id);
             #[cfg(debug_assertions)]
             log::debug!(
-                "[FUNDING_STATE] SwapID: {} | Action: reset_after_substitution | OutgoingSwapcoinsRemoved: {}",
+                "[FUNDING_STATE] Source: taker::api::funding_reinitialize | SwapID: {} | Action: reset_after_substitution | OutgoingSwapcoinsRemoved: {}",
                 swap_id,
                 old_keys.len()
             );
@@ -1668,7 +1668,7 @@ impl Taker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[FUNDING_STATE] SwapID: {} | Protocol: {:?} | OutgoingSwapcoins: {} | SendAmount: {} | ManualUtxos: {}",
+            "[FUNDING_STATE] Source: taker::api::funding_initialize | SwapID: {} | Protocol: {:?} | OutgoingSwapcoins: {} | SendAmount: {} | ManualUtxos: {}",
             swap.id,
             protocol,
             num_swapcoins,
@@ -2370,7 +2370,7 @@ impl Taker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_STATE] SwapID: {} | Action: clear_active_for_recovery",
+            "[SWAP_STATE] Source: taker::api::recover_active_swap | SwapID: {} | Action: clear_active_for_recovery",
             swap_id
         );
         self.ongoing_swap = None;

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -466,6 +466,12 @@ impl BreachDetector {
         }
         if let Ok(mut guard) = self.sentinels.lock() {
             guard.extend_from_slice(sentinels);
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[WATCH_STATE] Action: register_breach_sentinels | Added: {} | Total: {}",
+                sentinels.len(),
+                guard.len()
+            );
         }
     }
 

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -468,7 +468,7 @@ impl BreachDetector {
             guard.extend_from_slice(sentinels);
             #[cfg(debug_assertions)]
             log::debug!(
-                "[WATCH_STATE] Action: register_breach_sentinels | Added: {} | Total: {}",
+                "[WATCH_STATE] Source: taker::background_services::add_sentinels | Action: register_breach_sentinels | Added: {} | Total: {}",
                 sentinels.len(),
                 guard.len()
             );

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -695,7 +695,7 @@ impl Taker {
 
             #[cfg(debug_assertions)]
             log::debug!(
-                "[LEGACY_HOP] SwapID: {} | MakerIndex: {} | FundingTxs: {} | ConfirmHeight: {} | ReceiverContracts: {} | SenderContracts: {} | WatchOnlyTotal: {}",
+                "[LEGACY_HOP] Source: taker::legacy_swap::exchange_legacy | SwapID: {} | MakerIndex: {} | FundingTxs: {} | ConfirmHeight: {} | ReceiverContracts: {} | SenderContracts: {} | WatchOnlyTotal: {}",
                 swap_id,
                 maker_idx,
                 maker_funding_txids.len(),

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -693,6 +693,17 @@ impl Taker {
             }
             self.persist_progress()?;
 
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[LEGACY_HOP] SwapID: {} | MakerIndex: {} | FundingTxs: {} | ConfirmHeight: {} | ReceiverContracts: {} | SenderContracts: {} | WatchOnlyTotal: {}",
+                swap_id,
+                maker_idx,
+                maker_funding_txids.len(),
+                maker_confirm_height,
+                receivers_contract_txs.len(),
+                senders_contract_txs_info.len(),
+                self.swap_state()?.watchonly_swapcoins.len()
+            );
             log::info!("Maker {} processed successfully", maker_idx);
             maker_idx += 1;
         }

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -119,6 +119,14 @@ pub struct MakerOfferCandidate {
 
 impl MakerOfferCandidate {
     fn mark_success(&mut self, offer: Offer, protocol: MakerProtocol, now_ts: u64) {
+        #[cfg(debug_assertions)]
+        if self.state != MakerState::Good {
+            log::debug!(
+                "[MAKER_STATE] Address: {} | State: {:?} -> Good",
+                self.address,
+                self.state
+            );
+        }
         self.fidelity_outpoint = Some(offer.fidelity.bond.outpoint());
         self.offer = Some(offer);
         self.protocol = Some(protocol);
@@ -132,14 +140,25 @@ impl MakerOfferCandidate {
         let base = self.next_offer_check_ts.unwrap_or(now_ts).max(now_ts);
         self.next_offer_check_ts = Some(base.saturating_add(step_secs));
 
-        self.state = match self.state {
+        let previous_state = self.state.clone();
+        self.state = match &previous_state {
             MakerState::Good => MakerState::Unresponsive { retries: 1 },
-            MakerState::Unresponsive { retries } if retries < 10 => MakerState::Unresponsive {
-                retries: retries + 1,
+            MakerState::Unresponsive { retries } if *retries < 10 => MakerState::Unresponsive {
+                retries: *retries + 1,
             },
             MakerState::Unresponsive { .. } => MakerState::Bad,
             MakerState::Bad => MakerState::Bad,
         };
+        #[cfg(debug_assertions)]
+        if previous_state != self.state {
+            log::debug!(
+                "[MAKER_STATE] Address: {} | State: {:?} -> {:?} | NextCheck: {:?}",
+                self.address,
+                previous_state,
+                self.state,
+                self.next_offer_check_ts
+            );
+        }
     }
 
     fn as_offer_and_address(&self) -> Option<OfferAndAddress> {
@@ -857,6 +876,14 @@ impl OfferBook {
 
     fn mark_bad(&mut self, address: &MakerAddress) {
         if let Some(m) = self.makers.iter_mut().find(|m| &m.address == address) {
+            #[cfg(debug_assertions)]
+            if m.state != MakerState::Bad {
+                log::debug!(
+                    "[MAKER_STATE] Address: {} | State: {:?} -> Bad",
+                    m.address,
+                    m.state
+                );
+            }
             m.state = MakerState::Bad;
         }
     }

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -122,7 +122,7 @@ impl MakerOfferCandidate {
         #[cfg(debug_assertions)]
         if self.state != MakerState::Good {
             log::debug!(
-                "[MAKER_STATE] Address: {} | State: {:?} -> Good",
+                "[MAKER_STATE] Source: taker::offers::MakerOfferCandidate::mark_success | Address: {} | State: {:?} -> Good",
                 self.address,
                 self.state
             );
@@ -152,7 +152,7 @@ impl MakerOfferCandidate {
         #[cfg(debug_assertions)]
         if previous_state != self.state {
             log::debug!(
-                "[MAKER_STATE] Address: {} | State: {:?} -> {:?} | NextCheck: {:?}",
+                "[MAKER_STATE] Source: taker::offers::MakerOfferCandidate::mark_failure | Address: {} | State: {:?} -> {:?} | NextCheck: {:?}",
                 self.address,
                 previous_state,
                 self.state,
@@ -879,7 +879,7 @@ impl OfferBook {
             #[cfg(debug_assertions)]
             if m.state != MakerState::Bad {
                 log::debug!(
-                    "[MAKER_STATE] Address: {} | State: {:?} -> Bad",
+                    "[MAKER_STATE] Source: taker::offers::OfferBook::mark_bad | Address: {} | State: {:?} -> Bad",
                     m.address,
                     m.state
                 );

--- a/src/taker/swap_tracker.rs
+++ b/src/taker/swap_tracker.rs
@@ -428,6 +428,20 @@ impl SwapTracker {
             SwapTrackerData::default()
         };
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[SWAP_TRACKER] Role: Taker | Action: load | Records: {} | Incomplete: {}",
+            data.swaps.len(),
+            data.swaps
+                .values()
+                .filter(|r| {
+                    r.phase != SwapPhase::Completed
+                        && !(r.phase == SwapPhase::Failed
+                            && r.recovery.phase >= RecoveryPhase::CleanedUp)
+                })
+                .count()
+        );
+
         Ok(Self { path, data })
     }
 
@@ -450,6 +464,23 @@ impl SwapTracker {
 
     /// Upsert a swap record and flush to disk.
     pub fn save_record(&mut self, record: &SwapRecord) -> Result<(), TakerError> {
+        #[cfg(debug_assertions)]
+        if self.data.swaps.get(&record.swap_id).is_none_or(|old| {
+            old.phase != record.phase
+                || old.recovery.phase != record.recovery.phase
+                || old.failed_at_phase != record.failed_at_phase
+        }) {
+            log::debug!(
+                "[SWAP_TRACKER] Role: Taker | SwapID: {} | Phase: {} | Recovery: {} | FailedAt: {:?} | Incoming: {} | Outgoing: {} | WatchOnly: {}",
+                record.swap_id,
+                record.phase,
+                record.recovery.phase,
+                record.failed_at_phase,
+                record.incoming_contract_txids.len(),
+                record.outgoing_contract_txids.len(),
+                record.watchonly_contract_txids.len()
+            );
+        }
         self.data
             .swaps
             .insert(record.swap_id.clone(), record.clone());

--- a/src/taker/swap_tracker.rs
+++ b/src/taker/swap_tracker.rs
@@ -430,7 +430,7 @@ impl SwapTracker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_TRACKER] Role: Taker | Action: load | Records: {} | Incomplete: {}",
+            "[SWAP_TRACKER] Source: taker::swap_tracker::load_or_create | Role: Taker | Action: load | Records: {} | Incomplete: {}",
             data.swaps.len(),
             data.swaps
                 .values()
@@ -471,7 +471,7 @@ impl SwapTracker {
                 || old.failed_at_phase != record.failed_at_phase
         }) {
             log::debug!(
-                "[SWAP_TRACKER] Role: Taker | SwapID: {} | Phase: {} | Recovery: {} | FailedAt: {:?} | Incoming: {} | Outgoing: {} | WatchOnly: {}",
+                "[SWAP_TRACKER] Source: taker::swap_tracker::save_record | Role: Taker | SwapID: {} | Phase: {} | Recovery: {} | FailedAt: {:?} | Incoming: {} | Outgoing: {} | WatchOnly: {}",
                 record.swap_id,
                 record.phase,
                 record.recovery.phase,

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -459,7 +459,7 @@ impl Taker {
                     self.persist_progress()?;
                     #[cfg(debug_assertions)]
                     log::debug!(
-                        "[TAPROOT_HOP] SwapID: {} | MakerIndex: {} | ContractTxs: {} | RequiredConfirms: {} | IncomingTotal: {} | WatchOnlyTotal: {}",
+                        "[TAPROOT_HOP] Source: taker::taproot_swap::exchange_taproot | SwapID: {} | MakerIndex: {} | ContractTxs: {} | RequiredConfirms: {} | IncomingTotal: {} | WatchOnlyTotal: {}",
                         self.swap_state()?.id,
                         i,
                         maker_funding_txids.len(),
@@ -656,7 +656,7 @@ impl Taker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[FUNDING_STATE] SwapID: {} | Protocol: Taproot | ContractTxs: {} | RequiredConfirms: {} | Status: confirmed",
+           "[FUNDING_STATE] Source: taker::taproot_swap::funding_broadcast | SwapID: {} | Protocol: Taproot | ContractTxs: {} | RequiredConfirms: {} | Status: confirmed",
             swap_id,
             contract_txids.len(),
             required_confirms

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -457,6 +457,16 @@ impl Taker {
                         .taproot_exchange_mut()?
                         .maker_funding_confirmed = true;
                     self.persist_progress()?;
+                    #[cfg(debug_assertions)]
+                    log::debug!(
+                        "[TAPROOT_HOP] SwapID: {} | MakerIndex: {} | ContractTxs: {} | RequiredConfirms: {} | IncomingTotal: {} | WatchOnlyTotal: {}",
+                        self.swap_state()?.id,
+                        i,
+                        maker_funding_txids.len(),
+                        required_confirms,
+                        self.swap_state()?.incoming_swapcoins.len(),
+                        self.swap_state()?.watchonly_swapcoins.len()
+                    );
                 }
                 _ => {
                     return Err(TakerError::General(format!(
@@ -644,6 +654,13 @@ impl Taker {
             &swap_id,
         )?;
 
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[FUNDING_STATE] SwapID: {} | Protocol: Taproot | ContractTxs: {} | RequiredConfirms: {} | Status: confirmed",
+            swap_id,
+            contract_txids.len(),
+            required_confirms
+        );
         log::info!("Contract transactions broadcast and confirmed");
         Ok(stream)
     }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -866,6 +866,16 @@ impl Wallet {
             self.save_to_disk()?;
         }
 
+        if !outcome.is_empty() {
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[RECOVERY_STATE] Wallet: {} | Action: recover_timelocked | Resolved: {} | Discarded: {} | OutgoingRemaining: {}",
+                self.store.file_name,
+                outcome.resolved.len(),
+                outcome.discarded.len(),
+                self.store.outgoing_swapcoins.len()
+            );
+        }
         Ok(outcome)
     }
 
@@ -1600,9 +1610,8 @@ impl Wallet {
         }
 
         // Remove UTXOs that no longer exist in the received utxos list
-        for outpoint in to_remove {
-            self.store.utxo_cache.remove(&outpoint);
-            log::debug!("[UTXO Cache] Removed UTXO: {outpoint:?}");
+        for outpoint in &to_remove {
+            self.store.utxo_cache.remove(outpoint);
         }
 
         // Process and add only new UTXOs
@@ -1631,12 +1640,24 @@ impl Wallet {
 
             // If we found valid spend info, store it in the cache
             if let Some(info) = spend_info {
-                log::debug!("[UTXO Cache] Added UTXO: {outpoint:?} -> {info:?}");
                 new_entries.push((outpoint, (utxo, info)));
             }
         }
 
         // Insert only new entries into the cache
+        #[cfg(debug_assertions)]
+        if !new_entries.is_empty() || !to_remove.is_empty() {
+            log::debug!(
+                "[UTXO_STATE] Wallet: {} | Added: {} | Removed: {} | CachedUtxos: {} -> {} | IncomingSwapcoins: {} | OutgoingSwapcoins: {}",
+                self.store.file_name,
+                new_entries.len(),
+                to_remove.len(),
+                self.store.utxo_cache.len() + to_remove.len(),
+                self.store.utxo_cache.len() + new_entries.len(),
+                self.store.incoming_swapcoins.len(),
+                self.store.outgoing_swapcoins.len()
+            );
+        }
         for (outpoint, entry) in new_entries {
             self.store.utxo_cache.insert(outpoint, entry);
         }
@@ -2010,8 +2031,6 @@ impl Wallet {
         let can_use_regular = target_sats + estimated_fee <= regular_total;
         let can_use_swap = target_sats + estimated_fee <= swap_total;
 
-        log::debug!("Coinselection : Estimated_fee : {estimated_fee} and Target : {target_sats}");
-
         // Check manual UTXO selection constraints
         let (manual_regular_selected, manual_swap_selected) =
             if let Some(ref manual_outpoints) = manually_selected_outpoints {
@@ -2206,6 +2225,15 @@ impl Wallet {
                     result_total,
                     target_sats + estimated_fee
                 );
+                        #[cfg(debug_assertions)]
+                        log::debug!(
+                            "[COIN_SELECTION] Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: grouped",
+                            self.store.file_name,
+                            utxo_type,
+                            result_utxos.len(),
+                            result_total,
+                            target_sats + estimated_fee
+                        );
                         return Ok(result_utxos);
                     }
                 }
@@ -2272,6 +2300,18 @@ impl Wallet {
                     final_selection.extend(additional_utxos);
 
                     log::info!("Selected {} {utxo_type} UTXOs", final_selection.len());
+                    #[cfg(debug_assertions)]
+                    log::debug!(
+                        "[COIN_SELECTION] Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: coinselect",
+                        self.store.file_name,
+                        utxo_type,
+                        final_selection.len(),
+                        final_selection
+                            .iter()
+                            .map(|(utxo, _)| utxo.amount.to_sat())
+                            .sum::<u64>(),
+                        target_sats + estimated_fee
+                    );
                     return Ok(final_selection);
                 }
                 Err(e) => {
@@ -2650,6 +2690,16 @@ impl Wallet {
         }
 
         self.save_to_disk()?;
+        if !outcome.is_empty() {
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "[RECOVERY_STATE] Wallet: {} | Action: sweep_incoming | Resolved: {} | Discarded: {} | IncomingRemaining: {}",
+                self.store.file_name,
+                outcome.resolved.len(),
+                outcome.discarded.len(),
+                self.store.incoming_swapcoins.len()
+            );
+        }
         Ok(outcome)
     }
 

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1648,7 +1648,7 @@ impl Wallet {
         #[cfg(debug_assertions)]
         if !new_entries.is_empty() || !to_remove.is_empty() {
             log::debug!(
-                "[UTXO_STATE] Wallet: {} | Added: {} | Removed: {} | CachedUtxos: {} -> {} | IncomingSwapcoins: {} | OutgoingSwapcoins: {}",
+                "[UTXO_STATE] Source: wallet::api::update_utxo_cache | Wallet: {} | Added: {} | Removed: {} | CachedUtxos: {} -> {} | IncomingSwapcoins: {} | OutgoingSwapcoins: {}",
                 self.store.file_name,
                 new_entries.len(),
                 to_remove.len(),
@@ -2227,7 +2227,7 @@ impl Wallet {
                 );
                         #[cfg(debug_assertions)]
                         log::debug!(
-                            "[COIN_SELECTION] Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: grouped",
+                            "[COIN_SELECTION] Source: wallet::api::coin_select | Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: grouped",
                             self.store.file_name,
                             utxo_type,
                             result_utxos.len(),
@@ -2302,7 +2302,7 @@ impl Wallet {
                     log::info!("Selected {} {utxo_type} UTXOs", final_selection.len());
                     #[cfg(debug_assertions)]
                     log::debug!(
-                        "[COIN_SELECTION] Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: coinselect",
+                        "[COIN_SELECTION] Source: wallet::api::coin_select | Wallet: {} | Type: {} | Inputs: {} | Selected: {} | TargetWithFee: {} | Strategy: coinselect",
                         self.store.file_name,
                         utxo_type,
                         final_selection.len(),

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -290,7 +290,7 @@ impl Wallet {
         #[cfg(debug_assertions)]
         if let Ok(funding) = &result {
             log::debug!(
-                "[FUNDING_STATE] Wallet: {} | Amount: {} | Destinations: {} | FundingTxs: {} | MinerFee: {} | ManualUtxos: {} | ExcludedUtxos: {}",
+                "[FUNDING_STATE] Source: wallet::funding::create_funding_txes_random_amounts | Wallet: {} | Amount: {} | Destinations: {} | FundingTxs: {} | MinerFee: {} | ManualUtxos: {} | ExcludedUtxos: {}",
                 self.get_name(),
                 coinswap_amount.to_sat(),
                 destinations.len(),

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -287,6 +287,26 @@ impl Wallet {
 
         self.rpc.unlock_unspent_all()?;
 
+        #[cfg(debug_assertions)]
+        if let Ok(funding) = &result {
+            log::debug!(
+                "[FUNDING_STATE] Wallet: {} | Amount: {} | Destinations: {} | FundingTxs: {} | MinerFee: {} | ManualUtxos: {} | ExcludedUtxos: {}",
+                self.get_name(),
+                coinswap_amount.to_sat(),
+                destinations.len(),
+                funding.funding_txes.len(),
+                funding.total_miner_fee,
+                manually_selected_outpoints
+                    .as_ref()
+                    .map(Vec::len)
+                    .unwrap_or_default(),
+                excluded_outpoints
+                    .as_ref()
+                    .map(Vec::len)
+                    .unwrap_or_default()
+            );
+        }
+
         result
     }
 }

--- a/src/watch_tower/registry_storage.rs
+++ b/src/watch_tower/registry_storage.rs
@@ -94,6 +94,21 @@ impl FileRegistry {
             data
         };
 
+        #[cfg(debug_assertions)]
+        if let Ok(registry) = data.lock() {
+            log::debug!(
+                "[WATCH_STATE] Action: load_registry | Watches: {} | SpentWatches: {} | FidelityRecords: {} | Checkpoint: {:?}",
+                registry.watches.len(),
+                registry
+                    .watches
+                    .values()
+                    .filter(|watch| watch.spent_tx.is_some())
+                    .count(),
+                registry.fidelity.len(),
+                registry.checkpoint.as_ref().map(|cp| cp.height)
+            );
+        }
+
         Self { path, data }
     }
 
@@ -131,13 +146,31 @@ impl FileRegistry {
 impl FileRegistry {
     /// Inserts a watch request and flushes the registry to disk.
     pub fn upsert_watch(&mut self, req: &WatchRequest) {
-        self.with_data(|data| data.watches.insert(req.outpoint, req.clone()));
+        self.with_data(
+            |data| match data.watches.insert(req.outpoint, req.clone()) {
+                #[cfg(debug_assertions)]
+                None => log::debug!(
+                    "[WATCH_STATE] Action: register | Outpoint: {} | ActiveWatches: {}",
+                    req.outpoint,
+                    data.watches.len()
+                ),
+                _ => {}
+            },
+        );
         self.flush();
     }
 
     /// Removes a watch request for the given outpoint and flushes the registry to disk.
     pub fn remove_watch(&mut self, outpoint: OutPoint) {
-        self.with_data(|data| data.watches.remove(&outpoint));
+        self.with_data(|data| match data.watches.remove(&outpoint) {
+            #[cfg(debug_assertions)]
+            Some(_) => log::debug!(
+                "[WATCH_STATE] Action: unregister | Outpoint: {} | ActiveWatches: {}",
+                outpoint,
+                data.watches.len()
+            ),
+            _ => {}
+        });
         self.flush();
     }
 

--- a/src/watch_tower/registry_storage.rs
+++ b/src/watch_tower/registry_storage.rs
@@ -97,7 +97,7 @@ impl FileRegistry {
         #[cfg(debug_assertions)]
         if let Ok(registry) = data.lock() {
             log::debug!(
-                "[WATCH_STATE] Action: load_registry | Watches: {} | SpentWatches: {} | FidelityRecords: {} | Checkpoint: {:?}",
+                "[WATCH_STATE] Source: watch_tower::registry_storage::load | Action: load_registry | Watches: {} | SpentWatches: {} | FidelityRecords: {} | Checkpoint: {:?}",
                 registry.watches.len(),
                 registry
                     .watches
@@ -150,7 +150,7 @@ impl FileRegistry {
             |data| match data.watches.insert(req.outpoint, req.clone()) {
                 #[cfg(debug_assertions)]
                 None => log::debug!(
-                    "[WATCH_STATE] Action: register | Outpoint: {} | ActiveWatches: {}",
+                    "[WATCH_STATE] Source: watch_tower::registry_storage::upsert_watch | Action: register | Outpoint: {} | ActiveWatches: {}",
                     req.outpoint,
                     data.watches.len()
                 ),
@@ -165,7 +165,7 @@ impl FileRegistry {
         self.with_data(|data| match data.watches.remove(&outpoint) {
             #[cfg(debug_assertions)]
             Some(_) => log::debug!(
-                "[WATCH_STATE] Action: unregister | Outpoint: {} | ActiveWatches: {}",
+                "[WATCH_STATE] Source: watch_tower::registry_storage::remove_watch | Action: unregister | Outpoint: {} | ActiveWatches: {}",
                 outpoint,
                 data.watches.len()
             ),

--- a/src/watch_tower/utils.rs
+++ b/src/watch_tower/utils.rs
@@ -160,7 +160,7 @@ pub fn process_transaction(tx: &Transaction, registry: &mut FileRegistry, in_blo
                 registry.upsert_watch(&watch_request);
                 #[cfg(debug_assertions)]
                 log::debug!(
-                    "[WATCH_STATE] Action: watched_outpoint_spent | Outpoint: {} | SpendingTxid: {} | Confirmed: {}",
+                    "[WATCH_STATE] Source: watch_tower::utils::process_transaction | Action: watched_outpoint_spent | Outpoint: {} | SpendingTxid: {} | Confirmed: {}",
                     outpoint,
                     tx.compute_txid(),
                     in_block

--- a/src/watch_tower/utils.rs
+++ b/src/watch_tower/utils.rs
@@ -158,6 +158,13 @@ pub fn process_transaction(tx: &Transaction, registry: &mut FileRegistry, in_blo
                 watch_request.spent_tx = Some(tx.clone());
                 watch_request.in_block = in_block;
                 registry.upsert_watch(&watch_request);
+                #[cfg(debug_assertions)]
+                log::debug!(
+                    "[WATCH_STATE] Action: watched_outpoint_spent | Outpoint: {} | SpendingTxid: {} | Confirmed: {}",
+                    outpoint,
+                    tx.compute_txid(),
+                    in_block
+                );
             }
         }
     }

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -135,7 +135,7 @@ impl<R: Role> Watcher<R> {
         }
         #[cfg(debug_assertions)]
         log::debug!(
-            "[WATCH_STATE] Action: watcher_ready | Network: {} | ActiveWatches: {} | Checkpoint: {:?} | Discovery: {}",
+            "[WATCH_STATE] Source: watch_tower::watcher::run | Action: watcher_ready | Network: {} | ActiveWatches: {} | Checkpoint: {:?} | Discovery: {}",
             network,
             self.registry.list_watches().len(),
             self.registry.load_checkpoint().map(|cp| cp.height),

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -133,6 +133,14 @@ impl<R: Role> Watcher<R> {
         if let Err(e) = rest_backend.process_mempool(&mut self.registry) {
             log::warn!("Failed to process mempool on startup: {}", e);
         }
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "[WATCH_STATE] Action: watcher_ready | Network: {} | ActiveWatches: {} | Checkpoint: {:?} | Discovery: {}",
+            network,
+            self.registry.list_watches().len(),
+            self.registry.load_checkpoint().map(|cp| cp.height),
+            R::RUN_DISCOVERY
+        );
 
         let discovery_shutdown = Arc::new(AtomicBool::new(false));
         let registry = self.registry.clone();


### PR DESCRIPTION
## Description
Adds some verbose debug logs.
Fixes #549 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added more comprehensive debug-only logging across maker/taker swap flows, including swap phase/state comparisons, legacy/ECDSA and Taproot verification points, swap tracker load/save mismatches, and taker routing/negotiation/spare substitution details.
  * Expanded wallet debug visibility during recovery, UTXO cache updates, coin selection, incoming-swap sweeping, and funding tx generation.
  * Improved watch tower observability with debug logs for registry load/upserts/removals, sentinel additions, watched transaction spend marking, and watcher startup/network state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->