### PR TITLE
fix: update fee estimates

### DIFF
--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -53,6 +53,16 @@ use super::{
 const HARDENDED_DERIVATION_P2WPKH: &str = "m/84'/1'/0'";
 /// BIP-86 derivation path for P2TR (Taproot key-path)
 const HARDENDED_DERIVATION_P2TR: &str = "m/86'/1'/0'";
+/// P2WSH ECDSA: 2 sigs/sig+preimage + full redeemscript (~149)
+const LEGACY_CONTRACT_SPEND_VSIZE: u64 = 150;
+/// key-path: one 64B Schnorr sig, no script (~111)
+const TAPROOT_KEYPATH_VSIZE: u64 = 112;
+/// script-path: sig+preimage+script+control_block (~154)
+const TAPROOT_SCRIPTPATH_VSIZE: u64 = 155;
+/// ≈141 + 1 (growing block-height)
+const LEGACY_TIMELOCK_VSIZE: u64 = 142;
+/// ≈138 + 2 (growing block-height)
+const TAPROOT_TIMELOCK_VSIZE: u64 = 140;
 
 /// Represents a Bitcoin wallet with associated functionality and data.
 #[derive(Debug)]
@@ -187,12 +197,9 @@ impl UTXOSpendInfo {
     /// Estimates Witness Size for different types of UTXOs in the context of Coinswap
     pub fn estimate_witness_size(&self) -> usize {
         const P2WPKH_WITNESS_SIZE: usize = 107; // 1 + 72 (sig) + 33 (pubkey) + 1 (count)
-        const P2TR_WITNESS_SIZE: usize = 65; // 1 + 64 (Schnorr sig)
+        const P2TR_WITNESS_SIZE: usize = 66; // 1 (witness items) + 1 (Signature length) + 64 (Schnorr sig)
         const P2WSH_MULTISIG_2OF2_WITNESS_SIZE: usize = 218; //1 + 1 + 72 + 72 + 72
-        const FIDELITY_BOND_WITNESS_SIZE: usize = 115;
-        const TIME_LOCK_CONTRACT_TX_WITNESS_SIZE: usize = 179;
-        const HASH_LOCK_CONTRACT_TX_WITNESS_SIZE: usize = 211;
-
+        const FIDELITY_BOND_WITNESS_SIZE: usize = 115; // 1 (count) + 1 (sig len) + 71 (sig) + 1 (script len) + 40 (script) = ~114
         match self {
             Self::SeedCoin { address_type, .. } | Self::SweptCoin { address_type, .. } => {
                 match address_type {
@@ -203,10 +210,37 @@ impl UTXOSpendInfo {
             Self::IncomingSwapCoin { .. } | Self::OutgoingSwapCoin { .. } => {
                 P2WSH_MULTISIG_2OF2_WITNESS_SIZE
             }
-            Self::TimelockContract { .. } => TIME_LOCK_CONTRACT_TX_WITNESS_SIZE,
-            Self::HashlockContract { .. } => HASH_LOCK_CONTRACT_TX_WITNESS_SIZE,
+            Self::TimelockContract { .. } => 179,
+            Self::HashlockContract { .. } => 211,
             Self::FidelityBondCoin { .. } => FIDELITY_BOND_WITNESS_SIZE,
         }
+    }
+}
+
+/// Spend path of a swap transaction, for protocol-aware vsize estimation.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SpendKind {
+    /// Incoming swapcoin spend; `cooperative` = key-path/2-of-2 vs hashlock path.
+    ContractSpend { cooperative: bool },
+    /// Timelock recovery of an outgoing swapcoin.
+    Timelock,
+}
+
+/// Returns the estimated vsize (virtual bytes) for cooperative keypath, preimage (hashlock),
+/// and timelock recovery spend transactions only.
+pub(crate) fn contract_and_timelock_vsize(
+    protocol: crate::protocol::ProtocolVersion,
+    kind: SpendKind,
+) -> u64 {
+    use crate::protocol::ProtocolVersion::{Legacy, Taproot};
+    use SpendKind::{ContractSpend, Timelock};
+
+    match (protocol, kind) {
+        (Legacy, ContractSpend { .. }) => LEGACY_CONTRACT_SPEND_VSIZE,
+        (Taproot, ContractSpend { cooperative: true }) => TAPROOT_KEYPATH_VSIZE,
+        (Taproot, ContractSpend { cooperative: false }) => TAPROOT_SCRIPTPATH_VSIZE,
+        (Legacy, Timelock) => LEGACY_TIMELOCK_VSIZE,
+        (Taproot, Timelock) => TAPROOT_TIMELOCK_VSIZE,
     }
 }
 
@@ -900,7 +934,9 @@ impl Wallet {
             .get(contract_vout as usize)
             .ok_or_else(|| WalletError::General("No output in contract tx".to_string()))?;
 
-        let fee = Amount::from_sat((150.0 * fee_rate) as u64);
+        let vsize = contract_and_timelock_vsize(swapcoin.protocol, SpendKind::Timelock);
+
+        let fee = Amount::from_sat((vsize as f64 * fee_rate) as u64);
         let output_amount = contract_output.value.checked_sub(fee).ok_or_else(|| {
             WalletError::General("Insufficient funds for recovery fee".to_string())
         })?;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -13,6 +13,7 @@ mod split_utxos;
 mod storage;
 pub(crate) mod swapcoin;
 
+pub(crate) use api::{contract_and_timelock_vsize, SpendKind};
 pub use api::{Balances, RecoveryOutcome, UTXOSpendInfo, Wallet};
 pub use backup::WalletBackup;
 pub use error::WalletError;

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -19,7 +19,7 @@ use crate::protocol::{
     },
 };
 
-use super::WalletError;
+use super::{contract_and_timelock_vsize, SpendKind, WalletError};
 
 mod option_scalar_serde {
     use super::*;
@@ -385,8 +385,14 @@ impl IncomingSwapCoin {
             witness: Witness::default(),
         };
 
-        let estimated_vsize = 150u64;
-        let fee = Amount::from_sat((feerate * estimated_vsize as f64) as u64);
+        let vsize = contract_and_timelock_vsize(
+            self.protocol,
+            SpendKind::ContractSpend {
+                cooperative: self.other_privkey.is_some(),
+            },
+        );
+
+        let fee = Amount::from_sat((feerate * vsize as f64) as u64);
         let output_value = input_value
             .checked_sub(fee)
             .ok_or_else(|| WalletError::General("Fee exceeds input value".to_string()))?;
@@ -1169,7 +1175,6 @@ impl OutgoingSwapCoin {
 
             tx.input[0].witness = witness;
         }
-
         Ok(tx)
     }
 }

--- a/tests/integration/abort1.rs
+++ b/tests/integration/abort1.rs
@@ -218,7 +218,7 @@ fn taker_abort1() {
             maker_balances.spendable,
         );
 
-        let expected_regular = [14499833u64, 14500421][i];
+        let expected_regular = [14499831u64, 14500419][i];
         let expected_swap = [499400u64, 498775][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
@@ -240,7 +240,7 @@ fn taker_abort1() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999233u64, 14999196][i];
+        let expected_spendable = [14999231u64, 14999194][i];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable,

--- a/tests/integration/abort2_case1.rs
+++ b/tests/integration/abort2_case1.rs
@@ -136,7 +136,7 @@ fn maker_abort2_case1() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999533u64, 14999516, 14999496][i];
+        let expected_spendable = [14999531u64, 14999514, 14999494][i];
         assert_eq!(
             balances.spendable.to_sat(),
             expected_spendable,

--- a/tests/integration/abort2_case2.rs
+++ b/tests/integration/abort2_case2.rs
@@ -136,7 +136,7 @@ fn maker_abort2_case2() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999516u64, 14999496, 14999533][i];
+        let expected_spendable = [14999514u64, 14999494, 14999531][i];
         assert_eq!(
             balances.spendable.to_sat(),
             expected_spendable,

--- a/tests/integration/abort2_case3.rs
+++ b/tests/integration/abort2_case3.rs
@@ -181,7 +181,7 @@ fn maker_abort2_case3() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999092,
+        14999108,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -209,7 +209,7 @@ fn maker_abort2_case3() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        908,
+        892,
         "Taker spendable balance change mismatch"
     );
 
@@ -224,7 +224,7 @@ fn maker_abort2_case3() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998608u64, 14999516][i];
+        let expected_regular = [14998622u64, 14999514][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular,

--- a/tests/integration/abort3_case1.rs
+++ b/tests/integration/abort3_case1.rs
@@ -182,7 +182,7 @@ fn maker_abort3_case1() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999092,
+        14999108,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -210,7 +210,7 @@ fn maker_abort3_case1() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        908,
+        892,
         "Taker spendable balance change mismatch"
     );
 
