### PR TITLE
reduce hotpath profiling noise

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -34,24 +34,59 @@ jobs:
           cargo install hotpath --version 0.15.0 --features utils --bin hotpath-utils --locked
 
       - name: Generate filtered PR comment
+        env:
+          HOTPATH_COMMENT_MIN_CHANGE_PERCENT: "5"
         run: |
           set -euo pipefail
           export GITHUB_BASE_REF="$(cat /tmp/metrics/base_ref.txt)"
           export GITHUB_HEAD_REF="$(cat /tmp/metrics/head_ref.txt)"
 
-          hotpath-utils profile-pr \
-            --head-metrics /tmp/metrics/head_maker.json \
-            --base-metrics /tmp/metrics/base_maker.json \
-            --benchmark-id "maker" \
-            --dry-run > /tmp/metrics/maker_comment.md
-          perl -i -pe 's/\([+-]0(?:\.0+)?%\)/" " x length($&)/eg' /tmp/metrics/maker_comment.md
+          for benchmark in maker taker; do
+            comment="/tmp/metrics/${benchmark}_comment.md"
+            hotpath-utils profile-pr \
+              --head-metrics "/tmp/metrics/head_${benchmark}.json" \
+              --base-metrics "/tmp/metrics/base_${benchmark}.json" \
+              --benchmark-id "$benchmark" \
+              --dry-run > "$comment"
+            perl -i -pe 's/\([+-]0(?:\.0+)?%\)/" " x length($&)/eg' "$comment"
+            perl -i -ne '
+              BEGIN { $threshold = $ENV{HOTPATH_COMMENT_MIN_CHANGE_PERCENT} // 5; }
 
-          hotpath-utils profile-pr \
-            --head-metrics /tmp/metrics/head_taker.json \
-            --base-metrics /tmp/metrics/base_taker.json \
-            --benchmark-id "taker" \
-            --dry-run > /tmp/metrics/taker_comment.md
-          perl -i -pe 's/\([+-]0(?:\.0+)?%\)/" " x length($&)/eg' /tmp/metrics/taker_comment.md
+              if ($drop_separator && /^\+-[-+]+\+\s*$/) {
+                  $drop_separator = 0;
+                  next;
+              }
+              $drop_separator = 0;
+
+              if (/^\|\s+(Function|Thread)\s+\|/) {
+                  $section = lc $1;
+                  print;
+                  next;
+              }
+
+              if (/^\|\s/ && !/^\|\s*(?:Function|Thread)\s+\|/) {
+                  my ($row) = /^\|(.*)\|\s*$/;
+                  my @columns = split /\|/, $row;
+                  s/^\s+|\s+$//g for @columns;
+
+                  # Function rows ignore "% Total"; it shifts when total run time changes.
+                  my @changes = $section eq "function" ? @columns[1..4] : @columns[1..$#columns];
+                  my $max = 0;
+                  for (@changes) {
+                      while (/\(([+-](?:\d+(?:\.\d+)?|\.\d+)%)\)/g) {
+                          (my $change = $1) =~ s/%$//;
+                          $max = abs($change) if abs($change) > $max;
+                      }
+                  }
+                  if ($max < $threshold) {
+                      $drop_separator = 1;
+                      next;
+                  }
+              }
+
+              print;
+            ' "$comment"
+          done
 
           {
             echo "<!-- hotpath-profile -->"

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -29,7 +29,6 @@ pub trait MakerRpc {
     fn get_tor_hostname(&self) -> Result<String, TorError>;
 }
 
-#[hotpath::measure]
 fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result<(), MakerError> {
     let msg_bytes = read_message(socket)?;
     let rpc_request: RpcMsgReq = serde_cbor::from_slice(&msg_bytes)?;
@@ -159,7 +158,6 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
     Ok(())
 }
 
-#[hotpath::measure]
 pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerError> {
     let rpc_port = maker.config().rpc_port;
     let listener = TcpListener::bind(("127.0.0.1", rpc_port))?;

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -42,7 +42,6 @@ const FIDELITY_BOND_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
 const FIDELITY_BOND_UPDATE_INTERVAL: Duration = Duration::from_secs(600);
 
 /// Start the maker server.
-#[hotpath::measure]
 pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     log::info!("[{}] Starting maker server", maker.config.network_port);
 
@@ -217,7 +216,6 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
 }
 
 /// Spawn a background thread for nostr bond announcements.
-#[hotpath::measure]
 fn spawn_nostr_broadcast_thread(
     maker: &Arc<MakerServer>,
     fidelity: FidelityProof,
@@ -419,7 +417,6 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
 }
 
 /// Background thread that checks for idle swap states and spawns recovery.
-#[hotpath::measure]
 fn check_for_idle_states(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     use super::swap_tracker::{now_secs, MakerRecoveryState, MakerSwapPhase, MakerSwapRecord};
 
@@ -481,7 +478,6 @@ fn check_for_idle_states(maker: Arc<MakerServer>) -> Result<(), MakerError> {
 }
 
 /// Periodically check for expired fidelity bonds and renew them.
-#[hotpath::measure]
 fn fidelity_renewal_loop(maker: Arc<MakerServer>, maker_address: &str) -> Result<(), MakerError> {
     use crate::wallet::AddressType;
 
@@ -958,7 +954,6 @@ fn recover_from_swap(
 }
 
 /// Read a message from a stream.
-#[hotpath::measure]
 fn read_message(stream: &TcpStream) -> Result<TakerToMakerMessage, MakerError> {
     let mut len_buf = [0u8; 4];
     use std::io::Read;
@@ -984,7 +979,6 @@ fn read_message(stream: &TcpStream) -> Result<TakerToMakerMessage, MakerError> {
 }
 
 /// Send a message to a stream.
-#[hotpath::measure]
 fn send_message(stream: &TcpStream, message: &MakerToTakerMessage) -> Result<(), MakerError> {
     let buf = serde_cbor::to_vec(message)
         .map_err(|_| MakerError::General("Failed to serialize message"))?;
@@ -1004,7 +998,6 @@ fn send_message(stream: &TcpStream, message: &MakerToTakerMessage) -> Result<(),
 }
 
 /// Retry with different ports if not availabe
-#[hotpath::measure]
 pub fn bind_port_retry(port: u16) -> Result<(TcpListener, u16), MakerError> {
     let mut current_port = port + 2;
     const MAX_PORT: u16 = 62000;

--- a/src/maker/swap_tracker.rs
+++ b/src/maker/swap_tracker.rs
@@ -200,7 +200,6 @@ impl MakerSwapTracker {
     }
 
     /// Upsert a swap record and flush to disk.
-    #[hotpath::measure]
     pub fn save_record(&mut self, record: &MakerSwapRecord) -> Result<(), MakerError> {
         self.data
             .swaps
@@ -209,13 +208,11 @@ impl MakerSwapTracker {
     }
 
     /// Get a reference to a swap record by ID.
-    #[hotpath::measure]
     pub fn get_record(&self, swap_id: &str) -> Option<&MakerSwapRecord> {
         self.data.swaps.get(swap_id)
     }
 
     /// Get a mutable reference to a swap record by ID.
-    #[hotpath::measure]
     pub fn get_record_mut(&mut self, swap_id: &str) -> Option<&mut MakerSwapRecord> {
         self.data.swaps.get_mut(swap_id)
     }

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -112,7 +112,6 @@ pub struct AckSwapDetails {
 
 impl AckSwapDetails {
     /// Create an acceptance response.
-    #[hotpath::measure]
     pub fn accept(tweakable_point: PublicKey) -> Self {
         AckSwapDetails {
             tweakable_point: Some(tweakable_point),

--- a/src/protocol/legacy_messages.rs
+++ b/src/protocol/legacy_messages.rs
@@ -196,7 +196,6 @@ impl Display for LegacyTakerMessage {
 
 impl LegacyTakerMessage {
     /// Returns the swap ID.
-    #[hotpath::measure]
     pub fn swap_id(&self) -> &str {
         match self {
             Self::ReqContractSigsForSender(req) => &req.id,

--- a/src/protocol/musig2.rs
+++ b/src/protocol/musig2.rs
@@ -13,7 +13,6 @@ use secp256k1::{
 use crate::protocol::error::ProtocolError;
 
 /// get aggregated public key from two public keys
-#[hotpath::measure]
 pub fn get_aggregated_pubkey(pubkey1: &PublicKey, pubkey2: &PublicKey) -> XOnlyPublicKey {
     let mut pubkeys = [pubkey1, pubkey2];
     // Sort pubkeys lexicographically (manual implementation)
@@ -23,14 +22,12 @@ pub fn get_aggregated_pubkey(pubkey1: &PublicKey, pubkey2: &PublicKey) -> XOnlyP
 }
 
 /// Generates a new nonce pair
-#[hotpath::measure]
 pub fn generate_new_nonce_pair(pubkey: PublicKey) -> (SecretNonce, PublicNonce) {
     let musig_session_sec_rand = SessionSecretRand::from_rng(&mut rand::rng());
     new_nonce_pair(musig_session_sec_rand, None, None, pubkey, None, None)
 }
 
 /// Generates a partial signature
-#[hotpath::measure]
 pub fn generate_partial_signature(
     message: Message,
     agg_nonce: &AggregatedNonce,
@@ -46,7 +43,6 @@ pub fn generate_partial_signature(
 }
 
 /// Aggregates the partial signatures
-#[hotpath::measure]
 pub fn aggregate_partial_signatures(
     message: Message,
     agg_nonce: AggregatedNonce,

--- a/src/protocol/musig_interface.rs
+++ b/src/protocol/musig_interface.rs
@@ -31,7 +31,6 @@ macro_rules! btc_msg_to_secp {
 }
 
 /// Aggregates the public keys
-#[hotpath::measure]
 pub fn get_aggregated_pubkey_compat(
     pubkey1: btc_secp::PublicKey,
     pubkey2: btc_secp::PublicKey,
@@ -45,7 +44,6 @@ pub fn get_aggregated_pubkey_compat(
 }
 
 /// Generates a new nonce pair
-#[hotpath::measure]
 pub fn generate_new_nonce_pair_compat(
     nonce_pubkey: btc_secp::PublicKey,
 ) -> Result<(secp::musig::SecretNonce, secp::musig::PublicNonce), ProtocolError> {
@@ -54,7 +52,6 @@ pub fn generate_new_nonce_pair_compat(
 }
 
 /// Get aggregated nonce
-#[hotpath::measure]
 pub fn get_aggregated_nonce_compat(
     nonces: &[&secp::musig::PublicNonce],
 ) -> secp::musig::AggregatedNonce {
@@ -62,7 +59,6 @@ pub fn get_aggregated_nonce_compat(
 }
 
 /// Generates a partial signature
-#[hotpath::measure]
 pub fn generate_partial_signature_compat(
     message: btc_secp::Message,
     agg_nonce: &secp::musig::AggregatedNonce,
@@ -84,7 +80,6 @@ pub fn generate_partial_signature_compat(
 }
 
 /// Aggregates the partial signatures
-#[hotpath::measure]
 pub fn aggregate_partial_signatures_compat(
     message: btc_secp::Message,
     agg_nonce: secp::musig::AggregatedNonce,

--- a/src/protocol/taproot_messages.rs
+++ b/src/protocol/taproot_messages.rs
@@ -14,7 +14,6 @@ pub struct SerializableScalar(pub Vec<u8>);
 
 impl SerializableScalar {
     /// Create from raw bytes.
-    #[hotpath::measure]
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         SerializableScalar(bytes)
     }
@@ -75,7 +74,6 @@ pub struct TaprootContractData {
 impl TaprootContractData {
     /// Create a new TaprootContractData message.
     #[allow(clippy::too_many_arguments)]
-    #[hotpath::measure]
     pub fn new(
         id: String,
         pubkeys: Vec<PublicKey>,
@@ -105,7 +103,6 @@ impl TaprootContractData {
     }
 
     /// Convenience method to get the tap tweak as a Scalar.
-    #[hotpath::measure]
     pub fn tap_tweak_scalar(
         &self,
     ) -> Result<bitcoin::secp256k1::Scalar, crate::protocol::error::ProtocolError> {
@@ -124,7 +121,6 @@ pub enum TaprootTakerMessage {
 
 impl TaprootTakerMessage {
     /// Returns the swap ID.
-    #[hotpath::measure]
     pub fn swap_id(&self) -> &str {
         match self {
             Self::ContractData(data) => &data.id,

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -47,7 +47,6 @@ impl RecoveryLoop {
     ///
     /// The `swap_tracker` is used to update per-contract resolution outcomes
     /// as contracts are resolved in the background.
-    #[hotpath::measure]
     pub(crate) fn start(
         wallet: Arc<RwLock<Wallet>>,
         swap_tracker: Arc<Mutex<SwapTracker>>,
@@ -237,7 +236,6 @@ impl RecoveryLoop {
     }
 
     /// Match resolved contract txids against tracker records and update outcomes.
-    #[hotpath::measure]
     fn update_tracker_outcomes(
         tracker: &mut SwapTracker,
         incoming: Option<&crate::wallet::RecoveryOutcome>,
@@ -390,7 +388,6 @@ pub(crate) struct BreachDetector {
 
 impl BreachDetector {
     /// Spawn a background thread that polls the WatchService for sentinel spends.
-    #[hotpath::measure]
     pub(crate) fn start(watch_service: WatchService) -> Self {
         let breached = Arc::new(AtomicBool::new(false));
         let sentinels: Arc<Mutex<Vec<(OutPoint, Txid)>>> = Arc::new(Mutex::new(Vec::new()));
@@ -455,7 +452,6 @@ impl BreachDetector {
     /// Each sentinel is a `(funding_outpoint, expected_contract_txid)` pair.
     /// Only a spend matching the contract txid is considered adversarial;
     /// cooperative spends (after finalization) produce a different txid and are ignored.
-    #[hotpath::measure]
     pub(crate) fn add_sentinels(
         &self,
         watch_service: &WatchService,

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -101,7 +101,6 @@ fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> ScriptBuf 
 
 /// Verifies a fidelity bond by checking timelock validity,
 /// certificate integrity, redeem script existence, and ECDSA signature correctness.
-#[hotpath::measure]
 pub(crate) fn verify_fidelity_checks(
     proof: &FidelityProof,
     addr: &str,
@@ -185,7 +184,6 @@ pub(crate) fn verify_fidelity_checks(
 
 #[allow(unused)]
 /// Reads the locktime from a fidelity redeemscript.
-#[hotpath::measure]
 fn read_locktime_from_fidelity_script(redeemscript: &ScriptBuf) -> Result<LockTime, FidelityError> {
     if let Some(Ok(Instruction::PushBytes(locktime_bytes))) = redeemscript.instructions().nth(2) {
         let mut u4slice: [u8; 4] = [0; 4];
@@ -404,7 +402,6 @@ impl Wallet {
     /// Calculate the theoretical fidelity bond value.
     /// Bond value calculation is described in the document below.
     /// <https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b#financial-mathematics-of-joinmarket-fidelity-bonds>
-    #[hotpath::measure]
     pub fn calculate_bond_value(&self, bond: &FidelityBond) -> Result<Amount, WalletError> {
         let current_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -448,7 +445,6 @@ impl Wallet {
     /// Upon confirmation it stores the fidelity information in the wallet data.
     /// Create and broadcast the fidelity bond transaction. Returns `(index, txid)`
     /// so the caller can wait for confirmation without holding the wallet lock.
-    #[hotpath::measure]
     pub fn create_fidelity(
         &mut self,
         amount: Amount,
@@ -499,7 +495,6 @@ impl Wallet {
     }
 
     /// Update the confirmation height of a fidelity bond after it confirms.
-    #[hotpath::measure]
     pub fn update_fidelity_bond_conf_details(
         &mut self,
         index: u32,
@@ -517,7 +512,6 @@ impl Wallet {
     }
 
     /// Redeems all expired fidelity bonds in the wallet ,if found any.
-    #[hotpath::measure]
     pub fn redeem_expired_fidelity_bonds(
         &mut self,
         destination_address_type: AddressType,
@@ -546,7 +540,6 @@ impl Wallet {
     }
 
     /// Generate a [`FidelityProof`] for bond at a given index and a specific onion address.
-    #[hotpath::measure]
     pub(crate) fn generate_fidelity_proof(
         &self,
         index: u32,

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -35,7 +35,6 @@ use crate::{
 
 // ## TODO: Instead of looping over relay's have a connection Pool.
 /// Runs the main discovery routine for maker's fidelity bonds by subscribing to network-specific Nostr events.
-#[hotpath::measure]
 pub fn run_discovery(
     bitcoin_rpc: BitcoinRest,
     network: Network,
@@ -87,7 +86,6 @@ pub fn run_discovery(
 
 /// Runs a long-lived Nostr session for a single relay.
 /// Reconnects automatically until shutdown is requested.
-#[hotpath::measure]
 #[allow(clippy::too_many_arguments)]
 fn run_nostr_session_for_relay(
     relay_url: &str,
@@ -129,7 +127,6 @@ fn run_nostr_session_for_relay(
 }
 
 /// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
-#[hotpath::measure]
 #[allow(clippy::too_many_arguments)]
 fn connect_and_run_once(
     relay_url: &str,
@@ -183,7 +180,6 @@ fn connect_and_run_once(
 }
 
 /// Stream all the events from the Nostr relay and deserialize from json until shutdown.
-#[hotpath::measure]
 #[allow(clippy::too_many_arguments)]
 fn read_event_loop(
     registry: Arc<FileRegistry>,
@@ -251,7 +247,6 @@ fn read_event_loop(
 }
 
 /// Processes a single relay message. Returns `Ok(true)` when EOSE is received.
-#[hotpath::measure]
 fn handle_relay_message(
     registry: Arc<FileRegistry>,
     msg: RelayMessage,

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -77,7 +77,6 @@ impl WatchService {
 }
 
 /// Starts the Maker Watch Service
-#[hotpath::measure]
 pub fn start_maker_watch_service(
     zmq_addr: &str,
     rpc_config: &RPCConfig,

--- a/src/watch_tower/utils.rs
+++ b/src/watch_tower/utils.rs
@@ -79,7 +79,6 @@ fn is_valid_address(s: &str) -> bool {
     matches!(port.parse::<u16>(), Ok(p) if p > 0)
 }
 
-#[hotpath::measure]
 fn parse_fidelity_op_return(data: &[u8]) -> Option<FidelityAnnouncement> {
     let decoded = std::str::from_utf8(data).ok()?;
     let (endpoint, locktime_str) = decoded.split_once('#')?;
@@ -106,7 +105,6 @@ fn parse_fidelity_op_return(data: &[u8]) -> Option<FidelityAnnouncement> {
 }
 
 /// Process a transaction for fidelity OP_RETURN announcement.
-#[hotpath::measure]
 pub fn process_fidelity(tx: &Transaction) -> Option<FidelityAnnouncement> {
     // Fidelity txs must be timelocked
     if tx.lock_time == LockTime::Blocks(Height::ZERO) {
@@ -130,7 +128,6 @@ pub fn process_fidelity(tx: &Transaction) -> Option<FidelityAnnouncement> {
 }
 
 /// Processes each transaction in a block, updating watch entries and recording fidelity data.
-#[hotpath::measure]
 pub fn process_block<R: Role>(block: Block, registry: &mut FileRegistry) {
     for tx in block.txdata.iter() {
         process_transaction(tx, registry, true);
@@ -147,7 +144,6 @@ pub fn process_block<R: Role>(block: Block, registry: &mut FileRegistry) {
 }
 
 /// Updates the registry for a transaction by clearing spent fidelities and marking watched spends.
-#[hotpath::measure]
 pub fn process_transaction(tx: &Transaction, registry: &mut FileRegistry, in_block: bool) {
     let watch_requests = registry.list_watches();
     for input in &tx.input {
@@ -163,7 +159,6 @@ pub fn process_transaction(tx: &Transaction, registry: &mut FileRegistry, in_blo
     }
 }
 
-#[hotpath::measure]
 pub(crate) fn parse_fidelity_event(event: &nostr::Event) -> Option<(Txid, u32)> {
     let content = event.content.trim();
     let (txid, vout) = content.split_once(':')?;

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -83,7 +83,6 @@ pub enum WatcherCommand {
 
 impl<R: Role> Watcher<R> {
     /// Creates a watcher with its backend, registry, and communication channels.
-    #[hotpath::measure]
     pub fn new(
         backend: ZmqBackend,
         registry: FileRegistry,
@@ -104,7 +103,6 @@ impl<R: Role> Watcher<R> {
     }
 
     /// Runs the watcher loop: handles ZMQ events and commands, optionally spawning discovery.
-    #[hotpath::measure]
     pub fn run(
         &mut self,
         rpc_config: RPCConfig,
@@ -180,7 +178,6 @@ impl<R: Role> Watcher<R> {
         Ok(())
     }
 
-    #[hotpath::measure]
     fn handle_command(&mut self, cmd: WatcherCommand) -> bool {
         match cmd {
             WatcherCommand::RegisterWatchRequest { outpoint } => {
@@ -219,7 +216,6 @@ impl<R: Role> Watcher<R> {
     }
 
     /// Handles a backend event, updating registry state and checkpoints.
-    #[hotpath::measure]
     pub fn handle_event(&mut self, ev: BackendEvent) {
         match ev {
             BackendEvent::TxSeen { raw_tx } => {

--- a/src/watch_tower/zmq_backend.rs
+++ b/src/watch_tower/zmq_backend.rs
@@ -28,7 +28,6 @@ pub struct ZmqBackend {
 
 impl ZmqBackend {
     /// Connects to a ZMQ endpoint and subscribes to rawtx and rawblock topics.
-    #[hotpath::measure]
     pub fn new(endpoint: &str) -> Self {
         let ctx = zmq::Context::new();
         let socket = ctx.socket(zmq::SUB).expect("socket");
@@ -44,7 +43,6 @@ impl ZmqBackend {
         Self { socket }
     }
 
-    #[hotpath::measure]
     fn recv_event(&self) -> Option<(String, Vec<u8>)> {
         let msg = self.socket.recv_multipart(zmq::DONTWAIT).ok()?;
         if msg.len() < 2 {
@@ -59,7 +57,6 @@ impl ZmqBackend {
 
 impl ZmqBackend {
     /// Non-blocking poll for the next backend event.
-    #[hotpath::measure]
     pub fn poll(&mut self) -> Option<BackendEvent> {
         let (topic, payload) = self.recv_event()?;
 


### PR DESCRIPTION
- Reduces `#[hotpath::measure]` calls from 162 -> 106.
- Shortened hotpath PR comments by filtering `maker/taker` table rows to only show metrics with at least a 5% direct change.

Can See [here](https://github.com/0xEgao/coinswap/pull/7#issuecomment-4786855177) the result of these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated PR comments by combining maker and taker results into one report and filtering out low-signal table rows for easier review.
* **Refactor**
  * Removed performance-measurement annotations from several wallet, protocol, watch-tower, maker, and RPC code paths without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->