@@ -225,7 +225,7 @@ fn maker_abort3_case1() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998608u64, 14999516][i];
+        let expected_regular = [14998622u64, 14999514][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular,

--- a/tests/integration/abort3_case2.rs
+++ b/tests/integration/abort3_case2.rs
@@ -220,7 +220,7 @@ fn maker_abort3_case2() {
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499833u64, 14500421][i];
+        let expected_regular = [14499831u64, 14500419][i];
         let expected_swap = [499400u64, 498775][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
@@ -242,7 +242,7 @@ fn maker_abort3_case2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999233u64, 14999196][i];
+        let expected_spendable = [14999231u64, 14999194][i];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable,

--- a/tests/integration/abort3_case3.rs
+++ b/tests/integration/abort3_case3.rs
@@ -215,7 +215,7 @@ fn maker_abort3_case3() {
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499833u64, 14500421][i];
+        let expected_regular = [14499831u64, 14500419][i];
         let expected_swap = [499700u64, 498775][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
@@ -237,7 +237,7 @@ fn maker_abort3_case3() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999533u64, 14999196][i];
+        let expected_spendable = [14999531u64, 14999194][i];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable,

--- a/tests/integration/concurrent_takers.rs
+++ b/tests/integration/concurrent_takers.rs
@@ -255,7 +255,7 @@ fn test_concurrent_takers_legacy() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(999533), Amount::from_sat(999496)];
+    let expected_maker_spendable = [Amount::from_sat(999531), Amount::from_sat(999494)];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {

--- a/tests/integration/malice1.rs
+++ b/tests/integration/malice1.rs
@@ -132,7 +132,7 @@ fn test_malice1_taker_broadcast_contract() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998608u64, 14998608][i];
+        let expected_regular = [14998622u64, 14998622][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular,

--- a/tests/integration/malice2.rs
+++ b/tests/integration/malice2.rs
@@ -142,7 +142,7 @@ fn test_malice2_maker_broadcast_contract() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998608u64, 14500421][i];
+        let expected_regular = [14998622u64, 14500419][i];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular,
@@ -195,7 +195,7 @@ fn test_malice2_maker_broadcast_contract() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999092,
+        14999108,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -223,7 +223,7 @@ fn test_malice2_maker_broadcast_contract() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        908,
+        892,
         "Taker spendable balance change mismatch"
     );
 

--- a/tests/integration/multi_taker.rs
+++ b/tests/integration/multi_taker.rs
@@ -233,7 +233,7 @@ fn test_multi_taker_coinswap() {
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [4999550u64, 4999476][i];
+        let expected_swap = [4999548u64, 4999474][i];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap,

--- a/tests/integration/standard_swap.rs
+++ b/tests/integration/standard_swap.rs
@@ -164,7 +164,7 @@ fn test_standard_coinswap() {
             balances.spendable,
         );
 
-        let expected_regular = [14499833u64, 14500421][i];
+        let expected_regular = [14499831u64, 14500419][i];
         let expected_swap = [499700u64, 499075][i];
         assert_eq!(
             balances.regular.to_sat(),

--- a/tests/integration/taproot_concurrent_takers.rs
+++ b/tests/integration/taproot_concurrent_takers.rs
@@ -257,7 +257,7 @@ fn test_concurrent_takers_taproot() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(999421), Amount::from_sat(999421)];
+    let expected_maker_spendable = [Amount::from_sat(999495), Amount::from_sat(999495)];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {

--- a/tests/integration/taproot_hashlock_recovery.rs
+++ b/tests/integration/taproot_hashlock_recovery.rs
@@ -182,7 +182,7 @@ fn test_taproot_hashlock_recovery() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        498674,
+        498664,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -205,7 +205,7 @@ fn test_taproot_hashlock_recovery() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        1634,
+        1644,
         "Taker spendable balance change mismatch"
     );
 
@@ -220,14 +220,14 @@ fn test_taproot_hashlock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499721, 14500234];
+        let expected_regular = [14499719, 14500232];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499700, 499187];
+        let expected_swap = [499776, 499263];
         assert_eq!(
             maker_balances.swap.to_sat(),
             expected_swap[i],
@@ -242,7 +242,7 @@ fn test_taproot_hashlock_recovery() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999421, 14999421];
+        let expected_spendable = [14999495, 14999495];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_maker_abort2.rs
+++ b/tests/integration/taproot_maker_abort2.rs
@@ -185,7 +185,7 @@ fn test_taproot_maker_abort2() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        498674,
+        498664,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -208,7 +208,7 @@ fn test_taproot_maker_abort2() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        1634,
+        1644,
         "Taker spendable balance change mismatch"
     );
 
@@ -223,14 +223,14 @@ fn test_taproot_maker_abort2() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499721, 14500234];
+        let expected_regular = [14499719, 14500232];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499700, 499187];
+        let expected_swap = [499776, 499177];
         assert_eq!(
             maker_balances.swap.to_sat(),
             expected_swap[i],
@@ -245,7 +245,7 @@ fn test_taproot_maker_abort2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999421, 14999421];
+        let expected_spendable = [14999495, 14999409];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_maker_abort3.rs
+++ b/tests/integration/taproot_maker_abort3.rs
@@ -129,7 +129,7 @@ fn test_taproot_maker_abort3() {
 
     assert_eq!(
         taker_balances.spendable.to_sat(),
-        14998366,
+        14998442,
         "Taker spendable balance mismatch"
     );
     assert_eq!(
@@ -146,7 +146,7 @@ fn test_taproot_maker_abort3() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999421, 14999516, 14999421];
+        let expected_spendable = [14999495, 14999514, 14999495];
         assert_eq!(
             balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_multi_maker.rs
+++ b/tests/integration/taproot_multi_maker.rs
@@ -150,7 +150,7 @@ fn test_taproot_multi_maker_coinswap() {
 
     assert_eq!(
         taker_balances_after.spendable.to_sat(),
-        24997340,
+        24997416,
         "Taker spendable balance mismatch"
     );
     assert_eq!(
@@ -159,7 +159,7 @@ fn test_taproot_multi_maker_coinswap() {
         "Taker contract balance mismatch"
     );
     assert_eq!(taker_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff.to_sat(), 2660, "Taker fee paid mismatch");
+    assert_eq!(balance_diff.to_sat(), 2584, "Taker fee paid mismatch");
 
     // Verify all 4 makers earned fees
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -171,14 +171,14 @@ fn test_taproot_multi_maker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499721, 14500234, 14500747, 14501260];
+        let expected_regular = [14499719, 14500232, 14500745, 14501258];
         assert_eq!(
             balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499700, 499187, 498674, 498161];
+        let expected_swap = [499776, 499263, 498750, 498237];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],

--- a/tests/integration/taproot_multi_taker.rs
+++ b/tests/integration/taproot_multi_taker.rs
@@ -178,7 +178,7 @@ fn test_taproot_multi_taker_coinswap() {
 
     assert_eq!(
         taker1_balances_after.spendable.to_sat(),
-        14998366,
+        14998442,
         "Taker 1 spendable balance mismatch"
     );
     assert_eq!(
@@ -187,7 +187,7 @@ fn test_taproot_multi_taker_coinswap() {
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff1.to_sat(), 1634, "Taker 1 fee paid mismatch");
+    assert_eq!(balance_diff1.to_sat(), 1558, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -206,7 +206,7 @@ fn test_taproot_multi_taker_coinswap() {
 
     assert_eq!(
         taker2_balances_after.spendable.to_sat(),
-        14998366,
+        14998442,
         "Taker 2 spendable balance mismatch"
     );
     assert_eq!(
@@ -215,7 +215,7 @@ fn test_taproot_multi_taker_coinswap() {
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff2.to_sat(), 1634, "Taker 2 fee paid mismatch");
+    assert_eq!(balance_diff2.to_sat(), 1558, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -234,7 +234,7 @@ fn test_taproot_multi_taker_coinswap() {
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [4999326, 4999326];
+        let expected_swap = [4999476, 4999476];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],

--- a/tests/integration/taproot_swap.rs
+++ b/tests/integration/taproot_swap.rs
@@ -127,7 +127,7 @@ fn test_taproot_coinswap() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        498674,
+        498750,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -145,7 +145,7 @@ fn test_taproot_coinswap() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        1634,
+        1558,
         "Taker spendable balance change mismatch"
     );
 
@@ -158,14 +158,14 @@ fn test_taproot_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499721, 14500234];
+        let expected_regular = [14499719, 14500232];
         assert_eq!(
             balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499700, 499187];
+        let expected_swap = [499776, 499263];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],

--- a/tests/integration/taproot_taker_abort2.rs
+++ b/tests/integration/taproot_taker_abort2.rs
@@ -141,7 +141,7 @@ fn test_taproot_taker_abort2() {
         );
         assert_eq!(
             maker_balances.regular.to_sat(),
-            14999516,
+            14999514,
             "Maker {} regular balance mismatch",
             i
         );
@@ -191,7 +191,7 @@ fn test_taproot_taker_abort2() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999392,
+        14999412,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -219,7 +219,7 @@ fn test_taproot_taker_abort2() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        608,
+        588,
         "Taker spendable balance change mismatch"
     );
 

--- a/tests/integration/taproot_taker_abort3.rs
+++ b/tests/integration/taproot_taker_abort3.rs
@@ -140,7 +140,7 @@ fn test_taproot_taker_abort3() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998908, 14999516];
+        let expected_regular = [14998926, 14999514];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],
@@ -193,7 +193,7 @@ fn test_taproot_taker_abort3() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999392,
+        14999412,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -221,7 +221,7 @@ fn test_taproot_taker_abort3() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        608,
+        588,
         "Taker spendable balance change mismatch"
     );
 

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -180,7 +180,7 @@ fn test_taproot_timelock_recovery() {
 
     assert_eq!(
         taker_balances.regular.to_sat(),
-        14999392,
+        14999412,
         "Taker regular balance mismatch"
     );
     assert_eq!(
@@ -208,7 +208,7 @@ fn test_taproot_timelock_recovery() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        608,
+        588,
         "Taker spendable balance change mismatch"
     );
 
@@ -223,7 +223,7 @@ fn test_taproot_timelock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998908, 14999516];
+        let expected_regular = [14998926, 14999514];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -346,7 +346,7 @@ pub fn verify_maker_pre_swap_balances(makers: &[Arc<MakerServer>]) -> Vec<Amount
         // Regular balance after fidelity bond creation
         let regular = balances.regular.to_sat();
         assert!(
-            regular == 14999516,
+            regular == 14999514,
             "Maker regular balance check after fidelity bond creation: {}",
             regular
         );


### PR DESCRIPTION
# Pull Request

## Description
fix(wallet): size recovery/sweep fees by protocol & spend path

Replace the flat 150-vbyte fee estimate in sign_spend_transaction and
create_timelock_recovery_tx with measured per-case vsizes — the witness
(and thus tx size) differs across legacy/taproot and cooperative/
hashlock/timelock spends.


## Related Issue(s)
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee estimation across contract and timelock flows, including updated Taproot witness-size handling.
  * Timelock recovery fees are now calculated from protocol-aware transaction size estimates rather than a fixed amount.
  * Contract spend fees now vary by protocol version and whether the spend is cooperative.
* **Tests**
  * Updated integration test balance assertions across abort, malicious, concurrent takers, and Taproot (Legacy/Timelock) recovery scenarios to match the corrected fee behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->