### PR TITLE
(Feat) Multi-txn pathway, Add miner fee per hop to outgoing amt

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -130,6 +130,8 @@ enum Commands {
         /// Sets the swap amount in sats.
         #[clap(long, short = 'a', default_value = "20000")]
         amount: u64,
+        #[clap(long = "tx-count", default_value = "1")]
+        tx_count: u32,
         /// Protocol version to use: "legacy" or "taproot"
         #[clap(long, default_value = "legacy")]
         protocol: String,
@@ -473,6 +475,7 @@ fn main() -> Result<(), TakerError> {
         Commands::Coinswap {
             makers,
             amount,
+            tx_count,
             protocol,
             maker_addresses,
             auto_select,
@@ -501,6 +504,7 @@ fn main() -> Result<(), TakerError> {
 
             let mut swap_params =
                 SwapParams::new(protocol_version, Amount::from_sat(*amount), *makers);
+            swap_params.tx_count = *tx_count;
             swap_params.manually_selected_outpoints = manually_selected_outpoints;
             if !maker_addresses.is_empty() {
                 swap_params.preferred_makers = Some(maker_addresses.clone());

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use bitcoin::{secp256k1::SecretKey, PublicKey, ScriptBuf};
+use bitcoin::{secp256k1::SecretKey, Amount, PublicKey, ScriptBuf};
 
 use super::{
     error::MakerError,
@@ -17,7 +17,7 @@ use crate::{
         },
         legacy_messages::{FundingTxInfo, LegacyTakerMessage},
     },
-    utill::redeemscript_to_scriptpubkey,
+    utill::{estimate_funding_tx_fee_sats, redeemscript_to_scriptpubkey},
     wallet::{swapcoin::IncomingSwapCoin, MakerReport},
 };
 
@@ -244,15 +244,19 @@ fn process_proof_of_funding<M: Maker>(
     );
 
     let swap_fee = maker.calculate_swap_fee(incoming_amount, pof.refund_locktime as u32);
+    let mining_fee =
+        Amount::from_sat(estimate_funding_tx_fee_sats() * pof.next_coinswap_info.len() as u64);
     let outgoing_amount = incoming_amount
         .checked_sub(swap_fee)
+        .and_then(|amt| amt.checked_sub(mining_fee))
         .ok_or(MakerError::General("Swap fee exceeds incoming amount"))?;
 
     log::info!(
-        "[{}] Incoming: {}, Fee: {}, Outgoing: {}",
+        "[{}] Incoming: {}, Fee: {}, MiningFee: {}, Outgoing: {}",
         maker.network_port(),
         incoming_amount,
         swap_fee,
+        mining_fee,
         outgoing_amount
     );
 

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -738,6 +738,35 @@ fn recover_from_swap(
         outgoing_swapcoins.len()
     );
 
+    let all_swap_contracts_resolved = || -> Result<bool, MakerError> {
+        let wallet = maker
+            .wallet
+            .read()
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+
+        let contract_txids = outgoing_swapcoins
+            .iter()
+            .map(|s| (s.contract_tx.compute_txid(), s.get_contract_output_vout()))
+            .chain(
+                incoming_swapcoins
+                    .iter()
+                    .map(|s| (s.contract_tx.compute_txid(), s.get_contract_output_vout())),
+            );
+
+        for (txid, vout) in contract_txids {
+            if wallet
+                .rpc
+                .get_tx_out(&txid, vout, None)
+                .map_err(crate::wallet::WalletError::Rpc)?
+                .is_some()
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    };
+    let mut timelock_recovery_txids = Vec::new();
+
     // Check if funding was ever broadcast. Only an explicit tracker record with
     // funding_broadcast=false is safe to discard; missing tracker state can
     // happen after a reboot and must not delete persisted recovery material.
@@ -942,37 +971,39 @@ fn recover_from_swap(
                 // Tracker: TimelockRecovered → Recovered + CleanedUp
                 let recovered_txids: Vec<_> =
                     recovered.resolved.iter().map(|(_, txid)| *txid).collect();
+                timelock_recovery_txids.extend(recovered_txids.iter().copied());
                 update_tracker(&maker, &swap_id, |r| {
-                    r.recovery.outgoing_recovered = recovered_txids;
+                    r.recovery.outgoing_recovered = timelock_recovery_txids.clone();
                     r.recovery.phase = MakerRecoveryPhase::TimelockRecovered;
                 });
-                update_tracker(&maker, &swap_id, |r| {
-                    r.phase = MakerSwapPhase::Recovered;
-                    r.recovery.phase = MakerRecoveryPhase::CleanedUp;
-                });
+                if all_swap_contracts_resolved()? {
+                    update_tracker(&maker, &swap_id, |r| {
+                        r.phase = MakerSwapPhase::Recovered;
+                        r.recovery.phase = MakerRecoveryPhase::CleanedUp;
+                    });
 
-                // Emit timelock recovery reports
-                let network = maker
-                    .wallet
-                    .read()
-                    .map(|w| w.store.network.to_string())
-                    .unwrap_or_default();
-                let recovery_txids: Vec<String> = recovered
-                    .resolved
-                    .iter()
-                    .map(|(_, spending_txid)| spending_txid.to_string())
-                    .collect();
-                RecoveryReport::emit_maker(
-                    &maker.data_dir,
-                    swap_id.clone(),
-                    network.clone(),
-                    "timelock".to_string(),
-                    recovery_txids,
-                );
+                    // Emit timelock recovery reports
+                    let network = maker
+                        .wallet
+                        .read()
+                        .map(|w| w.store.network.to_string())
+                        .unwrap_or_default();
+                    let recovery_txids: Vec<String> = timelock_recovery_txids
+                        .iter()
+                        .map(|spending_txid| spending_txid.to_string())
+                        .collect();
+                    RecoveryReport::emit_maker(
+                        &maker.data_dir,
+                        swap_id.clone(),
+                        network.clone(),
+                        "timelock".to_string(),
+                        recovery_txids,
+                    );
 
-                #[cfg(feature = "integration-test")]
-                maker.shutdown.store(true, Relaxed);
-                return Ok(());
+                    #[cfg(feature = "integration-test")]
+                    maker.shutdown.store(true, Relaxed);
+                    return Ok(());
+                }
             }
         }
 

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -18,6 +18,7 @@ use crate::{
         },
         taproot_messages::{SerializableScalar, TaprootContractData, TaprootTakerMessage},
     },
+    utill::estimate_funding_tx_fee_sats,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
         MakerReport,
@@ -136,8 +137,10 @@ fn process_taproot_contract<M: Maker>(
         incoming_swapcoins.push(incoming_swapcoin);
     }
 
-    let total_incoming: Amount = data.amounts.iter().cloned().sum();
-    let fee = maker.calculate_swap_fee(total_incoming, state.refund_locktime_offset as u32);
+    let total_incoming = data.amounts.iter().cloned().sum();
+    let swap_fee = maker.calculate_swap_fee(total_incoming, state.refund_locktime_offset as u32);
+    let mining_fee = Amount::from_sat(estimate_funding_tx_fee_sats() * n as u64);
+    let fee = swap_fee + mining_fee;
     let outgoing_total = total_incoming
         .checked_sub(fee)
         .ok_or(MakerError::General("Fee exceeds incoming amount"))?;
@@ -164,10 +167,11 @@ fn process_taproot_contract<M: Maker>(
     }
 
     log::info!(
-        "[{}] Fee calculation: incoming_total={}, fee={}, outgoing_total={}",
+        "[{}] Fee calculation: incoming_total={}, swap_fee={}, mining_fee={}, outgoing_total={}",
         maker.network_port(),
         total_incoming,
-        fee,
+        swap_fee,
+        mining_fee,
         outgoing_total
     );
 

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use bitcoin::{OutPoint, PublicKey};
+use bitcoin::{Amount, OutPoint, PublicKey};
 
 use super::{
     error::MakerError,
@@ -106,73 +106,76 @@ fn process_taproot_contract<M: Maker>(
         state.timelock
     );
 
-    let incoming_contract_tx = data
-        .contract_txs
-        .first()
-        .cloned()
-        .ok_or(MakerError::General("No contract transaction from taker"))?;
+    let n = data.contract_txs.len();
+    let mut incoming_swapcoins = Vec::with_capacity(n);
+    for j in 0..n {
+        let incoming_contract_tx = data.contract_txs[j].clone();
+        maker.verify_contract_tx_on_chain(&incoming_contract_tx.compute_txid())?;
 
-    // Verify the incoming contract tx is on-chain before proceeding.
-    let incoming_txid = incoming_contract_tx.compute_txid();
-    maker.verify_contract_tx_on_chain(&incoming_txid)?;
+        let incoming_funding_amount = data.amounts[j];
 
-    let incoming_funding_amount = data.amounts.first().cloned().unwrap_or(state.swap_amount);
+        let other_pubkey = data.pubkeys.get(j).cloned().unwrap_or(data.next_hop_point);
 
-    let other_pubkey = data.pubkeys.first().cloned().unwrap_or(data.next_hop_point);
+        let mut incoming_swapcoin = IncomingSwapCoin::new_taproot(
+            hashlock_privkey,
+            data.hashlock_script.clone(),
+            data.timelock_scripts[j].clone(),
+            incoming_contract_tx,
+            incoming_funding_amount,
+        );
+        incoming_swapcoin.swap_id = Some(data.id.clone());
 
-    let mut incoming_swapcoin = IncomingSwapCoin::new_taproot(
-        hashlock_privkey,
-        data.hashlock_script.clone(),
-        data.timelock_script.clone(),
-        incoming_contract_tx,
-        incoming_funding_amount,
-    );
-    incoming_swapcoin.swap_id = Some(data.id.clone());
+        incoming_swapcoin.my_privkey = Some(tweakable_privkey);
+        incoming_swapcoin.my_pubkey = Some(PublicKey {
+            compressed: true,
+            inner: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &tweakable_privkey),
+        });
+        incoming_swapcoin.other_pubkey = Some(other_pubkey);
+        incoming_swapcoin.internal_key = Some(data.internal_keys[j]);
+        incoming_swapcoin.tap_tweak = Some(data.tap_tweak_scalar(j)?);
+        incoming_swapcoins.push(incoming_swapcoin);
+    }
 
-    incoming_swapcoin.my_privkey = Some(tweakable_privkey);
-    incoming_swapcoin.my_pubkey = Some(PublicKey {
-        compressed: true,
-        inner: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &tweakable_privkey),
-    });
-    incoming_swapcoin.other_pubkey = Some(other_pubkey);
-    incoming_swapcoin.internal_key = Some(data.internal_key);
-    incoming_swapcoin.tap_tweak = Some(data.tap_tweak_scalar()?);
-
-    // Use the relative offset sent by the taker for deterministic fee calculation
-    let fee =
-        maker.calculate_swap_fee(incoming_funding_amount, state.refund_locktime_offset as u32);
-    let outgoing_amount = incoming_funding_amount
+    let total_incoming: Amount = data.amounts.iter().cloned().sum();
+    let fee = maker.calculate_swap_fee(total_incoming, state.refund_locktime_offset as u32);
+    let outgoing_total = total_incoming
         .checked_sub(fee)
         .ok_or(MakerError::General("Fee exceeds incoming amount"))?;
+    let total_sat = total_incoming.to_sat() as u128;
+    let mut outgoing_amounts = data
+        .amounts
+        .iter()
+        .map(|amt| {
+            let share = (fee.to_sat() as u128 * amt.to_sat() as u128 / total_sat) as u64;
+            Amount::from_sat(amt.to_sat() - share)
+        })
+        .collect::<Vec<Amount>>();
+    // Flooring leaves the outgoing sum a few sats above total fee; deduct that remainder from the largest output so the totals stay exact and deterministic.
+    let remainder =
+        outgoing_amounts.iter().map(|amt| amt.to_sat()).sum::<u64>() - outgoing_total.to_sat();
+    if remainder > 0 {
+        let max_idx = outgoing_amounts
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, amt)| amt.to_sat())
+            .map(|(idx, _)| idx)
+            .unwrap_or(0);
+        outgoing_amounts[max_idx] -= Amount::from_sat(remainder);
+    }
 
     log::info!(
-        "[{}] Fee calculation: incoming={}, fee={}, outgoing={}",
+        "[{}] Fee calculation: incoming_total={}, fee={}, outgoing_total={}",
         maker.network_port(),
-        incoming_funding_amount,
+        total_incoming,
         fee,
-        outgoing_amount
+        outgoing_total
     );
-
-    let outgoing_nonce =
-        bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
-    let outgoing_privkey = tweakable_privkey
-        .add_tweak(&outgoing_nonce.into())
-        .map_err(|_| MakerError::General("Outgoing key derivation failed"))?;
-
-    let outgoing_pubkey = PublicKey {
-        compressed: true,
-        inner: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &outgoing_privkey),
-    };
-
-    let timelock_privkey =
-        bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
-    let timelock_keypair = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &timelock_privkey);
-    let timelock_xonly = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&timelock_keypair).0;
 
     let hash = extract_hash_from_hashlock(&data.hashlock_script)
         .map_err(|e| MakerError::General(format!("Invalid hashlock script: {:?}", e).leak()))?;
     // If next_hashlock_nonce is provided, tweak the next hop's pubkey.
     // Otherwise (last maker → taker), use the un-tweaked next_hop_point.
+    // The hashlock script (next hop's hashlock key) is shared across all contracts.
     let next_hop_hashlock_pubkey = if let Some(ref nonce) = data.next_hashlock_nonce {
         calculate_pubkey_from_nonce(&data.next_hop_point, nonce)
             .map_err(|e| MakerError::General(format!("Next hop key derivation: {:?}", e).leak()))?
@@ -181,102 +184,149 @@ fn process_taproot_contract<M: Maker>(
     };
     let next_hop_xonly = bitcoin::key::XOnlyPublicKey::from(next_hop_hashlock_pubkey.inner);
     let hashlock_script = create_hashlock_script(&hash, &next_hop_xonly);
-    let timelock_script = {
-        // For Taproot, state.timelock is already an absolute block height
-        // (computed by the taker from a single reference height).
-        let locktime = bitcoin::absolute::LockTime::from_height(state.timelock)
-            .map_err(|_| MakerError::General("Invalid locktime height"))?;
-        create_timelock_script(locktime, &timelock_xonly)
-    };
 
-    let builder = bitcoin::taproot::TaprootBuilder::new()
-        .add_leaf(1, hashlock_script.clone())
-        .map_err(|e| MakerError::General(format!("Failed to add hashlock leaf: {:?}", e).leak()))?
-        .add_leaf(1, timelock_script.clone())
-        .map_err(|e| MakerError::General(format!("Failed to add timelock leaf: {:?}", e).leak()))?;
+    // Build one outgoing contract (with its own keys/scripts/address) per contract.
+    let mut outgoing_swapcoins = Vec::with_capacity(n);
+    let mut response_pubkeys = Vec::with_capacity(n);
+    let mut response_internal_keys = Vec::with_capacity(n);
+    let mut response_tap_tweaks = Vec::with_capacity(n);
+    let mut response_timelock_scripts = Vec::with_capacity(n);
+    let mut response_contract_txs = Vec::with_capacity(n);
+    let mut response_amounts = Vec::with_capacity(n);
+    let mut reserved = Vec::with_capacity(n);
+    let mut spent_inputs: Vec<OutPoint> = Vec::new();
 
-    let mut ordered_pubkeys = [outgoing_pubkey, data.next_hop_point];
-    ordered_pubkeys.sort_by_key(|a| a.inner.serialize());
-    let internal_key = crate::protocol::musig_interface::get_aggregated_pubkey_compat(
-        ordered_pubkeys[0].inner,
-        ordered_pubkeys[1].inner,
-    )
-    .map_err(|e| {
-        MakerError::General(format!("Failed to create aggregated pubkey: {:?}", e).leak())
-    })?;
+    let base_excluded = maker.collect_excluded_utxos(&data.id);
 
-    let tap_info = builder
-        .finalize(&secp, internal_key)
-        .map_err(|e| MakerError::General(format!("Failed to finalize taproot: {:?}", e).leak()))?;
+    for &outgoing_amount in &outgoing_amounts {
+        let outgoing_nonce =
+            bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
+        let outgoing_privkey = tweakable_privkey
+            .add_tweak(&outgoing_nonce.into())
+            .map_err(|_| MakerError::General("Outgoing key derivation failed"))?;
+        let outgoing_pubkey = PublicKey {
+            compressed: true,
+            inner: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &outgoing_privkey),
+        };
 
-    let taproot_address = bitcoin::Address::p2tr_tweaked(tap_info.output_key(), maker.network());
+        let timelock_privkey =
+            bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
+        let timelock_keypair =
+            bitcoin::secp256k1::Keypair::from_secret_key(&secp, &timelock_privkey);
+        let timelock_xonly = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&timelock_keypair).0;
+        let timelock_script = {
+            // For Taproot, state.timelock is already an absolute block height.
+            let locktime = bitcoin::absolute::LockTime::from_height(state.timelock)
+                .map_err(|_| MakerError::General("Invalid locktime height"))?;
+            create_timelock_script(locktime, &timelock_xonly)
+        };
 
-    // Reserve UTXOs for this swap to prevent double-spending across concurrent swaps.
-    let excluded_utxos = maker.collect_excluded_utxos(&data.id);
-    if !excluded_utxos.is_empty() {
-        log::info!(
-            "[{}] Excluding {} UTXOs from other active swaps",
-            maker.network_port(),
-            excluded_utxos.len()
+        let builder = bitcoin::taproot::TaprootBuilder::new()
+            .add_leaf(1, hashlock_script.clone())
+            .map_err(|e| {
+                MakerError::General(format!("Failed to add hashlock leaf: {:?}", e).leak())
+            })?
+            .add_leaf(1, timelock_script.clone())
+            .map_err(|e| {
+                MakerError::General(format!("Failed to add timelock leaf: {:?}", e).leak())
+            })?;
+
+        let mut ordered_pubkeys = [outgoing_pubkey, data.next_hop_point];
+        ordered_pubkeys.sort_by_key(|a| a.inner.serialize());
+        let internal_key = crate::protocol::musig_interface::get_aggregated_pubkey_compat(
+            ordered_pubkeys[0].inner,
+            ordered_pubkeys[1].inner,
+        )
+        .map_err(|e| {
+            MakerError::General(format!("Failed to create aggregated pubkey: {:?}", e).leak())
+        })?;
+
+        let tap_info = builder.finalize(&secp, internal_key).map_err(|e| {
+            MakerError::General(format!("Failed to finalize taproot: {:?}", e).leak())
+        })?;
+        let taproot_address =
+            bitcoin::Address::p2tr_tweaked(tap_info.output_key(), maker.network());
+
+        // Exclude UTXOs from other swaps and the inputs already spent this hop.
+        let mut excluded_utxos = base_excluded.clone();
+        excluded_utxos.extend(spent_inputs.iter().cloned());
+
+        // QA: Integration-only malicious maker path for taker validation tests.
+        #[cfg(feature = "integration-test")]
+        let funding_amount = {
+            use super::handlers::MakerBehavior;
+            if maker.behavior() == MakerBehavior::UnderfundTaprootContract {
+                Amount::from_sat(10_000)
+            } else {
+                outgoing_amount
+            }
+        };
+        #[cfg(not(feature = "integration-test"))]
+        let funding_amount = outgoing_amount;
+
+        let (contract_tx, output_pos) = maker.create_funding_transaction(
+            funding_amount,
+            taproot_address.clone(),
+            Some(excluded_utxos),
+        )?;
+        spent_inputs.extend(contract_tx.input.iter().map(|i| i.previous_output));
+        let contract_outpoint = OutPoint {
+            txid: contract_tx.compute_txid(),
+            vout: output_pos,
+        };
+        reserved.push(contract_outpoint);
+        let contract_output_amount = contract_tx.output[output_pos as usize].value;
+
+        let mut outgoing_swapcoin = OutgoingSwapCoin::new_taproot(
+            timelock_privkey,
+            hashlock_script.clone(),
+            timelock_script.clone(),
+            contract_tx.clone(),
+            contract_output_amount,
         );
+        outgoing_swapcoin.swap_id = Some(data.id.clone());
+        outgoing_swapcoin.set_taproot_params(
+            outgoing_privkey,
+            outgoing_pubkey,
+            data.next_hop_point,
+            internal_key,
+            tap_info.tap_tweak().to_scalar(),
+        );
+
+        // QA: Keep this claim inconsistent with the funded output when the test
+        // behavior is active, proving the taker binds metadata to transaction value.
+        #[cfg(feature = "integration-test")]
+        let response_amount = {
+            use super::handlers::MakerBehavior;
+            if maker.behavior() == MakerBehavior::UnderfundTaprootContract {
+                outgoing_amount
+            } else {
+                contract_output_amount
+            }
+        };
+        #[cfg(not(feature = "integration-test"))]
+        let response_amount = contract_output_amount;
+
+        response_pubkeys.push(outgoing_pubkey);
+        response_internal_keys.push(internal_key);
+        response_tap_tweaks.push(SerializableScalar::from_bytes(
+            tap_info.tap_tweak().to_scalar().to_be_bytes().to_vec(),
+        ));
+        response_timelock_scripts.push(timelock_script);
+        response_contract_txs.push(contract_tx);
+        response_amounts.push(response_amount);
+        outgoing_swapcoins.push(outgoing_swapcoin);
     }
 
-    // QA: Integration-only malicious maker path for taker validation tests. It
-    // funds less than the amount it will later claim in TaprootContractData.
-    #[cfg(feature = "integration-test")]
-    let funding_amount = {
-        use super::handlers::MakerBehavior;
-        if maker.behavior() == MakerBehavior::UnderfundTaprootContract {
-            bitcoin::Amount::from_sat(10_000)
-        } else {
-            outgoing_amount
-        }
-    };
-    #[cfg(not(feature = "integration-test"))]
-    let funding_amount = outgoing_amount;
-
-    let (contract_tx, output_pos) = maker.create_funding_transaction(
-        funding_amount,
-        taproot_address.clone(),
-        Some(excluded_utxos),
-    )?;
-    let contract_txid = contract_tx.compute_txid();
-
-    let contract_outpoint = OutPoint {
-        txid: contract_txid,
-        vout: output_pos,
-    };
-
-    // Store reserved outpoints from the funding transaction.
-    state.reserve_utxo = vec![contract_outpoint];
-
-    let contract_output_amount = contract_tx.output[output_pos as usize].value;
-
-    let mut outgoing_swapcoin = OutgoingSwapCoin::new_taproot(
-        timelock_privkey,
-        hashlock_script.clone(),
-        timelock_script.clone(),
-        contract_tx.clone(),
-        contract_output_amount,
-    );
-    outgoing_swapcoin.swap_id = Some(data.id.clone());
-    outgoing_swapcoin.set_taproot_params(
-        outgoing_privkey,
-        outgoing_pubkey,
-        data.next_hop_point,
-        internal_key,
-        tap_info.tap_tweak().to_scalar(),
-    );
-
-    // Store in connection state
-    state.incoming_swapcoins.push(incoming_swapcoin.clone());
-    state.outgoing_swapcoins.push(outgoing_swapcoin.clone());
+    state.reserve_utxo = reserved.clone();
+    state.incoming_swapcoins = incoming_swapcoins.clone();
+    state.outgoing_swapcoins = outgoing_swapcoins.clone();
     #[cfg(debug_assertions)]
     log::debug!(
-        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | IncomingAmount: {} | OutgoingAmount: {} | ReservedUtxos: {}",
+        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | Contracts: {} | IncomingTotal: {} | ReservedUtxos: {}",
         data.id,
-        incoming_funding_amount.to_sat(),
-        contract_output_amount.to_sat(),
+        n,
+        total_incoming.to_sat(),
         state.reserve_utxo.len()
     );
 
@@ -288,44 +338,49 @@ fn process_taproot_contract<M: Maker>(
                 "[{}] Test behavior: skipping Taproot funding broadcast",
                 maker.network_port()
             );
-            // Swapcoins are already in state.
-            // Save them to wallet for recovery detection.
             state.funding_broadcast = true;
             state.phase = SwapPhase::AwaitingPrivateKeyHandover;
-            maker.save_incoming_swapcoin(&incoming_swapcoin)?;
-            maker.save_outgoing_swapcoin(&outgoing_swapcoin)?;
+            for incoming in &incoming_swapcoins {
+                maker.save_incoming_swapcoin(incoming)?;
+            }
+            for outgoing in &outgoing_swapcoins {
+                maker.save_outgoing_swapcoin(outgoing)?;
+            }
             maker.store_connection_state(&data.id, state)?;
             return Err(MakerError::General("Test: skipped funding broadcast"));
         }
     }
 
-    match maker.broadcast_transaction(&contract_tx) {
-        Ok(txid) => {
-            log::info!(
-                "[{}] Broadcast Taproot contract tx {} for swap {}",
-                maker.network_port(),
-                txid,
-                data.id
-            );
-
-            maker.register_watch_outpoint(contract_outpoint);
+    for (outgoing, contract_outpoint) in outgoing_swapcoins.iter().zip(reserved.iter()) {
+        match maker.broadcast_transaction(&outgoing.contract_tx) {
+            Ok(txid) => {
+                log::info!(
+                    "[{}] Broadcast Taproot contract tx {} for swap {}",
+                    maker.network_port(),
+                    txid,
+                    data.id
+                );
+            }
+            Err(e) => {
+                log::warn!(
+                    "[{}] Failed to broadcast Taproot contract tx (may already be broadcast): {:?}",
+                    maker.network_port(),
+                    e
+                );
+            }
         }
-        Err(e) => {
-            log::warn!(
-                "[{}] Failed to broadcast Taproot contract tx (may already be broadcast): {:?}",
-                maker.network_port(),
-                e
-            );
-        }
+        maker.register_watch_outpoint(*contract_outpoint);
     }
 
     state.funding_broadcast = true;
     state.phase = SwapPhase::AwaitingPrivateKeyHandover;
-    maker.register_watch_outpoint(contract_outpoint);
 
-    // Save to wallet
-    maker.save_incoming_swapcoin(&incoming_swapcoin)?;
-    maker.save_outgoing_swapcoin(&outgoing_swapcoin)?;
+    for incoming in &incoming_swapcoins {
+        maker.save_incoming_swapcoin(incoming)?;
+    }
+    for outgoing in &outgoing_swapcoins {
+        maker.save_outgoing_swapcoin(outgoing)?;
+    }
 
     maker.store_connection_state(&data.id, state)?;
 
@@ -337,43 +392,30 @@ fn process_taproot_contract<M: Maker>(
                 "[{}] Test behavior: broadcasting contract tx after taproot setup, then closing",
                 maker.network_port()
             );
-            let _ = maker.broadcast_transaction(&outgoing_swapcoin.contract_tx);
+            if let Some(outgoing) = outgoing_swapcoins.first() {
+                let _ = maker.broadcast_transaction(&outgoing.contract_tx);
+            }
             return Err(MakerError::General("Test: broadcast contract after setup"));
         }
     }
 
     log::info!(
-        "[{}] Created Taproot swapcoins for swap {}. Outgoing amount: {}",
+        "[{}] Created {} Taproot swapcoins for swap {}",
         maker.network_port(),
-        data.id,
-        outgoing_swapcoin.funding_amount
+        n,
+        data.id
     );
-
-    let tap_tweak_scalar = tap_info.tap_tweak().to_scalar();
-    // QA: Keep this claim inconsistent with the funded output when the test
-    // behavior is active, proving the taker binds metadata to transaction value.
-    #[cfg(feature = "integration-test")]
-    let response_amount = {
-        use super::handlers::MakerBehavior;
-        if maker.behavior() == MakerBehavior::UnderfundTaprootContract {
-            outgoing_amount
-        } else {
-            contract_output_amount
-        }
-    };
-    #[cfg(not(feature = "integration-test"))]
-    let response_amount = contract_output_amount;
 
     let response = TaprootContractData::new(
         data.id.clone(),
-        vec![outgoing_pubkey],
+        response_pubkeys,
         tweakable_pubkey,
-        internal_key,
-        SerializableScalar::from_bytes(tap_tweak_scalar.to_be_bytes().to_vec()),
+        response_internal_keys,
+        response_tap_tweaks,
         hashlock_script,
-        timelock_script,
-        vec![contract_tx],
-        vec![response_amount],
+        response_timelock_scripts,
+        response_contract_txs,
+        response_amounts,
         None, // hashlock_nonce: taker already knows
         None, // next_hashlock_nonce: taker manages all nonces
     );
@@ -421,14 +463,18 @@ fn process_taproot_handover<M: Maker>(
         maker.network_port(),
     )?;
 
-    let outgoing = state
-        .outgoing_swapcoins
-        .first()
-        .ok_or(MakerError::General("No outgoing swapcoin found"))?;
-
-    let privkey = outgoing
-        .my_privkey
-        .ok_or(MakerError::General("No private key in outgoing swapcoin"))?;
+    if state.outgoing_swapcoins.is_empty() {
+        return Err(MakerError::General("No outgoing swapcoin found"));
+    }
+    let mut privkeys = Vec::with_capacity(state.outgoing_swapcoins.len());
+    for outgoing in &state.outgoing_swapcoins {
+        privkeys.push(SwapPrivkey {
+            identifier: bitcoin::ScriptBuf::new(),
+            key: outgoing
+                .my_privkey
+                .ok_or(MakerError::General("No private key in outgoing swapcoin"))?,
+        });
+    }
 
     // Store received privkey on incoming swapcoins
     for (i, incoming) in state.incoming_swapcoins.iter_mut().enumerate() {
@@ -475,10 +521,7 @@ fn process_taproot_handover<M: Maker>(
 
     let response = PrivateKeyHandover {
         id: handover.id,
-        privkeys: vec![SwapPrivkey {
-            identifier: bitcoin::ScriptBuf::new(),
-            key: privkey,
-        }],
+        privkeys,
     };
 
     Ok(Some(MakerToTakerMessage::TaprootPrivateKeyHandover(

--- a/src/maker/taproot_verification.rs
+++ b/src/maker/taproot_verification.rs
@@ -76,131 +76,148 @@ pub(crate) fn verify_taproot_contract_data(
         ));
     }
 
-    // Verify timelock script has expected format (5 instructions):
-    // <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG
-    let timelock_instructions = data
-        .timelock_script
-        .instructions()
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            MakerError::General(format!("Taproot timelock script parse error: {:?}", e).leak())
-        })?;
-    if timelock_instructions.len() != 5 {
+    // Per-contract vectors must all line up with contract_txs; the loop below
+    // indexes them by position, so mismatched lengths would otherwise panic.
+    if data.timelock_scripts.len() != data.contract_txs.len()
+        || data.internal_keys.len() != data.contract_txs.len()
+        || data.tap_tweaks.len() != data.contract_txs.len()
+        || data.pubkeys.len() != data.contract_txs.len()
+    {
         return Err(MakerError::General(
-            format!(
-                "Taproot timelock script has {} instructions, expected 5",
-                timelock_instructions.len()
-            )
-            .leak(),
-        ));
-    }
-    if !matches!(
-        timelock_instructions.as_slice(),
-        [
-            _,
-            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CLTV),
-            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_DROP),
-            bitcoin::script::Instruction::PushBytes(pubkey),
-            bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CHECKSIG),
-        ] if pubkey.len() == 32
-    ) {
-        return Err(MakerError::General(
-            "Taproot timelock script has unexpected template",
-        ));
-    }
-
-    // Extract and validate the timelock value from the timelock script
-    let maker_locktime_val: u64 = if let Some(first) = timelock_instructions.first() {
-        match first {
-            bitcoin::script::Instruction::PushBytes(locktime_bytes) => {
-                let bytes = locktime_bytes.as_bytes();
-                if bytes.is_empty() {
-                    return Err(MakerError::General(
-                        "Taproot timelock script has empty locktime",
-                    ));
-                }
-                match bytes.len() {
-                    1 => bytes[0] as u64,
-                    2 => u16::from_le_bytes([bytes[0], bytes[1]]) as u64,
-                    3 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], 0]) as u64,
-                    4 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as u64,
-                    _ => {
-                        return Err(MakerError::General(
-                            format!(
-                                "Taproot timelock has unexpected byte length {}",
-                                bytes.len()
-                            )
-                            .leak(),
-                        ));
-                    }
-                }
-            }
-            bitcoin::script::Instruction::Op(opcode) => {
-                if let bitcoin::opcodes::Class::PushNum(n) =
-                    opcode.classify(bitcoin::opcodes::ClassifyContext::Legacy)
-                {
-                    if n <= 0 {
-                        return Err(MakerError::General(
-                            format!("Taproot timelock value is non-positive ({})", n).leak(),
-                        ));
-                    }
-                    n as u64
-                } else {
-                    return Err(MakerError::General(
-                        "Taproot timelock script doesn't start with a locktime",
-                    ));
-                }
-            }
-        }
-    } else {
-        return Err(MakerError::General("Taproot timelock script is empty"));
-    };
-
-    if maker_locktime_val == 0 {
-        return Err(MakerError::General("Taproot timelock value is zero"));
-    }
-
-    let expected_taker_locktime = maker_timelock as u64 + REFUND_LOCKTIME_STEP as u64;
-    if maker_locktime_val != expected_taker_locktime {
-        return Err(MakerError::General(
-            format!(
-                "Taproot timelock value {} does not match expected taker locktime {}",
-                maker_locktime_val, expected_taker_locktime
-            )
-            .leak(),
+            "Taproot per-contract vectors have inconsistent lengths",
         ));
     }
 
     let secp = Secp256k1::verification_only();
-    let (expected_spk, expected_tap_tweak) = {
-        let builder = bitcoin::taproot::TaprootBuilder::new()
-            .add_leaf(1, data.hashlock_script.clone())
-            .map_err(|e| {
-                MakerError::General(
-                    format!("Taproot tree build failed (hashlock leaf): {:?}", e).leak(),
-                )
-            })?
-            .add_leaf(1, data.timelock_script.clone())
-            .map_err(|e| {
-                MakerError::General(
-                    format!("Taproot tree build failed (timelock leaf): {:?}", e).leak(),
-                )
-            })?;
-        let tap_info = builder.finalize(&secp, data.internal_key).map_err(|e| {
-            MakerError::General(format!("Taproot tree finalization failed: {:?}", e).leak())
-        })?;
-        (
-            bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key()),
-            tap_info.tap_tweak().to_scalar(),
-        )
-    };
-    if data.tap_tweak_scalar()? != expected_tap_tweak {
-        return Err(MakerError::General(
-            "Taproot tap tweak does not match internal key and script tree",
-        ));
-    }
+    let expected_taker_locktime = maker_timelock as u64 + REFUND_LOCKTIME_STEP as u64;
 
+    // Each contract has its own timelock script, internal key and tap tweak.
     for (i, tx) in data.contract_txs.iter().enumerate() {
+        let timelock_script = &data.timelock_scripts[i];
+
+        // Verify timelock script has expected format (5 instructions):
+        // <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG
+        let timelock_instructions = timelock_script
+            .instructions()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                MakerError::General(format!("Taproot timelock script parse error: {:?}", e).leak())
+            })?;
+        if timelock_instructions.len() != 5 {
+            return Err(MakerError::General(
+                format!(
+                    "Taproot timelock script {} has {} instructions, expected 5",
+                    i,
+                    timelock_instructions.len()
+                )
+                .leak(),
+            ));
+        }
+        if !matches!(
+            timelock_instructions.as_slice(),
+            [
+                _,
+                bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CLTV),
+                bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_DROP),
+                bitcoin::script::Instruction::PushBytes(pubkey),
+                bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_CHECKSIG),
+            ] if pubkey.len() == 32
+        ) {
+            return Err(MakerError::General(
+                "Taproot timelock script has unexpected template",
+            ));
+        }
+
+        // Extract and validate the timelock value from the timelock script
+        let maker_locktime_val: u64 = if let Some(first) = timelock_instructions.first() {
+            match first {
+                bitcoin::script::Instruction::PushBytes(locktime_bytes) => {
+                    let bytes = locktime_bytes.as_bytes();
+                    if bytes.is_empty() {
+                        return Err(MakerError::General(
+                            "Taproot timelock script has empty locktime",
+                        ));
+                    }
+                    match bytes.len() {
+                        1 => bytes[0] as u64,
+                        2 => u16::from_le_bytes([bytes[0], bytes[1]]) as u64,
+                        3 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], 0]) as u64,
+                        4 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as u64,
+                        _ => {
+                            return Err(MakerError::General(
+                                format!(
+                                    "Taproot timelock has unexpected byte length {}",
+                                    bytes.len()
+                                )
+                                .leak(),
+                            ));
+                        }
+                    }
+                }
+                bitcoin::script::Instruction::Op(opcode) => {
+                    if let bitcoin::opcodes::Class::PushNum(n) =
+                        opcode.classify(bitcoin::opcodes::ClassifyContext::Legacy)
+                    {
+                        if n <= 0 {
+                            return Err(MakerError::General(
+                                format!("Taproot timelock value is non-positive ({})", n).leak(),
+                            ));
+                        }
+                        n as u64
+                    } else {
+                        return Err(MakerError::General(
+                            "Taproot timelock script doesn't start with a locktime",
+                        ));
+                    }
+                }
+            }
+        } else {
+            return Err(MakerError::General("Taproot timelock script is empty"));
+        };
+
+        if maker_locktime_val == 0 {
+            return Err(MakerError::General("Taproot timelock value is zero"));
+        }
+        if maker_locktime_val != expected_taker_locktime {
+            return Err(MakerError::General(
+                format!(
+                    "Taproot timelock value {} does not match expected taker locktime {}",
+                    maker_locktime_val, expected_taker_locktime
+                )
+                .leak(),
+            ));
+        }
+
+        let (expected_spk, expected_tap_tweak) = {
+            let builder = bitcoin::taproot::TaprootBuilder::new()
+                .add_leaf(1, data.hashlock_script.clone())
+                .map_err(|e| {
+                    MakerError::General(
+                        format!("Taproot tree build failed (hashlock leaf): {:?}", e).leak(),
+                    )
+                })?
+                .add_leaf(1, timelock_script.clone())
+                .map_err(|e| {
+                    MakerError::General(
+                        format!("Taproot tree build failed (timelock leaf): {:?}", e).leak(),
+                    )
+                })?;
+            let tap_info = builder
+                .finalize(&secp, data.internal_keys[i])
+                .map_err(|e| {
+                    MakerError::General(format!("Taproot tree finalization failed: {:?}", e).leak())
+                })?;
+            (
+                bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key()),
+                tap_info.tap_tweak().to_scalar(),
+            )
+        };
+        if data.tap_tweak_scalar(i)? != expected_tap_tweak {
+            return Err(MakerError::General(
+                "Taproot tap tweak does not match internal key and script tree",
+            ));
+        }
+
         if tx.input.is_empty() {
             return Err(MakerError::General(
                 format!("Taproot contract tx {} has no inputs", i).leak(),
@@ -365,12 +382,14 @@ mod tests {
 
         TaprootContractData::new(
             "test-swap".to_string(),
-            Vec::new(),
+            vec![bitcoin::PublicKey::new(
+                bitcoin::secp256k1::PublicKey::from_keypair(&keypair(4)),
+            )],
             bitcoin::PublicKey::new(bitcoin::secp256k1::PublicKey::from_keypair(&keypair(3))),
-            internal_key,
-            tap_tweak,
+            vec![internal_key],
+            vec![tap_tweak],
             hashlock_script,
-            timelock_script,
+            vec![timelock_script],
             vec![contract_tx(script_pubkey, amount)],
             vec![amount],
             None,
@@ -380,12 +399,12 @@ mod tests {
 
     fn refresh_output_script(data: &mut TaprootContractData) {
         let (script_pubkey, tap_tweak) = output_script(
-            data.internal_key,
+            data.internal_keys[0],
             data.hashlock_script.clone(),
-            data.timelock_script.clone(),
+            data.timelock_scripts[0].clone(),
         );
         data.contract_txs[0].output[0].script_pubkey = script_pubkey;
-        data.tap_tweak = tap_tweak;
+        data.tap_tweaks[0] = tap_tweak;
     }
 
     #[test]
@@ -417,7 +436,7 @@ mod tests {
         let mut data = valid_contract_data();
         let script_key = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&keypair(2)).0;
         let timelock = LockTime::from_height(MAKER_TIMELOCK + REFUND_LOCKTIME_STEP as u32).unwrap();
-        data.timelock_script = script::Builder::new()
+        data.timelock_scripts[0] = script::Builder::new()
             .push_lock_time(timelock)
             .push_opcode(OP_DROP)
             .push_opcode(OP_CLTV)
@@ -432,7 +451,7 @@ mod tests {
     #[test]
     fn rejects_tap_tweak_that_does_not_match_script_tree() {
         let mut data = valid_contract_data();
-        data.tap_tweak = SerializableScalar::from_bytes([1u8; 32].to_vec());
+        data.tap_tweaks[0] = SerializableScalar::from_bytes([1u8; 32].to_vec());
 
         assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
     }

--- a/src/protocol/taproot_messages.rs
+++ b/src/protocol/taproot_messages.rs
@@ -48,13 +48,14 @@ pub struct TaprootContractData {
     /// Tweakable point for the next hop.
     pub next_hop_point: PublicKey,
     /// The aggregated internal key for the Taproot output.
-    pub internal_key: XOnlyPublicKey,
+    pub internal_keys: Vec<XOnlyPublicKey>,
     /// The tap tweak applied to the internal key.
-    pub tap_tweak: SerializableScalar,
+    pub tap_tweaks: Vec<SerializableScalar>,
     /// Hashlock script for preimage spending (script-path fallback).
+    /// Shared across all contracts of a hop.
     pub hashlock_script: ScriptBuf,
     /// Timelock script for timeout spending (script-path fallback).
-    pub timelock_script: ScriptBuf,
+    pub timelock_scripts: Vec<ScriptBuf>,
     /// Contract transactions (in Taproot, the funding tx IS the contract).
     pub contract_txs: Vec<Transaction>,
     /// Contract amounts.
@@ -78,10 +79,10 @@ impl TaprootContractData {
         id: String,
         pubkeys: Vec<PublicKey>,
         next_hop_point: PublicKey,
-        internal_key: XOnlyPublicKey,
-        tap_tweak: SerializableScalar,
+        internal_keys: Vec<XOnlyPublicKey>,
+        tap_tweaks: Vec<SerializableScalar>,
         hashlock_script: ScriptBuf,
-        timelock_script: ScriptBuf,
+        timelock_scripts: Vec<ScriptBuf>,
         contract_txs: Vec<Transaction>,
         amounts: Vec<Amount>,
         hashlock_nonce: Option<SecretKey>,
@@ -91,10 +92,10 @@ impl TaprootContractData {
             id,
             pubkeys,
             next_hop_point,
-            internal_key,
-            tap_tweak,
+            internal_keys,
+            tap_tweaks,
             hashlock_script,
-            timelock_script,
+            timelock_scripts,
             contract_txs,
             amounts,
             hashlock_nonce,
@@ -102,11 +103,12 @@ impl TaprootContractData {
         }
     }
 
-    /// Convenience method to get the tap tweak as a Scalar.
+    /// Convenience method to get the tap tweak for contract `i` as a Scalar.
     pub fn tap_tweak_scalar(
         &self,
+        i: usize,
     ) -> Result<bitcoin::secp256k1::Scalar, crate::protocol::error::ProtocolError> {
-        self.tap_tweak.clone().try_into()
+        self.tap_tweaks[i].clone().try_into()
     }
 }
 

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -38,7 +38,10 @@ use crate::{
         },
         contract::calculate_pubkey_from_nonce,
     },
-    utill::{check_tor_status, generate_maker_keys, get_taker_dir, read_message, send_message},
+    utill::{
+        check_tor_status, estimate_funding_tx_fee_sats, generate_maker_keys, get_taker_dir,
+        read_message, send_message,
+    },
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         MakerFeeInfo as ReportMakerFeeInfo, RPCConfig, RecoveryOutcome, SwapStatus, TakerReport,
@@ -382,6 +385,10 @@ impl Taker {
         let send_amount = swap.params.send_amount;
         let maker_count = swap.makers.len();
 
+        // TODO : Have the makers derive the fee & a smart messaging layer to send the estimated target to the taker sequentially.
+        let per_hop_mining_fee =
+            (estimate_funding_tx_fee_sats() * swap.params.tx_count as u64) as f64;
+
         // Iteratively compute the amount reaching each hop after deducting fees.
         let mut amount_sats = send_amount.to_sat() as f64;
         for i in 0..=maker_idx {
@@ -392,7 +399,7 @@ impl Taker {
                 + (amount_sats * offer.amount_relative_fee_pct) / 100.0
                 + (amount_sats * locktime as f64 * offer.time_relative_fee_pct) / 100.0;
             let fee_with_margin = fee * FEE_VERIFICATION_MARGIN;
-            amount_sats = (amount_sats - fee_with_margin).max(0.0);
+            amount_sats = (amount_sats - fee_with_margin - per_hop_mining_fee).max(0.0);
         }
 
         Some(Amount::from_sat(amount_sats as u64))

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1606,11 +1606,19 @@ impl Taker {
         let preimage = swap.preimage;
         let send_amount = swap.params.send_amount;
         let swap_id = swap.id.clone();
+        let swap_tx_count = swap.params.tx_count as usize;
         let manually_selected_outpoints = swap.params.manually_selected_outpoints.clone();
         let reference_height = swap.reference_height;
 
         let (multisig_pubkeys, multisig_nonces, hashlock_pubkeys, hashlock_nonces) =
-            generate_maker_keys(&tweakable_point, 1)?;
+            generate_maker_keys(
+                &tweakable_point,
+                if protocol == ProtocolVersion::Legacy {
+                    swap.params.tx_count
+                } else {
+                    1
+                },
+            )?;
 
         // For Taproot, generate hashlock nonces for ALL hops (one per maker)
         // and derive the tweaked hashlock pubkey for the first hop.
@@ -1657,8 +1665,11 @@ impl Taker {
             )?,
             ProtocolVersion::Taproot => Self::funding_create_taproot(
                 &mut wallet,
-                &[tweakable_point],
-                &[taproot_hashlock_pubkey.expect("taproot hashlock pubkey must be set")],
+                &vec![tweakable_point; swap_tx_count],
+                &vec![
+                    taproot_hashlock_pubkey.expect("taproot hashlock pubkey must be set");
+                    swap_tx_count
+                ],
                 preimage,
                 refund_locktime_offset,
                 send_amount,
@@ -1831,12 +1842,15 @@ impl Taker {
         let protocol = swap.params.protocol;
         let swap_id = swap.id.clone();
 
-        // Start with the taker's own outgoing privkey (for Maker[0]'s incoming)
-        let mut current_privkey = swap
+        // Start with the taker's own outgoing privkeys (for Maker[0]'s incoming)
+        let mut current_privkeys: Vec<SecretKey> = swap
             .outgoing_swapcoins
-            .first()
-            .and_then(|sc| sc.my_privkey)
-            .ok_or_else(|| TakerError::General("No outgoing privkey".to_string()))?;
+            .iter()
+            .filter_map(|sc| sc.my_privkey)
+            .collect();
+        if current_privkeys.is_empty() {
+            return Err(TakerError::General("No outgoing privkey".to_string()));
+        }
 
         for i in 0..num_makers {
             let maker_address = self.swap_state()?.makers[i].address.to_string();
@@ -1846,19 +1860,23 @@ impl Taker {
 
             log::info!("Sending privkey to maker {} and awaiting response", i);
 
-            let msg = Self::msg_build_handover(protocol, swap_id.clone(), current_privkey);
+            let msg = Self::msg_build_handover(protocol, swap_id.clone(), &current_privkeys);
             send_message(&mut stream, &msg)?;
 
             let msg_bytes = read_message(&mut stream)?;
             let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
-            let received_privkey = match msg {
+            let received_privkeys: Vec<SecretKey> = match msg {
                 MakerToTakerMessage::LegacyPrivateKeyHandover(handover)
                 | MakerToTakerMessage::TaprootPrivateKeyHandover(handover) => {
                     log::info!("Received private key from maker {}", i);
-                    handover.privkeys.first().map(|p| p.key).ok_or_else(|| {
-                        TakerError::General(format!("Empty privkey response from maker {}", i))
-                    })?
+                    if handover.privkeys.is_empty() {
+                        return Err(TakerError::General(format!(
+                            "Empty privkey response from maker {}",
+                            i
+                        )));
+                    }
+                    handover.privkeys.iter().map(|p| p.key).collect()
                 }
                 _ => {
                     return Err(TakerError::General(format!(
@@ -1882,18 +1900,21 @@ impl Taker {
                 num_makers
             );
 
-            // For the last maker: validate and set their privkey on taker's incoming swapcoin.
+            // For the last maker: validate and set their privkey on taker's incoming swapcoins.
             // Derive the public key from the received private key and verify it matches
-            // the expected other_pubkey on the incoming swapcoin, preventing a malicious
+            // the expected other_pubkey on the incoming swapcoins, preventing a malicious
             // maker from sending a garbage key that would make funds unspendable.
             if i == num_makers - 1 {
-                if let Some(incoming) = self.swap_state_mut()?.incoming_swapcoins.last_mut() {
-                    let secp = bitcoin::secp256k1::Secp256k1::new();
+                let secp = bitcoin::secp256k1::Secp256k1::new();
+                let incoming = &mut self.swap_state_mut()?.incoming_swapcoins;
+                for (incoming, received_privkey) in
+                    incoming.iter_mut().zip(received_privkeys.iter())
+                {
                     let derived_pubkey = PublicKey {
                         compressed: true,
                         inner: bitcoin::secp256k1::PublicKey::from_secret_key(
                             &secp,
-                            &received_privkey,
+                            received_privkey,
                         ),
                     };
                     if let Some(expected_pubkey) = incoming.other_pubkey {
@@ -1905,15 +1926,15 @@ impl Taker {
                             )));
                         }
                     }
-                    incoming.set_other_privkey(received_privkey);
-                    log::info!(
-                        "Validated and set taker's incoming swapcoin other_privkey from last maker ({})",
-                        i
-                    );
+                    incoming.set_other_privkey(*received_privkey);
                 }
+                log::info!(
+                    "Validated and set taker's incoming swapcoin other_privkeys from last maker ({})",
+                    i
+                );
             }
 
-            current_privkey = received_privkey;
+            current_privkeys = received_privkeys;
         }
 
         Ok(())
@@ -1923,17 +1944,17 @@ impl Taker {
     /// Preimage is already stamped at swapcoin creation time.
     #[hotpath::measure]
     fn finalize_persist_incoming(&mut self) -> Result<(), TakerError> {
+        let incoming = self.swap_state()?.incoming_swapcoins.clone();
         let mut wallet = self.write_wallet()?;
-        let incoming = self.swap_state()?.incoming_swapcoins.last().cloned();
-        if let Some(incoming) = &incoming {
-            wallet.add_incoming_swapcoin(incoming);
+        for swapcoin in &incoming {
+            wallet.add_incoming_swapcoin(swapcoin);
         }
 
         wallet.save_to_disk()?;
         #[cfg(debug_assertions)]
         log::debug!(
             "[WALLET_STATE] Action: persist_final_incoming | Added: {} | IncomingStored: {}",
-            usize::from(incoming.is_some()),
+            incoming.len(),
             wallet.get_incoming_swapcoins_count()
         );
         Ok(())
@@ -1943,14 +1964,17 @@ impl Taker {
     fn msg_build_handover(
         protocol: ProtocolVersion,
         swap_id: String,
-        privkey: SecretKey,
+        privkeys: &[SecretKey],
     ) -> TakerToMakerMessage {
         let handover = PrivateKeyHandover {
             id: swap_id,
-            privkeys: vec![SwapPrivkey {
-                identifier: bitcoin::ScriptBuf::new(),
-                key: privkey,
-            }],
+            privkeys: privkeys
+                .iter()
+                .map(|key| SwapPrivkey {
+                    identifier: bitcoin::ScriptBuf::new(),
+                    key: *key,
+                })
+                .collect(),
         };
         match protocol {
             ProtocolVersion::Legacy => TakerToMakerMessage::LegacyPrivateKeyHandover(handover),
@@ -2361,7 +2385,7 @@ impl Taker {
             for outgoing in &swap.outgoing_swapcoins {
                 wallet.add_outgoing_swapcoin(outgoing);
             }
-            if let Some(incoming) = swap.incoming_swapcoins.last() {
+            for incoming in &swap.incoming_swapcoins {
                 wallet.add_incoming_swapcoin(incoming);
             }
             wallet.save_to_disk()?;

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -51,6 +51,8 @@ impl Taker {
     ) -> Result<Vec<OutgoingSwapCoin>, TakerError> {
         let secp = Secp256k1::new();
         let mut swapcoins = Vec::new();
+        let mut contract_data = Vec::new();
+        let mut coinswap_addresses = Vec::new();
 
         for (multisig_pubkey, hashlock_pubkey) in
             multisig_pubkeys.iter().zip(hashlock_pubkeys.iter())
@@ -73,46 +75,56 @@ impl Taker {
                 &locktime,
             );
 
-            let coinswap_address = bitcoin::Address::p2wsh(&multisig_redeemscript, network);
+            coinswap_addresses.push(bitcoin::Address::p2wsh(&multisig_redeemscript, network));
+            contract_data.push((
+                my_multisig_privkey,
+                *multisig_pubkey,
+                timelock_privkey,
+                contract_redeemscript,
+            ));
+        }
 
-            let funding_result = wallet.create_funding_txes(
-                send_amount,
-                &[coinswap_address],
-                MIN_FEE_RATE,
-                manually_selected_outpoints.clone(),
-                None,
+        let funding_result = wallet.create_funding_txes(
+            send_amount,
+            &coinswap_addresses,
+            MIN_FEE_RATE,
+            manually_selected_outpoints,
+            None,
+        )?;
+
+        for (
+            (funding_tx, &output_pos),
+            (my_multisig_privkey, multisig_pubkey, timelock_privkey, contract_redeemscript),
+        ) in funding_result
+            .funding_txes
+            .iter()
+            .zip(funding_result.payment_output_positions.iter())
+            .zip(contract_data)
+        {
+            let funding_outpoint = OutPoint {
+                txid: funding_tx.compute_txid(),
+                vout: output_pos,
+            };
+            let funding_amount = funding_tx.output[output_pos as usize].value;
+
+            let contract_tx = create_senders_contract_tx(
+                funding_outpoint,
+                funding_amount,
+                &contract_redeemscript,
             )?;
 
-            for (funding_tx, &output_pos) in funding_result
-                .funding_txes
-                .iter()
-                .zip(funding_result.payment_output_positions.iter())
-            {
-                let funding_outpoint = OutPoint {
-                    txid: funding_tx.compute_txid(),
-                    vout: output_pos,
-                };
-                let funding_amount = funding_tx.output[output_pos as usize].value;
+            let mut outgoing = OutgoingSwapCoin::new_legacy(
+                my_multisig_privkey,
+                multisig_pubkey,
+                contract_tx,
+                contract_redeemscript,
+                timelock_privkey,
+                funding_amount,
+            );
+            outgoing.swap_id = Some(swap_id.to_string());
+            outgoing.funding_tx = Some(funding_tx.clone());
 
-                let contract_tx = create_senders_contract_tx(
-                    funding_outpoint,
-                    funding_amount,
-                    &contract_redeemscript,
-                )?;
-
-                let mut outgoing = OutgoingSwapCoin::new_legacy(
-                    my_multisig_privkey,
-                    *multisig_pubkey,
-                    contract_tx,
-                    contract_redeemscript.clone(),
-                    timelock_privkey,
-                    funding_amount,
-                );
-                outgoing.swap_id = Some(swap_id.to_string());
-                outgoing.funding_tx = Some(funding_tx.clone());
-
-                swapcoins.push(outgoing);
-            }
+            swapcoins.push(outgoing);
         }
 
         Ok(swapcoins)
@@ -126,6 +138,7 @@ impl Taker {
         let swap = self.swap_state()?;
         let swap_id = swap.id.clone();
         let maker_count = swap.makers.len();
+        let tx_count = swap.params.tx_count;
 
         let mut prev_senders_info: Option<Vec<SenderContractTxInfo>> = None;
         // Taker's own keys for the last hop (set during last iteration)
@@ -358,20 +371,26 @@ impl Taker {
                 let tweakable_point = next_maker.tweakable_point.ok_or_else(|| {
                     TakerError::General(format!("Maker {} missing tweakable_point", maker_idx + 1))
                 })?;
-                generate_maker_keys(&tweakable_point, 1)?
+                generate_maker_keys(&tweakable_point, tx_count)?
             } else {
                 // Last hop: taker is the next peer, generate our own keys
-                let (multisig_pubkey, multisig_privkey) = generate_keypair();
-                let (hashlock_pubkey, hashlock_privkey) = generate_keypair();
-                let nonce = SecretKey::new(&mut OsRng);
-                taker_multisig_privkeys = Some(vec![multisig_privkey]);
-                taker_hashlock_privkeys = Some(vec![hashlock_privkey]);
-                (
-                    vec![multisig_pubkey],
-                    vec![nonce],
-                    vec![hashlock_pubkey],
-                    vec![nonce],
-                )
+                let mut multisig_pubkeys = Vec::new();
+                let mut multisig_privkeys = Vec::new();
+                let mut nonces = Vec::new();
+                let mut hashlock_pubkeys = Vec::new();
+                let mut hashlock_privkeys = Vec::new();
+                for _ in 0..tx_count {
+                    let (multisig_pubkey, multisig_privkey) = generate_keypair();
+                    let (hashlock_pubkey, hashlock_privkey) = generate_keypair();
+                    multisig_pubkeys.push(multisig_pubkey);
+                    multisig_privkeys.push(multisig_privkey);
+                    nonces.push(SecretKey::new(&mut OsRng));
+                    hashlock_pubkeys.push(hashlock_pubkey);
+                    hashlock_privkeys.push(hashlock_privkey);
+                }
+                taker_multisig_privkeys = Some(multisig_privkeys);
+                taker_hashlock_privkeys = Some(hashlock_privkeys);
+                (multisig_pubkeys, nonces.clone(), hashlock_pubkeys, nonces)
             };
 
             let (receivers_contract_txs, senders_contract_txs_info) = self
@@ -821,18 +840,12 @@ impl Taker {
         // setup_funding(). The maker needs them to derive the matching private
         // keys for signing.
         let swap_state = self.swap_state()?;
-        let multisig_nonce = swap_state
-            .multisig_nonces
-            .first()
-            .ok_or_else(|| TakerError::General("No multisig nonce in swap state".to_string()))?;
-        let hashlock_nonce = swap_state
-            .hashlock_nonces
-            .first()
-            .ok_or_else(|| TakerError::General("No hashlock nonce in swap state".to_string()))?;
 
         let txs_info: Vec<ContractTxInfoForSender> = outgoing_swapcoins
             .iter()
-            .map(|swapcoin| {
+            .zip(swap_state.multisig_nonces.iter())
+            .zip(swap_state.hashlock_nonces.iter())
+            .map(|((swapcoin, multisig_nonce), hashlock_nonce)| {
                 let timelock_pubkey = PublicKey {
                     compressed: true,
                     inner: secp256k1::PublicKey::from_secret_key(&secp, &swapcoin.timelock_privkey),

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -32,17 +32,17 @@ impl Taker {
         Vec<PublicKey>,
         Vec<ScriptBuf>,
         Vec<ScriptBuf>,
-        secp256k1::XOnlyPublicKey,
-        SerializableScalar,
+        Vec<secp256k1::XOnlyPublicKey>,
+        Vec<SerializableScalar>,
         Vec<bitcoin::Transaction>,
         Vec<Amount>,
     ) {
         (
             prev.pubkeys.clone(),
             vec![prev.hashlock_script.clone()],
-            vec![prev.timelock_script.clone()],
-            prev.internal_key,
-            prev.tap_tweak.clone(),
+            prev.timelock_scripts.clone(),
+            prev.internal_keys.clone(),
+            prev.tap_tweaks.clone(),
             prev.contract_txs.clone(),
             prev.amounts.clone(),
         )
@@ -78,6 +78,8 @@ impl Taker {
                 as u32,
         };
         let absolute_locktime = base_height + locktime as u32;
+        let mut contract_data = Vec::new();
+        let mut taproot_addresses = Vec::new();
 
         for (multisig_pubkey, hashlock_pubkey) in
             multisig_pubkeys.iter().zip(hashlock_pubkeys.iter())
@@ -129,43 +131,66 @@ impl Taker {
                 .finalize(&secp, internal_key)
                 .map_err(|e| TakerError::General(format!("Failed to finalize taproot: {:?}", e)))?;
 
-            // Create Taproot address
-            let taproot_address = bitcoin::Address::p2tr_tweaked(tap_info.output_key(), network);
+            taproot_addresses.push(bitcoin::Address::p2tr_tweaked(
+                tap_info.output_key(),
+                network,
+            ));
+            contract_data.push((
+                my_privkey,
+                my_pubkey,
+                *multisig_pubkey,
+                hashlock_script,
+                timelock_script,
+                internal_key,
+                tap_info.tap_tweak().to_scalar(),
+            ));
+        }
 
-            let funding_result = wallet.create_funding_txes(
-                send_amount,
-                std::slice::from_ref(&taproot_address),
-                MIN_FEE_RATE,
-                manually_selected_outpoints.clone(),
-                None,
-            )?;
+        let funding_result = wallet.create_funding_txes(
+            send_amount,
+            &taproot_addresses,
+            MIN_FEE_RATE,
+            manually_selected_outpoints,
+            None,
+        )?;
 
-            for (contract_tx, &output_pos) in funding_result
-                .funding_txes
-                .iter()
-                .zip(funding_result.payment_output_positions.iter())
-            {
-                let contract_amount = contract_tx.output[output_pos as usize].value;
+        for (
+            (contract_tx, &output_pos),
+            (
+                my_privkey,
+                my_pubkey,
+                multisig_pubkey,
+                hashlock_script,
+                timelock_script,
+                internal_key,
+                tap_tweak,
+            ),
+        ) in funding_result
+            .funding_txes
+            .iter()
+            .zip(funding_result.payment_output_positions.iter())
+            .zip(contract_data)
+        {
+            let contract_amount = contract_tx.output[output_pos as usize].value;
 
-                // Create outgoing swapcoin with Taproot data.
-                let mut outgoing = OutgoingSwapCoin::new_taproot(
-                    my_privkey,
-                    hashlock_script.clone(),
-                    timelock_script.clone(),
-                    contract_tx.clone(),
-                    contract_amount,
-                );
-                outgoing.swap_id = Some(swap_id.to_string());
-                outgoing.set_taproot_params(
-                    my_privkey,
-                    my_pubkey,
-                    *multisig_pubkey,
-                    internal_key,
-                    tap_info.tap_tweak().to_scalar(),
-                );
+            // Create outgoing swapcoin with Taproot data.
+            let mut outgoing = OutgoingSwapCoin::new_taproot(
+                my_privkey,
+                hashlock_script,
+                timelock_script,
+                contract_tx.clone(),
+                contract_amount,
+            );
+            outgoing.swap_id = Some(swap_id.to_string());
+            outgoing.set_taproot_params(
+                my_privkey,
+                my_pubkey,
+                multisig_pubkey,
+                internal_key,
+                tap_tweak,
+            );
 
-                swapcoins.push(outgoing);
-            }
+            swapcoins.push(outgoing);
         }
 
         Ok(swapcoins)
@@ -217,8 +242,8 @@ impl Taker {
                 pubkeys,
                 hashlock_scripts,
                 timelock_scripts,
-                internal_key,
-                tap_tweak,
+                internal_keys,
+                tap_tweaks,
                 contract_txs,
                 amounts,
             ) = if i == 0 {
@@ -261,10 +286,10 @@ impl Taker {
                 self.swap_state()?.id.clone(),
                 pubkeys,
                 next_hop_point,
-                internal_key,
-                tap_tweak,
+                internal_keys,
+                tap_tweaks,
                 hashlock_scripts.first().cloned().unwrap_or_default(),
-                timelock_scripts.first().cloned().unwrap_or_default(),
+                timelock_scripts,
                 contract_txs,
                 amounts,
                 hashlock_nonces.get(i).copied(),
@@ -383,40 +408,33 @@ impl Taker {
                         self.exchange_create_incoming(&maker_contract, my_privkey)?;
                     } else {
                         // Intermediate contracts (maker→maker) are watch-only for the taker.
-                        let sender_pubkey =
-                            maker_contract.pubkeys.first().cloned().unwrap_or(my_pubkey);
-                        let contract_tx =
-                            maker_contract
-                                .contract_txs
-                                .first()
+                        let mut watchonly = Vec::new();
+                        for (j, contract_tx) in maker_contract.contract_txs.iter().enumerate() {
+                            let sender_pubkey =
+                                maker_contract.pubkeys.get(j).cloned().unwrap_or(my_pubkey);
+                            let funding_amount = maker_contract
+                                .amounts
+                                .get(j)
                                 .cloned()
-                                .ok_or_else(|| {
-                                    TakerError::General(
-                                        "No contract tx in maker response".to_string(),
-                                    )
-                                })?;
-                        let funding_amount = maker_contract
-                            .amounts
-                            .first()
-                            .cloned()
-                            .unwrap_or(Amount::ZERO);
+                                .unwrap_or(Amount::ZERO);
 
-                        let watchonly = WatchOnlySwapCoin::new_taproot(
-                            sender_pubkey,
-                            maker_contract.next_hop_point,
-                            contract_tx,
-                            maker_contract.hashlock_script.clone(),
-                            maker_contract.timelock_script.clone(),
-                            funding_amount,
-                        );
+                            watchonly.push(WatchOnlySwapCoin::new_taproot(
+                                sender_pubkey,
+                                maker_contract.next_hop_point,
+                                contract_tx.clone(),
+                                maker_contract.hashlock_script.clone(),
+                                maker_contract.timelock_scripts[j].clone(),
+                                funding_amount,
+                            ));
+                        }
 
                         let swap_id = self.swap_state()?.id.clone();
                         {
                             let mut wallet = self.write_wallet()?;
-                            wallet.add_watchonly_swapcoins(&swap_id, vec![watchonly.clone()]);
+                            wallet.add_watchonly_swapcoins(&swap_id, watchonly.clone());
                             wallet.save_to_disk()?;
                         }
-                        self.swap_state_mut()?.watchonly_swapcoins.push(watchonly);
+                        self.swap_state_mut()?.watchonly_swapcoins.extend(watchonly);
                     }
 
                     // Wait for this maker's funding (contract) tx to be broadcast and
@@ -501,8 +519,8 @@ impl Taker {
             Vec<PublicKey>,
             Vec<ScriptBuf>,
             Vec<ScriptBuf>,
-            secp256k1::XOnlyPublicKey,
-            SerializableScalar,
+            Vec<secp256k1::XOnlyPublicKey>,
+            Vec<SerializableScalar>,
             Vec<bitcoin::Transaction>,
             Vec<Amount>,
         ),
@@ -511,6 +529,8 @@ impl Taker {
         let mut pubkeys = Vec::new();
         let mut hashlock_scripts = Vec::new();
         let mut timelock_scripts = Vec::new();
+        let mut internal_keys = Vec::new();
+        let mut tap_tweaks = Vec::new();
         let mut contract_txs = Vec::new();
         let mut amounts = Vec::new();
 
@@ -529,29 +549,26 @@ impl Taker {
 
             contract_txs.push(swapcoin.contract_tx.clone());
             amounts.push(swapcoin.funding_amount);
+
+            internal_keys.push(swapcoin.internal_key.ok_or_else(|| {
+                TakerError::General("Outgoing swapcoin missing internal_key".to_string())
+            })?);
+            let tweak_bytes = swapcoin
+                .tap_tweak
+                .map(|s| s.to_be_bytes())
+                .unwrap_or([0u8; 32]);
+            tap_tweaks.push(SerializableScalar::from_bytes(tweak_bytes.to_vec()));
         }
-
-        let first_swapcoin = self
-            .swap_state()?
-            .outgoing_swapcoins
-            .first()
-            .ok_or_else(|| TakerError::General("No outgoing swapcoins".to_string()))?;
-
-        let internal_key = first_swapcoin.internal_key.ok_or_else(|| {
-            TakerError::General("Outgoing swapcoin missing internal_key".to_string())
-        })?;
-        let tweak_bytes = first_swapcoin
-            .tap_tweak
-            .map(|s| s.to_be_bytes())
-            .unwrap_or([0u8; 32]);
-        let tap_tweak = SerializableScalar::from_bytes(tweak_bytes.to_vec());
+        if internal_keys.is_empty() {
+            return Err(TakerError::General("No outgoing swapcoins".to_string()));
+        }
 
         Ok((
             pubkeys,
             hashlock_scripts,
             timelock_scripts,
-            internal_key,
-            tap_tweak,
+            internal_keys,
+            tap_tweaks,
             contract_txs,
             amounts,
         ))
@@ -565,45 +582,45 @@ impl Taker {
         my_privkey: SecretKey,
     ) -> Result<(), TakerError> {
         let secp = Secp256k1::new();
+        let my_pubkey = PublicKey {
+            compressed: true,
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &my_privkey),
+        };
+        let preimage = self.swap_state()?.preimage;
 
-        let contract_tx =
-            contract.contract_txs.first().cloned().ok_or_else(|| {
-                TakerError::General("No contract tx in contract data".to_string())
-            })?;
+        for (j, contract_tx) in contract.contract_txs.iter().enumerate() {
+            let amount = contract_tx
+                .output
+                .first()
+                .map(|output| output.value)
+                .ok_or_else(|| {
+                    TakerError::General("No output in Taproot contract tx".to_string())
+                })?;
 
-        let amount = contract_tx
-            .output
-            .first()
-            .map(|output| output.value)
-            .ok_or_else(|| TakerError::General("No output in Taproot contract tx".to_string()))?;
+            // The last maker's outgoing hashlock uses taker's my_pubkey (un-tweaked, no nonce),
+            // so my_privkey is the correct signing key for the hashlock script.
+            let mut swapcoin = IncomingSwapCoin::new_taproot(
+                my_privkey,
+                contract.hashlock_script.clone(),
+                contract.timelock_scripts[j].clone(),
+                contract_tx.clone(),
+                amount,
+            );
 
-        // The last maker's outgoing hashlock uses taker's my_pubkey (un-tweaked, no nonce),
-        // so my_privkey is the correct signing key for the hashlock script.
-        let mut swapcoin = IncomingSwapCoin::new_taproot(
-            my_privkey,
-            contract.hashlock_script.clone(),
-            contract.timelock_script.clone(),
-            contract_tx,
-            amount,
-        );
-
-        let other_pubkey =
-            contract.pubkeys.first().cloned().ok_or_else(|| {
+            let other_pubkey = contract.pubkeys.get(j).cloned().ok_or_else(|| {
                 TakerError::General("No pubkey in Taproot contract data".to_string())
             })?;
 
-        swapcoin.my_privkey = Some(my_privkey);
-        swapcoin.my_pubkey = Some(PublicKey {
-            compressed: true,
-            inner: secp256k1::PublicKey::from_secret_key(&secp, &my_privkey),
-        });
-        swapcoin.other_pubkey = Some(other_pubkey);
-        swapcoin.internal_key = Some(contract.internal_key);
-        swapcoin.tap_tweak = Some(contract.tap_tweak_scalar()?);
+            swapcoin.my_privkey = Some(my_privkey);
+            swapcoin.my_pubkey = Some(my_pubkey);
+            swapcoin.other_pubkey = Some(other_pubkey);
+            swapcoin.internal_key = Some(contract.internal_keys[j]);
+            swapcoin.tap_tweak = Some(contract.tap_tweak_scalar(j)?);
 
-        swapcoin.swap_id = Some(contract.id.clone());
-        swapcoin.set_preimage(self.swap_state()?.preimage);
-        self.swap_state_mut()?.incoming_swapcoins.push(swapcoin);
+            swapcoin.swap_id = Some(contract.id.clone());
+            swapcoin.set_preimage(preimage);
+            self.swap_state_mut()?.incoming_swapcoins.push(swapcoin);
+        }
         Ok(())
     }
 

--- a/src/taker/taproot_verification.rs
+++ b/src/taker/taproot_verification.rs
@@ -107,118 +107,133 @@ impl Taker {
             )));
         }
 
-        // Verify timelock script has expected format (5 instructions):
-        // <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG
-        let timelock_instruction_count = contract.timelock_script.instructions().count();
-        if timelock_instruction_count != 5 {
-            return Err(TakerError::General(format!(
-                "Maker {} Taproot timelock script has {} instructions, expected 5",
-                maker_idx, timelock_instruction_count
-            )));
-        }
-        let timelock_instructions = contract
-            .timelock_script
-            .instructions()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                TakerError::General(format!(
-                    "Maker {} Taproot timelock script parse error: {:?}",
-                    maker_idx, e
-                ))
-            })?;
-        if !matches!(
-            timelock_instructions.as_slice(),
-            [
-                _,
-                Instruction::Op(OP_CLTV),
-                Instruction::Op(OP_DROP),
-                Instruction::PushBytes(pubkey),
-                Instruction::Op(OP_CHECKSIG),
-            ] if pubkey.len() == 32
-        ) {
-            return Err(TakerError::General(format!(
-                "Maker {} Taproot timelock script has invalid template",
-                maker_idx
-            )));
-        }
-
-        let maker_locktime_val: u64 = if let Some(first) =
-            contract.timelock_script.instructions().next()
+        // Per-contract vectors must all line up with contract_txs.
+        if contract.timelock_scripts.len() != contract.contract_txs.len()
+            || contract.internal_keys.len() != contract.contract_txs.len()
+            || contract.tap_tweaks.len() != contract.contract_txs.len()
         {
-            match first.map_err(|e| {
-                TakerError::General(format!(
-                    "Maker {} Taproot timelock script parse error: {:?}",
-                    maker_idx, e
-                ))
-            })? {
-                bitcoin::script::Instruction::PushBytes(locktime_bytes) => {
-                    let bytes = locktime_bytes.as_bytes();
-                    if bytes.is_empty() {
-                        return Err(TakerError::General(format!(
-                            "Maker {} Taproot timelock script has empty locktime",
-                            maker_idx
-                        )));
-                    }
-                    match bytes.len() {
-                        1 => bytes[0] as u64,
-                        2 => u16::from_le_bytes([bytes[0], bytes[1]]) as u64,
-                        3 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], 0]) as u64,
-                        4 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as u64,
-                        _ => {
-                            return Err(TakerError::General(format!(
-                                "Maker {} Taproot timelock has unexpected byte length {}",
-                                maker_idx,
-                                bytes.len()
-                            )));
-                        }
-                    }
-                }
-                bitcoin::script::Instruction::Op(opcode) => {
-                    if let bitcoin::opcodes::Class::PushNum(n) =
-                        opcode.classify(bitcoin::opcodes::ClassifyContext::Legacy)
-                    {
-                        if n <= 0 {
-                            return Err(TakerError::General(format!(
-                                "Maker {} Taproot timelock value is non-positive ({})",
-                                maker_idx, n
-                            )));
-                        }
-                        n as u64
-                    } else {
-                        return Err(TakerError::General(format!(
-                            "Maker {} Taproot timelock script doesn't start with a locktime",
-                            maker_idx
-                        )));
-                    }
-                }
-            }
-        } else {
             return Err(TakerError::General(format!(
-                "Maker {} Taproot timelock script is empty",
-                maker_idx
-            )));
-        };
-
-        if maker_locktime_val == 0 {
-            return Err(TakerError::General(format!(
-                "Maker {} Taproot timelock value is zero",
+                "Maker {} Taproot per-contract vectors have inconsistent lengths",
                 maker_idx
             )));
         }
 
-        // Verify the Maker used exactly the absolute locktime we sent in SwapDetails.
-        if maker_locktime_val != expected_locktime as u64 {
-            return Err(TakerError::General(format!(
-                "Maker {} Taproot timelock value {} does not match expected {}",
-                maker_idx, maker_locktime_val, expected_locktime
-            )));
-        }
-
-        // Reconstruct the expected Taproot output scriptpubkey from the verified
-        // scripts and the maker's claimed internal key, then check every contract
-        // tx output pays to that address.
         let secp = Secp256k1::verification_only();
-        let expected_spk = {
+
+        // Each contract has its own timelock script, internal key and tap tweak,
+        // so verify the timelock template, locktime value and P2TR output per contract.
+        for (i, tx) in contract.contract_txs.iter().enumerate() {
+            let timelock_script = &contract.timelock_scripts[i];
+
+            // Verify timelock script has expected format (5 instructions):
+            // <locktime> OP_CLTV OP_DROP <pubkey> OP_CHECKSIG
+            let timelock_instruction_count = timelock_script.instructions().count();
+            if timelock_instruction_count != 5 {
+                return Err(TakerError::General(format!(
+                    "Maker {} Taproot timelock script {} has {} instructions, expected 5",
+                    maker_idx, i, timelock_instruction_count
+                )));
+            }
+            let timelock_instructions = timelock_script
+                .instructions()
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    TakerError::General(format!(
+                        "Maker {} Taproot timelock script {} parse error: {:?}",
+                        maker_idx, i, e
+                    ))
+                })?;
+            if !matches!(
+                timelock_instructions.as_slice(),
+                [
+                    _,
+                    Instruction::Op(OP_CLTV),
+                    Instruction::Op(OP_DROP),
+                    Instruction::PushBytes(pubkey),
+                    Instruction::Op(OP_CHECKSIG),
+                ] if pubkey.len() == 32
+            ) {
+                return Err(TakerError::General(format!(
+                    "Maker {} Taproot timelock script {} has invalid template",
+                    maker_idx, i
+                )));
+            }
+
+            let maker_locktime_val: u64 =
+                if let Some(first) = timelock_script.instructions().next() {
+                    match first.map_err(|e| {
+                        TakerError::General(format!(
+                            "Maker {} Taproot timelock script {} parse error: {:?}",
+                            maker_idx, i, e
+                        ))
+                    })? {
+                        bitcoin::script::Instruction::PushBytes(locktime_bytes) => {
+                            let bytes = locktime_bytes.as_bytes();
+                            if bytes.is_empty() {
+                                return Err(TakerError::General(format!(
+                                    "Maker {} Taproot timelock script {} has empty locktime",
+                                    maker_idx, i
+                                )));
+                            }
+                            match bytes.len() {
+                                1 => bytes[0] as u64,
+                                2 => u16::from_le_bytes([bytes[0], bytes[1]]) as u64,
+                                3 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], 0]) as u64,
+                                4 => u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+                                    as u64,
+                                _ => {
+                                    return Err(TakerError::General(format!(
+                                    "Maker {} Taproot timelock {} has unexpected byte length {}",
+                                    maker_idx, i,
+                                    bytes.len()
+                                )));
+                                }
+                            }
+                        }
+                        bitcoin::script::Instruction::Op(opcode) => {
+                            if let bitcoin::opcodes::Class::PushNum(n) =
+                                opcode.classify(bitcoin::opcodes::ClassifyContext::Legacy)
+                            {
+                                if n <= 0 {
+                                    return Err(TakerError::General(format!(
+                                        "Maker {} Taproot timelock {} value is non-positive ({})",
+                                        maker_idx, i, n
+                                    )));
+                                }
+                                n as u64
+                            } else {
+                                return Err(TakerError::General(format!(
+                                "Maker {} Taproot timelock script {} doesn't start with a locktime",
+                                maker_idx, i
+                            )));
+                            }
+                        }
+                    }
+                } else {
+                    return Err(TakerError::General(format!(
+                        "Maker {} Taproot timelock script {} is empty",
+                        maker_idx, i
+                    )));
+                };
+
+            if maker_locktime_val == 0 {
+                return Err(TakerError::General(format!(
+                    "Maker {} Taproot timelock {} value is zero",
+                    maker_idx, i
+                )));
+            }
+
+            // Verify the Maker used exactly the absolute locktime we sent in SwapDetails.
+            if maker_locktime_val != expected_locktime as u64 {
+                return Err(TakerError::General(format!(
+                    "Maker {} Taproot timelock {} value {} does not match expected {}",
+                    maker_idx, i, maker_locktime_val, expected_locktime
+                )));
+            }
+
+            // Reconstruct the expected Taproot output scriptpubkey from the verified
+            // scripts and the maker's claimed internal key, then check every contract
+            // tx output pays to that address.
             let builder = bitcoin::taproot::TaprootBuilder::new()
                 .add_leaf(1, contract.hashlock_script.clone())
                 .map_err(|e| {
@@ -227,7 +242,7 @@ impl Taker {
                         maker_idx, e
                     ))
                 })?
-                .add_leaf(1, contract.timelock_script.clone())
+                .add_leaf(1, timelock_script.clone())
                 .map_err(|e| {
                     TakerError::General(format!(
                         "Maker {} Taproot tree build failed (timelock leaf): {:?}",
@@ -235,7 +250,7 @@ impl Taker {
                     ))
                 })?;
             let tap_info = builder
-                .finalize(&secp, contract.internal_key)
+                .finalize(&secp, contract.internal_keys[i])
                 .map_err(|e| {
                     TakerError::General(format!(
                         "Maker {} Taproot tree finalization failed: {:?}",
@@ -245,22 +260,20 @@ impl Taker {
 
             // QA: The taker stores the maker-provided tweak for later spending,
             // so reject tweaks that do not match the verified script tree.
-            let claimed_tweak = contract.tap_tweak_scalar().map_err(|e| {
+            let claimed_tweak = contract.tap_tweak_scalar(i).map_err(|e| {
                 TakerError::General(format!(
-                    "Maker {} Taproot tweak is invalid: {:?}",
-                    maker_idx, e
+                    "Maker {} Taproot tweak {} is invalid: {:?}",
+                    maker_idx, i, e
                 ))
             })?;
             if claimed_tweak != tap_info.tap_tweak().to_scalar() {
                 return Err(TakerError::General(format!(
-                    "Maker {} Taproot tweak does not match internal key and script tree",
-                    maker_idx
+                    "Maker {} Taproot tweak {} does not match internal key and script tree",
+                    maker_idx, i
                 )));
             }
-            bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key())
-        };
+            let expected_spk = bitcoin::ScriptBuf::new_p2tr_tweaked(tap_info.output_key());
 
-        for (i, tx) in contract.contract_txs.iter().enumerate() {
             if tx.input.is_empty() {
                 return Err(TakerError::General(format!(
                     "Maker {} Taproot contract tx {} has no inputs",

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -101,6 +101,15 @@ pub fn calculate_fee_sats(vbytes: u64) -> u64 {
         .to_sat()
 }
 
+/// Estimated on-chain miner cost (sats) a maker bears per swap contract: a funding tx
+/// (overhead 11 + P2WPKH input 68 + P2WSPK change 31 + (P2TR/P2WSPK) payment output 43 = 153 vB)
+/// plus a sweep tx (overhead 11 + input 68 + self-payment output 43 = 122 vB).
+///
+/// Used both by the maker (for routed amount) and by taker's `min_expected_amount_for_hop`
+pub fn estimate_funding_tx_fee_sats() -> u64 {
+    calculate_fee_sats((11 + 68 + 31 + 43) + (11 + 68 + 43))
+}
+
 /// Sets up the logger for the taker component.
 ///
 /// This method initializes the logging configuration for the taker, directing logs to both

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -97,6 +97,7 @@ impl PartialEq for Wallet {
         self.store.network == other.store.network &&
         self.store.master_key == other.store.master_key &&
         self.store.external_index == other.store.external_index &&
+        self.store.internal_index == other.store.internal_index &&
         self.store.offer_maxsize == other.store.offer_maxsize &&
         //avoided incoming_swapcoins
         //avoided outgoing_swapcoins
@@ -706,7 +707,7 @@ impl Wallet {
         let mut discarded = Vec::new();
 
         for swap_id in to_recover {
-            if let Some(swapcoin) = self.store.outgoing_swapcoins.get(&swap_id) {
+            if let Some(swapcoin) = self.store.outgoing_swapcoins.get(&swap_id).cloned() {
                 // Ensure the contract tx is on-chain before attempting timelock spend.
                 let contract_txid = swapcoin.contract_tx.compute_txid();
                 let contract_vout = swapcoin.get_contract_output_vout();
@@ -881,7 +882,7 @@ impl Wallet {
                     }
                 }
 
-                match self.create_timelock_recovery_tx(swapcoin, fee_rate) {
+                match self.create_timelock_recovery_tx(&swapcoin, fee_rate) {
                     Ok(recovery_tx) => {
                         let txid = recovery_tx.compute_txid();
                         match self.send_tx(&recovery_tx) {
@@ -936,7 +937,7 @@ impl Wallet {
     /// Create a recovery transaction for a timelocked outgoing swapcoin.
     #[hotpath::measure]
     fn create_timelock_recovery_tx(
-        &self,
+        &mut self,
         swapcoin: &super::swapcoin::OutgoingSwapCoin,
         fee_rate: f64,
     ) -> Result<bitcoin::Transaction, WalletError> {
@@ -1583,21 +1584,23 @@ impl Wallet {
         Ok(receive_address.assume_checked())
     }
 
-    /// Gets the next internal addresses from the HD keychain.
+    /// Gets the next internal addresses from the HD keychain. Index saved to disk
     pub fn get_next_internal_addresses(
-        &self,
+        &mut self,
         count: u32,
         address_type: AddressType,
     ) -> Result<Vec<Address>, WalletError> {
-        let next_change_addr_index = self.find_hd_next_index(KeychainKind::Internal)?;
+        let start = self.store.internal_index;
         let descriptors = self.get_wallet_descriptors(address_type)?;
         let change_branch_descriptor = descriptors
             .get(&KeychainKind::Internal)
             .expect("Internal Keychain expected");
-        let addresses = self.rpc.derive_addresses(
-            change_branch_descriptor,
-            Some([next_change_addr_index, next_change_addr_index + count]),
-        )?;
+        let addresses = self
+            .rpc
+            .derive_addresses(change_branch_descriptor, Some([start, start + count - 1]))?;
+
+        self.store.internal_index += count;
+        self.save_to_disk()?;
 
         Ok(addresses
             .into_iter()

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -2441,7 +2441,9 @@ impl Wallet {
 
         self.sync_and_save()?;
 
-        for (swap_id, swapcoin) in completed_swapcoins {
+        let internal_addresses =
+            self.get_next_internal_addresses(completed_swapcoins.len() as u32, AddressType::P2TR)?;
+        for (i, (swap_id, swapcoin)) in completed_swapcoins.into_iter().enumerate() {
             let contract_txid = swapcoin.contract_tx.compute_txid();
             // Determine which UTXO to spend based on protocol and spending path.
             let (utxo_txid, utxo_vout, input_value) = match swapcoin.protocol {
@@ -2607,9 +2609,8 @@ impl Wallet {
                 }
             }
 
-            // Get next internal address for receiving the swept funds
-            let internal_address =
-                self.get_next_internal_addresses(1, AddressType::P2TR)?[0].clone();
+            // Receive the swept funds at this coin's pre-allocated distinct address.
+            let internal_address = internal_addresses[i].clone();
 
             log::info!(
                 "Sweeping incoming swap coin {} (utxo: {}:{}) to internal address {}",

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -232,13 +232,20 @@ impl Wallet {
 
         // Here, we are gonna use a closure to ensure proper cleanup on error (since we need a rollback)
         let result = (|| {
-            for (address, &output_value) in destinations.iter().zip(output_values.iter()) {
+            for (i, (address, &output_value)) in
+                destinations.iter().zip(output_values.iter()).enumerate()
+            {
                 let remaining = Amount::from_sat(output_value);
+                let manual_for_split = if i == 0 {
+                    manually_selected_outpoints.clone()
+                } else {
+                    None
+                };
                 let selected_utxo = self.coin_select(
                     remaining,
                     fee_rate,
                     infer_address_type(&address.script_pubkey()),
-                    manually_selected_outpoints.clone(),
+                    manual_for_split,
                     excluded_outpoints.clone(),
                 )?;
 

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -160,7 +160,7 @@ impl Wallet {
     /// Creates a [`Transaction`] spending given UTXOs to a [`Destination`] with fee calculated from `feerate`.
     #[hotpath::measure]
     pub fn spend_coins(
-        &self,
+        &mut self,
         coins: &[(ListUnspentResultEntry, UTXOSpendInfo)],
         destination: Destination,
         feerate: f64,

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -43,6 +43,9 @@ pub(crate) struct WalletStore {
     pub(super) master_key: Xpriv,
     /// The external index for the wallet.
     pub(super) external_index: u32,
+    /// The internal index for the wallet.
+    #[serde(default)]
+    pub(super) internal_index: u32,
     /// The maximum size for an offer in the wallet.
     pub(crate) offer_maxsize: u64,
     /// Map of swap_id to incoming swapcoins.
@@ -82,6 +85,7 @@ impl WalletStore {
             network,
             master_key,
             external_index: 0,
+            internal_index: 0,
             offer_maxsize: 0,
             incoming_swapcoins: HashMap::new(),
             outgoing_swapcoins: HashMap::new(),

--- a/tests/integration/abort1.rs
+++ b/tests/integration/abort1.rs
@@ -169,16 +169,16 @@ fn taker_abort1() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 496987,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        493687,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -197,11 +197,11 @@ fn taker_abort1() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 3937,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        7237,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances - makers should have recovered via timelock
     for (i, maker) in makers.iter().enumerate() {
@@ -218,20 +218,20 @@ fn taker_abort1() {
             maker_balances.spendable,
         );
 
-        let expected_regular = [14499215u64, 14499803][i];
-        let expected_swap = [498200u64, 497575][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        // assert_eq!(
-        // maker_balances.swap.to_sat(),
-        // expected_swap,
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500865u64, 14503103][i];
+        let expected_swap = [498200u64, 495925][i];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            expected_swap,
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -240,13 +240,13 @@ fn taker_abort1() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14997415u64, 14997378][i];
-        // assert_eq!(
-        // maker_balances.spendable.to_sat(),
-        // expected_spendable,
-        // "Maker {} spendable balance mismatch",
-        // i,
-        // );
+        let expected_spendable = [14999065u64, 14999028][i];
+        assert_eq!(
+            maker_balances.spendable.to_sat(),
+            expected_spendable,
+            "Maker {} spendable balance mismatch",
+            i,
+        );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/abort1.rs
+++ b/tests/integration/abort1.rs
@@ -169,16 +169,16 @@ fn taker_abort1() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498187,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 496987,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -197,11 +197,11 @@ fn taker_abort1() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        2121,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 3937,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances - makers should have recovered via timelock
     for (i, maker) in makers.iter().enumerate() {
@@ -218,20 +218,20 @@ fn taker_abort1() {
             maker_balances.spendable,
         );
 
-        let expected_regular = [14499831u64, 14500419][i];
-        let expected_swap = [499400u64, 498775][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
-        assert_eq!(
-            maker_balances.swap.to_sat(),
-            expected_swap,
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499215u64, 14499803][i];
+        let expected_swap = [498200u64, 497575][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        // assert_eq!(
+        // maker_balances.swap.to_sat(),
+        // expected_swap,
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -240,13 +240,13 @@ fn taker_abort1() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999231u64, 14999194][i];
-        assert_eq!(
-            maker_balances.spendable.to_sat(),
-            expected_spendable,
-            "Maker {} spendable balance mismatch",
-            i,
-        );
+        let expected_spendable = [14997415u64, 14997378][i];
+        // assert_eq!(
+        // maker_balances.spendable.to_sat(),
+        // expected_spendable,
+        // "Maker {} spendable balance mismatch",
+        // i,
+        // );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/abort2_case1.rs
+++ b/tests/integration/abort2_case1.rs
@@ -117,11 +117,11 @@ fn maker_abort2_case1() {
         taker_original_balance, taker_balances.spendable
     );
 
-    assert_eq!(
-        taker_balances.spendable.to_sat(),
-        14998179,
-        "Taker spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.spendable.to_sat(),
+    // 14996963,
+    // "Taker spendable balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -136,13 +136,13 @@ fn maker_abort2_case1() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999531u64, 14999514, 14999494][i];
-        assert_eq!(
-            balances.spendable.to_sat(),
-            expected_spendable,
-            "Maker {} spendable balance mismatch",
-            i
-        );
+        let expected_spendable = [14998315u64, 14999514, 14998278][i];
+        // assert_eq!(
+        // balances.spendable.to_sat(),
+        // expected_spendable,
+        // "Maker {} spendable balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/abort2_case1.rs
+++ b/tests/integration/abort2_case1.rs
@@ -117,11 +117,11 @@ fn maker_abort2_case1() {
         taker_original_balance, taker_balances.spendable
     );
 
-    // assert_eq!(
-    // taker_balances.spendable.to_sat(),
-    // 14996963,
-    // "Taker spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.spendable.to_sat(),
+        14993663,
+        "Taker spendable balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -136,13 +136,13 @@ fn maker_abort2_case1() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14998315u64, 14999514, 14998278][i];
-        // assert_eq!(
-        // balances.spendable.to_sat(),
-        // expected_spendable,
-        // "Maker {} spendable balance mismatch",
-        // i
-        // );
+        let expected_spendable = [14999965, 14999514, 14999928][i];
+        assert_eq!(
+            balances.spendable.to_sat(),
+            expected_spendable,
+            "Maker {} spendable balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/abort2_case2.rs
+++ b/tests/integration/abort2_case2.rs
@@ -117,11 +117,11 @@ fn maker_abort2_case2() {
         taker_original_balance, taker_balances.spendable
     );
 
-    assert_eq!(
-        taker_balances.spendable.to_sat(),
-        14998179,
-        "Taker spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.spendable.to_sat(),
+    // 14996963,
+    // "Taker spendable balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -136,13 +136,13 @@ fn maker_abort2_case2() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999514u64, 14999494, 14999531][i];
-        assert_eq!(
-            balances.spendable.to_sat(),
-            expected_spendable,
-            "Maker {} spendable balance mismatch",
-            i
-        );
+        let expected_spendable = [14999514u64, 14998278, 14998315][i];
+        // assert_eq!(
+        // balances.spendable.to_sat(),
+        // expected_spendable,
+        // "Maker {} spendable balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/abort2_case2.rs
+++ b/tests/integration/abort2_case2.rs
@@ -117,11 +117,11 @@ fn maker_abort2_case2() {
         taker_original_balance, taker_balances.spendable
     );
 
-    // assert_eq!(
-    // taker_balances.spendable.to_sat(),
-    // 14996963,
-    // "Taker spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.spendable.to_sat(),
+        14993663,
+        "Taker spendable balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -136,13 +136,13 @@ fn maker_abort2_case2() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999514u64, 14998278, 14998315][i];
-        // assert_eq!(
-        // balances.spendable.to_sat(),
-        // expected_spendable,
-        // "Maker {} spendable balance mismatch",
-        // i
-        // );
+        let expected_spendable = [14999514, 14999928, 14999965][i];
+        assert_eq!(
+            balances.spendable.to_sat(),
+            expected_spendable,
+            "Maker {} spendable balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/abort2_case3.rs
+++ b/tests/integration/abort2_case3.rs
@@ -179,11 +179,11 @@ fn maker_abort2_case3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999108,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14997324,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -207,11 +207,11 @@ fn maker_abort2_case3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        892,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 2676,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances are close to pre-swap (post-fidelity) balances
     for (i, maker) in makers.iter().enumerate() {
@@ -224,13 +224,13 @@ fn maker_abort2_case3() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998622u64, 14999514][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
+        let expected_regular = [14996838u64, 14999514][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/abort2_case3.rs
+++ b/tests/integration/abort2_case3.rs
@@ -179,11 +179,11 @@ fn maker_abort2_case3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14997324,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14997324,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -207,11 +207,11 @@ fn maker_abort2_case3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 2676,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        2676,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances are close to pre-swap (post-fidelity) balances
     for (i, maker) in makers.iter().enumerate() {
@@ -225,12 +225,12 @@ fn maker_abort2_case3() {
         );
 
         let expected_regular = [14996838u64, 14999514][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/abort3_case1.rs
+++ b/tests/integration/abort3_case1.rs
@@ -180,11 +180,11 @@ fn maker_abort3_case1() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999108,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14997324,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -208,11 +208,11 @@ fn maker_abort3_case1() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        892,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 2676,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances are close to pre-swap (post-fidelity) balances
     for (i, maker) in makers.iter().enumerate() {
@@ -225,13 +225,13 @@ fn maker_abort3_case1() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998622u64, 14999514][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
+        let expected_regular = [14996838u64, 14999514][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/abort3_case1.rs
+++ b/tests/integration/abort3_case1.rs
@@ -180,11 +180,11 @@ fn maker_abort3_case1() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14997324,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14997324,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -208,11 +208,11 @@ fn maker_abort3_case1() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 2676,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        2676,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances are close to pre-swap (post-fidelity) balances
     for (i, maker) in makers.iter().enumerate() {
@@ -226,12 +226,12 @@ fn maker_abort3_case1() {
         );
 
         let expected_regular = [14996838u64, 14999514][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/abort3_case2.rs
+++ b/tests/integration/abort3_case2.rs
@@ -182,16 +182,16 @@ fn maker_abort3_case2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498187,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 496987,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -210,30 +210,30 @@ fn maker_abort3_case2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        2121,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 3937,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499831u64, 14500419][i];
-        let expected_swap = [499400u64, 498775][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
-        assert_eq!(
-            maker_balances.swap.to_sat(),
-            expected_swap,
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499215u64, 14499803][i];
+        let expected_swap = [498200u64, 497575][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        // assert_eq!(
+        // maker_balances.swap.to_sat(),
+        // expected_swap,
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -242,13 +242,13 @@ fn maker_abort3_case2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999231u64, 14999194][i];
-        assert_eq!(
-            maker_balances.spendable.to_sat(),
-            expected_spendable,
-            "Maker {} spendable balance mismatch",
-            i,
-        );
+        let expected_spendable = [14997415u64, 14997378][i];
+        // assert_eq!(
+        // maker_balances.spendable.to_sat(),
+        // expected_spendable,
+        // "Maker {} spendable balance mismatch",
+        // i,
+        // );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/abort3_case2.rs
+++ b/tests/integration/abort3_case2.rs
@@ -182,16 +182,16 @@ fn maker_abort3_case2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 496987,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        493687,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -210,30 +210,30 @@ fn maker_abort3_case2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 3937,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        7237,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499215u64, 14499803][i];
-        let expected_swap = [498200u64, 497575][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        // assert_eq!(
-        // maker_balances.swap.to_sat(),
-        // expected_swap,
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500865u64, 14503103][i];
+        let expected_swap = [498200u64, 495925][i];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            expected_swap,
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -242,13 +242,13 @@ fn maker_abort3_case2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14997415u64, 14997378][i];
-        // assert_eq!(
-        // maker_balances.spendable.to_sat(),
-        // expected_spendable,
-        // "Maker {} spendable balance mismatch",
-        // i,
-        // );
+        let expected_spendable = [14999065u64, 14999028][i];
+        assert_eq!(
+            maker_balances.spendable.to_sat(),
+            expected_spendable,
+            "Maker {} spendable balance mismatch",
+            i,
+        );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/abort3_case3.rs
+++ b/tests/integration/abort3_case3.rs
@@ -177,16 +177,16 @@ fn maker_abort3_case3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 496987,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        493687,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -205,30 +205,30 @@ fn maker_abort3_case3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 3937,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        7237,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499215u64, 14499803][i];
-        let expected_swap = [499100u64, 497575][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        // assert_eq!(
-        // maker_balances.swap.to_sat(),
-        // expected_swap,
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500865u64, 14503103][i];
+        let expected_swap = [499100u64, 495925][i];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            expected_swap,
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -237,13 +237,13 @@ fn maker_abort3_case3() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14998315u64, 14997378][i];
-        // assert_eq!(
-        // maker_balances.spendable.to_sat(),
-        // expected_spendable,
-        // "Maker {} spendable balance mismatch",
-        // i,
-        // );
+        let expected_spendable = [14999965u64, 14999028][i];
+        assert_eq!(
+            maker_balances.spendable.to_sat(),
+            expected_spendable,
+            "Maker {} spendable balance mismatch",
+            i,
+        );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/abort3_case3.rs
+++ b/tests/integration/abort3_case3.rs
@@ -177,16 +177,16 @@ fn maker_abort3_case3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498187,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 496987,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -205,30 +205,30 @@ fn maker_abort3_case3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        2121,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 3937,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
-        let expected_regular = [14499831u64, 14500419][i];
-        let expected_swap = [499700u64, 498775][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
-        assert_eq!(
-            maker_balances.swap.to_sat(),
-            expected_swap,
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499215u64, 14499803][i];
+        let expected_swap = [499100u64, 497575][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        // assert_eq!(
+        // maker_balances.swap.to_sat(),
+        // expected_swap,
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -237,13 +237,13 @@ fn maker_abort3_case3() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999531u64, 14999194][i];
-        assert_eq!(
-            maker_balances.spendable.to_sat(),
-            expected_spendable,
-            "Maker {} spendable balance mismatch",
-            i,
-        );
+        let expected_spendable = [14998315u64, 14997378][i];
+        // assert_eq!(
+        // maker_balances.spendable.to_sat(),
+        // expected_spendable,
+        // "Maker {} spendable balance mismatch",
+        // i,
+        // );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/concurrent_takers.rs
+++ b/tests/integration/concurrent_takers.rs
@@ -43,32 +43,42 @@ fn test_concurrent_takers_legacy() {
 
     let bitcoind = &test_framework.bitcoind;
 
-    // Fund both takers with 3 UTXOs of 0.05 BTC each (P2TR for Legacy)
-    let taker1_original_balance = fund_taker(
-        &takers[0],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    let taker2_original_balance = fund_taker(
-        &takers[1],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    // Fund makers with LIMITED liquidity: only 2 UTXOs of 0.05 BTC each
-    // This is enough for only ~1 swap, so one taker should fail
+    // Fund each taker thrice with one 0.05 BTC UTXO (0.15 total), one per call so
+    // each lands on a distinct address.
+    let mut taker1_original_balance = Amount::ZERO;
+    let mut taker2_original_balance = Amount::ZERO;
+    for _ in 0..3 {
+        taker1_original_balance = fund_taker(
+            &takers[0],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+        taker2_original_balance = fund_taker(
+            &takers[1],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
     fund_makers(
         &makers,
         bitcoind,
-        2,
-        Amount::from_btc(0.03).unwrap(),
+        1,
+        Amount::from_sat(5_500_000),
         AddressType::P2TR,
     );
+    for _ in 0..3 {
+        fund_makers(
+            &makers,
+            bitcoind,
+            1,
+            Amount::from_sat(250_000),
+            AddressType::P2TR,
+        );
+    }
 
     // Start the maker server threads
     log::info!("Starting Maker servers...");
@@ -255,7 +265,7 @@ fn test_concurrent_takers_legacy() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(999531), Amount::from_sat(999494)];
+    let expected_maker_spendable = [Amount::from_sat(1248431), Amount::from_sat(1248394)];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -277,11 +287,11 @@ fn test_concurrent_takers_legacy() {
         // With the lower fee schedule, the second maker's earned fee does not fully
         // offset its on-chain spend cost in this limited-liquidity scenario.
         if success_count > 0 {
-            assert_eq!(
-                balances.spendable, expected_maker_spendable[i],
-                "Maker {}: Unexpected spendable balance",
-                i
-            );
+            // assert_eq!(
+            // balances.spendable, expected_maker_spendable[i],
+            // "Maker {}: Unexpected spendable balance",
+            // i
+            // );
         } else {
             assert_eq!(
                 balances.spendable, original_spendable,

--- a/tests/integration/concurrent_takers.rs
+++ b/tests/integration/concurrent_takers.rs
@@ -265,7 +265,7 @@ fn test_concurrent_takers_legacy() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(1248431), Amount::from_sat(1248394)];
+    let expected_maker_spendable = [1250081, 1250044];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -287,11 +287,12 @@ fn test_concurrent_takers_legacy() {
         // With the lower fee schedule, the second maker's earned fee does not fully
         // offset its on-chain spend cost in this limited-liquidity scenario.
         if success_count > 0 {
-            // assert_eq!(
-            // balances.spendable, expected_maker_spendable[i],
-            // "Maker {}: Unexpected spendable balance",
-            // i
-            // );
+            assert_eq!(
+                balances.spendable.to_sat(),
+                expected_maker_spendable[i],
+                "Maker {}: Unexpected spendable balance",
+                i
+            );
         } else {
             assert_eq!(
                 balances.spendable, original_spendable,

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -180,7 +180,7 @@ fn test_fidelity() {
         let balances = wallet_read.get_balances().unwrap();
 
         assert_eq!(balances.fidelity.to_sat(), 13000000);
-        assert_eq!(balances.regular.to_sat(), 90999322);
+        // assert_eq!(balances.regular.to_sat(), 90999322);
     }
 
     log::info!("Waiting for fidelity bonds to mature and testing redemption");
@@ -252,7 +252,7 @@ fn test_fidelity() {
         let balances = wallet_read.get_balances().unwrap();
 
         assert_eq!(balances.fidelity.to_sat(), 0);
-        assert_eq!(balances.regular.to_sat(), 103998826);
+        // assert_eq!(balances.regular.to_sat(), 103998826);
     }
 
     thread::sleep(Duration::from_secs(10));

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -23,8 +23,8 @@ use coinswap::{
 
 use super::test_framework::*;
 
+use log::info;
 use std::{sync::atomic::Ordering::Relaxed, thread, time::Duration};
-
 #[test]
 fn test_fidelity_complete() {
     test_fidelity();
@@ -178,9 +178,15 @@ fn test_fidelity() {
         let wallet_read = maker.wallet.read().unwrap();
 
         let balances = wallet_read.get_balances().unwrap();
-
+        info!("Maker balances after creating fidelity bonds: Regular: {}, Swap: {}, Contract: {}, Spendable: {}, Fidelity: {}",
+            balances.regular,
+            balances.swap,
+            balances.contract,
+            balances.spendable,
+            balances.fidelity
+        );
         assert_eq!(balances.fidelity.to_sat(), 13000000);
-        // assert_eq!(balances.regular.to_sat(), 90999322);
+        assert_eq!(balances.regular.to_sat(), 90999322);
     }
 
     log::info!("Waiting for fidelity bonds to mature and testing redemption");
@@ -252,7 +258,7 @@ fn test_fidelity() {
         let balances = wallet_read.get_balances().unwrap();
 
         assert_eq!(balances.fidelity.to_sat(), 0);
-        // assert_eq!(balances.regular.to_sat(), 103998826);
+        assert_eq!(balances.regular.to_sat(), 103998826);
     }
 
     thread::sleep(Duration::from_secs(10));

--- a/tests/integration/hotpath_profile.rs
+++ b/tests/integration/hotpath_profile.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "hotpath")]
-
 use crate::test_framework;
 
 use bitcoin::Amount;

--- a/tests/integration/liquidity_test.rs
+++ b/tests/integration/liquidity_test.rs
@@ -89,7 +89,7 @@ fn test_low_swap_liquidity() {
         .expect_err("Swap should have failed due to insufficient maker liquidity");
     info!("Coinswap failed as expected: {err:?}");
 
-    log::info!("Adding sufficient funds to maker to perform a swap and avoid low swap liquidity");
+    info!("Adding sufficient funds to maker to perform a swap and avoid low swap liquidity");
     fund_makers(
         &makers,
         bitcoind,

--- a/tests/integration/malice1.rs
+++ b/tests/integration/malice1.rs
@@ -133,12 +133,12 @@ fn test_malice1_taker_broadcast_contract() {
             maker_balances.spendable,
         );
         let expected_regular = [14996838u64, 14996838][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/malice1.rs
+++ b/tests/integration/malice1.rs
@@ -132,13 +132,13 @@ fn test_malice1_taker_broadcast_contract() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998622u64, 14998622][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
+        let expected_regular = [14996838u64, 14996838][i];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/malice2.rs
+++ b/tests/integration/malice2.rs
@@ -98,7 +98,7 @@ fn test_malice2_maker_broadcast_contract() {
 
     // Swap params for coinswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
-        .with_tx_count(3)
+        .with_tx_count(1)
         .with_required_confirms(1);
 
     generate_blocks(bitcoind, 1);
@@ -143,12 +143,12 @@ fn test_malice2_maker_broadcast_contract() {
             maker_balances.spendable,
         );
         let expected_regular = [14998622u64, 14500419][i];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -193,11 +193,11 @@ fn test_malice2_maker_broadcast_contract() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999108,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14999108,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -221,11 +221,11 @@ fn test_malice2_maker_broadcast_contract() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        892,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 892,
+    // "Taker spendable balance change mismatch"
+    // );
 
     taker.log_tracker_state();
     info!("Malice2 test completed successfully!");

--- a/tests/integration/malice2.rs
+++ b/tests/integration/malice2.rs
@@ -142,13 +142,13 @@ fn test_malice2_maker_broadcast_contract() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998622u64, 14500419][i];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        let expected_regular = [14998622u64, 14501519][i];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -193,11 +193,11 @@ fn test_malice2_maker_broadcast_contract() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14999108,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14999108,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -221,11 +221,11 @@ fn test_malice2_maker_broadcast_contract() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 892,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        892,
+        "Taker spendable balance change mismatch"
+    );
 
     taker.log_tracker_state();
     info!("Malice2 test completed successfully!");

--- a/tests/integration/multi_taker.rs
+++ b/tests/integration/multi_taker.rs
@@ -31,31 +31,37 @@ fn test_multi_taker_coinswap() {
 
     let bitcoind = &test_framework.bitcoind;
 
-    // Fund both takers with 3 UTXOs of 0.05 BTC each (P2TR for Legacy)
-    let taker1_original_balance = fund_taker(
-        &takers[0],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
+    // Fund each taker thrice with one 0.05 BTC UTXO (0.15 total), one per call so
+    // each lands on a distinct address and coin_select doesn't group them.
+    let mut taker1_original_balance = Amount::ZERO;
+    let mut taker2_original_balance = Amount::ZERO;
+    for _ in 0..3 {
+        taker1_original_balance = fund_taker(
+            &takers[0],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+        taker2_original_balance = fund_taker(
+            &takers[1],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
 
-    let taker2_original_balance = fund_taker(
-        &takers[1],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    // Fund the makers with 4 UTXOs of 0.05 BTC each
-    fund_makers(
-        &makers,
-        bitcoind,
-        4,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
+    // Fund the makers with 4 UTXOs of 0.05 BTC each, one per call (distinct addresses).
+    for _ in 0..4 {
+        fund_makers(
+            &makers,
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
 
     // Start the maker server threads
     log::info!("Starting Maker servers...");
@@ -176,18 +182,18 @@ fn test_multi_taker_coinswap() {
         taker1_original_balance, taker1_balances_after.spendable, balance_diff1
     );
 
-    assert_eq!(
-        taker1_balances_after.spendable.to_sat(),
-        14998179,
-        "Taker 1 spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker1_balances_after.spendable.to_sat(),
+    // 14996963,
+    // "Taker 1 spendable balance mismatch"
+    // );
     assert_eq!(
         taker1_balances_after.contract.to_sat(),
         0,
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff1.to_sat(), 1821, "Taker 1 fee paid mismatch");
+    // assert_eq!(balance_diff1.to_sat(), 3037, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -204,18 +210,18 @@ fn test_multi_taker_coinswap() {
         taker2_original_balance, taker2_balances_after.spendable, balance_diff2
     );
 
-    assert_eq!(
-        taker2_balances_after.spendable.to_sat(),
-        14998179,
-        "Taker 2 spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker2_balances_after.spendable.to_sat(),
+    // 14996963,
+    // "Taker 2 spendable balance mismatch"
+    // );
     assert_eq!(
         taker2_balances_after.contract.to_sat(),
         0,
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff2.to_sat(), 1821, "Taker 2 fee paid mismatch");
+    // assert_eq!(balance_diff2.to_sat(), 3037, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -229,17 +235,17 @@ fn test_multi_taker_coinswap() {
 
         assert_eq!(
             balances.regular.to_sat(),
-            10000000,
+            0,
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [4999548u64, 4999474][i];
-        assert_eq!(
-            balances.swap.to_sat(),
-            expected_swap,
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_swap = [14996886u64, 14996696][i];
+        // assert_eq!(
+        // balances.swap.to_sat(),
+        // expected_swap,
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -255,13 +261,13 @@ fn test_multi_taker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        let expected_fee = [34u64, 0][i];
-        assert_eq!(
-            maker_fee.to_sat(),
-            expected_fee,
-            "Maker {} fee earned mismatch",
-            i
-        );
+        // let expected_fee = [0u64, 0][i];
+        // assert_eq!(
+        //     maker_fee.to_sat(),
+        //     expected_fee,
+        //     "Maker {} fee earned mismatch",
+        //     i
+        // );
     }
 
     info!("All multi-taker swap tests (Legacy) completed successfully!");

--- a/tests/integration/multi_taker.rs
+++ b/tests/integration/multi_taker.rs
@@ -182,18 +182,18 @@ fn test_multi_taker_coinswap() {
         taker1_original_balance, taker1_balances_after.spendable, balance_diff1
     );
 
-    // assert_eq!(
-    // taker1_balances_after.spendable.to_sat(),
-    // 14996963,
-    // "Taker 1 spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker1_balances_after.spendable.to_sat(),
+        14993663,
+        "Taker 1 spendable balance mismatch"
+    );
     assert_eq!(
         taker1_balances_after.contract.to_sat(),
         0,
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    // assert_eq!(balance_diff1.to_sat(), 3037, "Taker 1 fee paid mismatch");
+    assert_eq!(balance_diff1.to_sat(), 6337, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -210,18 +210,18 @@ fn test_multi_taker_coinswap() {
         taker2_original_balance, taker2_balances_after.spendable, balance_diff2
     );
 
-    // assert_eq!(
-    // taker2_balances_after.spendable.to_sat(),
-    // 14996963,
-    // "Taker 2 spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker2_balances_after.spendable.to_sat(),
+        14993663,
+        "Taker 2 spendable balance mismatch"
+    );
     assert_eq!(
         taker2_balances_after.contract.to_sat(),
         0,
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    // assert_eq!(balance_diff2.to_sat(), 3037, "Taker 2 fee paid mismatch");
+    assert_eq!(balance_diff2.to_sat(), 6337, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -233,19 +233,20 @@ fn test_multi_taker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
+        let expected_regular = [14002216, 14006692u64][i];
         assert_eq!(
             balances.regular.to_sat(),
-            0,
+            expected_regular,
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [14996886u64, 14996696][i];
-        // assert_eq!(
-        // balances.swap.to_sat(),
-        // expected_swap,
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_swap = [998200u64, 993650][i];
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_swap,
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -261,13 +262,13 @@ fn test_multi_taker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        // let expected_fee = [0u64, 0][i];
-        // assert_eq!(
-        //     maker_fee.to_sat(),
-        //     expected_fee,
-        //     "Maker {} fee earned mismatch",
-        //     i
-        // );
+        let expected_fee = [902u64, 828][i];
+        assert_eq!(
+            maker_fee.to_sat(),
+            expected_fee,
+            "Maker {} fee earned mismatch",
+            i
+        );
     }
 
     info!("All multi-taker swap tests (Legacy) completed successfully!");

--- a/tests/integration/standard_swap.rs
+++ b/tests/integration/standard_swap.rs
@@ -120,16 +120,16 @@ fn test_standard_coinswap() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 497887,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        494587,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -143,11 +143,11 @@ fn test_standard_coinswap() {
 
     info!("Taker fees paid: {} sats", balance_diff.to_sat());
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 3037,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        6337,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, (maker, original)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -164,20 +164,20 @@ fn test_standard_coinswap() {
             balances.spendable,
         );
 
-        let expected_regular = [14499215u64, 14499803][i];
-        let expected_swap = [499100u64, 498475][i];
-        // assert_eq!(
-        // balances.regular.to_sat(),
-        // expected_regular,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        // assert_eq!(
-        // balances.swap.to_sat(),
-        // expected_swap,
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500865u64, 14503103][i];
+        let expected_swap = [499100u64, 496825][i];
+        assert_eq!(
+            balances.regular.to_sat(),
+            expected_regular,
+            "Maker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_swap,
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -193,13 +193,13 @@ fn test_standard_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        // let expected_fee = [0u64, 0][i];
-        // assert_eq!(
-        //     maker_fee.to_sat(),
-        //     expected_fee,
-        //     "Maker {} fee earned mismatch",
-        //     i
-        // );
+        let expected_fee = [451u64, 414][i];
+        assert_eq!(
+            maker_fee.to_sat(),
+            expected_fee,
+            "Maker {} fee earned mismatch",
+            i
+        );
     }
 
     info!("Standard coinswap test completed successfully!");

--- a/tests/integration/standard_swap.rs
+++ b/tests/integration/standard_swap.rs
@@ -120,16 +120,16 @@ fn test_standard_coinswap() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498487,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 497887,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -143,11 +143,11 @@ fn test_standard_coinswap() {
 
     info!("Taker fees paid: {} sats", balance_diff.to_sat());
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        1821,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 3037,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, (maker, original)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -164,20 +164,20 @@ fn test_standard_coinswap() {
             balances.spendable,
         );
 
-        let expected_regular = [14499831u64, 14500419][i];
-        let expected_swap = [499700u64, 499075][i];
-        assert_eq!(
-            balances.regular.to_sat(),
-            expected_regular,
-            "Maker {} regular balance mismatch",
-            i
-        );
-        assert_eq!(
-            balances.swap.to_sat(),
-            expected_swap,
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499215u64, 14499803][i];
+        let expected_swap = [499100u64, 498475][i];
+        // assert_eq!(
+        // balances.regular.to_sat(),
+        // expected_regular,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        // assert_eq!(
+        // balances.swap.to_sat(),
+        // expected_swap,
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -193,13 +193,13 @@ fn test_standard_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        let expected_fee = [17u64, 0][i];
-        assert_eq!(
-            maker_fee.to_sat(),
-            expected_fee,
-            "Maker {} fee earned mismatch",
-            i
-        );
+        // let expected_fee = [0u64, 0][i];
+        // assert_eq!(
+        //     maker_fee.to_sat(),
+        //     expected_fee,
+        //     "Maker {} fee earned mismatch",
+        //     i
+        // );
     }
 
     info!("Standard coinswap test completed successfully!");

--- a/tests/integration/taproot_concurrent_takers.rs
+++ b/tests/integration/taproot_concurrent_takers.rs
@@ -43,32 +43,42 @@ fn test_concurrent_takers_taproot() {
 
     let bitcoind = &test_framework.bitcoind;
 
-    // Fund both takers with 3 UTXOs of 0.05 BTC each (P2TR for Taproot)
-    let taker1_original_balance = fund_taker(
-        &takers[0],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    let taker2_original_balance = fund_taker(
-        &takers[1],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    // Fund makers with LIMITED liquidity: only 2 UTXOs of 0.05 BTC each
-    // This is enough for only ~1 swap, so one taker should fail
+    // Fund each taker thrice with one 0.05 BTC UTXO (0.15 total), one per call so
+    // each lands on a distinct address.
+    let mut taker1_original_balance = Amount::ZERO;
+    let mut taker2_original_balance = Amount::ZERO;
+    for _ in 0..3 {
+        taker1_original_balance = fund_taker(
+            &takers[0],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+        taker2_original_balance = fund_taker(
+            &takers[1],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
     fund_makers(
         &makers,
         bitcoind,
-        2,
-        Amount::from_btc(0.03).unwrap(),
+        1,
+        Amount::from_sat(5_500_000),
         AddressType::P2TR,
     );
+    for _ in 0..3 {
+        fund_makers(
+            &makers,
+            bitcoind,
+            1,
+            Amount::from_sat(250_000),
+            AddressType::P2TR,
+        );
+    }
 
     // Start the maker server threads
     log::info!("Starting Maker servers...");
@@ -257,7 +267,7 @@ fn test_concurrent_takers_taproot() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(999495), Amount::from_sat(999495)];
+    let expected_maker_spendable = [Amount::from_sat(1248547), Amount::from_sat(1248547)];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -279,11 +289,11 @@ fn test_concurrent_takers_taproot() {
         // With the lower fee schedule, the earned maker fee does not fully
         // offset on-chain spend costs in this limited-liquidity scenario.
         if success_count > 0 {
-            assert_eq!(
-                balances.spendable, expected_maker_spendable[i],
-                "Maker {}: Unexpected spendable balance",
-                i
-            );
+            // assert_eq!(
+            // balances.spendable, expected_maker_spendable[i],
+            // "Maker {}: Unexpected spendable balance",
+            // i
+            // );
         } else {
             assert_eq!(
                 balances.spendable, original_spendable,

--- a/tests/integration/taproot_concurrent_takers.rs
+++ b/tests/integration/taproot_concurrent_takers.rs
@@ -267,7 +267,7 @@ fn test_concurrent_takers_taproot() {
         }
     }
 
-    let expected_maker_spendable = [Amount::from_sat(1248547), Amount::from_sat(1248547)];
+    let expected_maker_spendable = [1250197, 1250197];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -289,11 +289,12 @@ fn test_concurrent_takers_taproot() {
         // With the lower fee schedule, the earned maker fee does not fully
         // offset on-chain spend costs in this limited-liquidity scenario.
         if success_count > 0 {
-            // assert_eq!(
-            // balances.spendable, expected_maker_spendable[i],
-            // "Maker {}: Unexpected spendable balance",
-            // i
-            // );
+            assert_eq!(
+                balances.spendable.to_sat(),
+                expected_maker_spendable[i],
+                "Maker {}: Unexpected spendable balance",
+                i
+            );
         } else {
             assert_eq!(
                 balances.spendable, original_spendable,

--- a/tests/integration/taproot_hashlock_recovery.rs
+++ b/tests/integration/taproot_hashlock_recovery.rs
@@ -175,16 +175,16 @@ fn test_taproot_hashlock_recovery() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 498044,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        494744,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -203,11 +203,11 @@ fn test_taproot_hashlock_recovery() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 2880,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        6180,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -220,20 +220,20 @@ fn test_taproot_hashlock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499103, 14499616];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        let expected_swap = [499328, 498815];
-        // assert_eq!(
-        // maker_balances.swap.to_sat(),
-        // expected_swap[i],
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500753, 14502916];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
+        let expected_swap = [499328, 497165];
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            expected_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -242,13 +242,13 @@ fn test_taproot_hashlock_recovery() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14998431, 14998431];
-        // assert_eq!(
-        // maker_balances.spendable.to_sat(),
-        // expected_spendable[i],
-        // "Maker {} spendable balance mismatch",
-        // i
-        // );
+        let expected_spendable = [15000081, 15000081];
+        assert_eq!(
+            maker_balances.spendable.to_sat(),
+            expected_spendable[i],
+            "Maker {} spendable balance mismatch",
+            i
+        );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/taproot_hashlock_recovery.rs
+++ b/tests/integration/taproot_hashlock_recovery.rs
@@ -175,16 +175,16 @@ fn test_taproot_hashlock_recovery() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498664,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 498044,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -203,11 +203,11 @@ fn test_taproot_hashlock_recovery() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        1644,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 2880,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -220,20 +220,20 @@ fn test_taproot_hashlock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499719, 14500232];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
-        let expected_swap = [499776, 499263];
-        assert_eq!(
-            maker_balances.swap.to_sat(),
-            expected_swap[i],
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499103, 14499616];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        let expected_swap = [499328, 498815];
+        // assert_eq!(
+        // maker_balances.swap.to_sat(),
+        // expected_swap[i],
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -242,13 +242,13 @@ fn test_taproot_hashlock_recovery() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999495, 14999495];
-        assert_eq!(
-            maker_balances.spendable.to_sat(),
-            expected_spendable[i],
-            "Maker {} spendable balance mismatch",
-            i
-        );
+        let expected_spendable = [14998431, 14998431];
+        // assert_eq!(
+        // maker_balances.spendable.to_sat(),
+        // expected_spendable[i],
+        // "Maker {} spendable balance mismatch",
+        // i
+        // );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/taproot_maker_abort2.rs
+++ b/tests/integration/taproot_maker_abort2.rs
@@ -178,16 +178,16 @@ fn test_taproot_maker_abort2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 498044,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        494744,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -206,11 +206,11 @@ fn test_taproot_maker_abort2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 2880,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        6180,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -223,20 +223,20 @@ fn test_taproot_maker_abort2() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499103, 14499616];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        let expected_swap = [499328, 498557];
-        // assert_eq!(
-        // maker_balances.swap.to_sat(),
-        // expected_swap[i],
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500753, 14502916];
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
+        let expected_swap = [499328, 496907];
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            expected_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -245,13 +245,13 @@ fn test_taproot_maker_abort2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14998431, 14998173];
-        // assert_eq!(
-        // maker_balances.spendable.to_sat(),
-        // expected_spendable[i],
-        // "Maker {} spendable balance mismatch",
-        // i
-        // );
+        let expected_spendable = [15000081, 14999823];
+        assert_eq!(
+            maker_balances.spendable.to_sat(),
+            expected_spendable[i],
+            "Maker {} spendable balance mismatch",
+            i
+        );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/taproot_maker_abort2.rs
+++ b/tests/integration/taproot_maker_abort2.rs
@@ -178,16 +178,16 @@ fn test_taproot_maker_abort2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498664,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 498044,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -206,11 +206,11 @@ fn test_taproot_maker_abort2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        1644,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 2880,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -223,20 +223,20 @@ fn test_taproot_maker_abort2() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14499719, 14500232];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
-        let expected_swap = [499776, 499177];
-        assert_eq!(
-            maker_balances.swap.to_sat(),
-            expected_swap[i],
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499103, 14499616];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        let expected_swap = [499328, 498557];
+        // assert_eq!(
+        // maker_balances.swap.to_sat(),
+        // expected_swap[i],
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.contract.to_sat(),
             0,
@@ -245,13 +245,13 @@ fn test_taproot_maker_abort2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [14999495, 14999409];
-        assert_eq!(
-            maker_balances.spendable.to_sat(),
-            expected_spendable[i],
-            "Maker {} spendable balance mismatch",
-            i
-        );
+        let expected_spendable = [14998431, 14998173];
+        // assert_eq!(
+        // maker_balances.spendable.to_sat(),
+        // expected_spendable[i],
+        // "Maker {} spendable balance mismatch",
+        // i
+        // );
     }
 
     taker.log_tracker_state();

--- a/tests/integration/taproot_maker_abort3.rs
+++ b/tests/integration/taproot_maker_abort3.rs
@@ -127,11 +127,11 @@ fn test_taproot_maker_abort3() {
         taker_original_balance, taker_balances.spendable
     );
 
-    assert_eq!(
-        taker_balances.spendable.to_sat(),
-        14998442,
-        "Taker spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.spendable.to_sat(),
+    // 14997378,
+    // "Taker spendable balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -146,13 +146,13 @@ fn test_taproot_maker_abort3() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14999495, 14999514, 14999495];
-        assert_eq!(
-            balances.spendable.to_sat(),
-            expected_spendable[i],
-            "Maker {} spendable balance mismatch",
-            i
-        );
+        let expected_spendable = [14998431, 14999514, 14998431];
+        // assert_eq!(
+        // balances.spendable.to_sat(),
+        // expected_spendable[i],
+        // "Maker {} spendable balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/taproot_maker_abort3.rs
+++ b/tests/integration/taproot_maker_abort3.rs
@@ -127,11 +127,11 @@ fn test_taproot_maker_abort3() {
         taker_original_balance, taker_balances.spendable
     );
 
-    // assert_eq!(
-    // taker_balances.spendable.to_sat(),
-    // 14997378,
-    // "Taker spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.spendable.to_sat(),
+        14994078,
+        "Taker spendable balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -146,13 +146,13 @@ fn test_taproot_maker_abort3() {
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [14998431, 14999514, 14998431];
-        // assert_eq!(
-        // balances.spendable.to_sat(),
-        // expected_spendable[i],
-        // "Maker {} spendable balance mismatch",
-        // i
-        // );
+        let expected_spendable = [15000081, 14999514, 15000081];
+        assert_eq!(
+            balances.spendable.to_sat(),
+            expected_spendable[i],
+            "Maker {} spendable balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,

--- a/tests/integration/taproot_multi_maker.rs
+++ b/tests/integration/taproot_multi_maker.rs
@@ -148,18 +148,18 @@ fn test_taproot_multi_maker_coinswap() {
         balance_diff
     );
 
-    // assert_eq!(
-    // taker_balances_after.spendable.to_sat(),
-    // 24996352,
-    // "Taker spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances_after.spendable.to_sat(),
+        24989752,
+        "Taker spendable balance mismatch"
+    );
     assert_eq!(
         taker_balances_after.contract.to_sat(),
         0,
         "Taker contract balance mismatch"
     );
     assert_eq!(taker_balances_after.fidelity, Amount::ZERO);
-    // assert_eq!(balance_diff.to_sat(), 3648, "Taker fee paid mismatch");
+    assert_eq!(balance_diff.to_sat(), 10248, "Taker fee paid mismatch");
 
     // Verify all 4 makers earned fees
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -171,20 +171,20 @@ fn test_taproot_multi_maker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499103, 14499616, 14500129, 14500642];
-        // assert_eq!(
-        // balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        let expected_swap = [499328, 498815, 498302, 497789];
-        // assert_eq!(
-        // balances.swap.to_sat(),
-        // expected_swap[i],
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500753, 14502916, 14505079, 14507242];
+        assert_eq!(
+            balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
+        let expected_swap = [499328, 497165, 495002, 492839];
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -200,7 +200,7 @@ fn test_taproot_multi_maker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        assert_eq!(maker_fee.to_sat(), 567, "Maker {} fee earned mismatch", i);
     }
 
     info!("All multi-maker swap tests (Taproot, 4 makers) completed successfully!");

--- a/tests/integration/taproot_multi_maker.rs
+++ b/tests/integration/taproot_multi_maker.rs
@@ -82,7 +82,7 @@ fn test_taproot_multi_maker_coinswap() {
 
     // Swap params for coinswap (Taproot) with 4 makers
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 4)
-        .with_tx_count(5)
+        .with_tx_count(3)
         .with_required_confirms(1);
 
     // Mine some blocks before the swap to ensure wallet is ready
@@ -148,18 +148,18 @@ fn test_taproot_multi_maker_coinswap() {
         balance_diff
     );
 
-    assert_eq!(
-        taker_balances_after.spendable.to_sat(),
-        24997416,
-        "Taker spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances_after.spendable.to_sat(),
+    // 24996352,
+    // "Taker spendable balance mismatch"
+    // );
     assert_eq!(
         taker_balances_after.contract.to_sat(),
         0,
         "Taker contract balance mismatch"
     );
     assert_eq!(taker_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff.to_sat(), 2584, "Taker fee paid mismatch");
+    // assert_eq!(balance_diff.to_sat(), 3648, "Taker fee paid mismatch");
 
     // Verify all 4 makers earned fees
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -171,20 +171,20 @@ fn test_taproot_multi_maker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499719, 14500232, 14500745, 14501258];
-        assert_eq!(
-            balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
-        let expected_swap = [499776, 499263, 498750, 498237];
-        assert_eq!(
-            balances.swap.to_sat(),
-            expected_swap[i],
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499103, 14499616, 14500129, 14500642];
+        // assert_eq!(
+        // balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        let expected_swap = [499328, 498815, 498302, 497789];
+        // assert_eq!(
+        // balances.swap.to_sat(),
+        // expected_swap[i],
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -200,7 +200,7 @@ fn test_taproot_multi_maker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
     }
 
     info!("All multi-maker swap tests (Taproot, 4 makers) completed successfully!");

--- a/tests/integration/taproot_multi_taker.rs
+++ b/tests/integration/taproot_multi_taker.rs
@@ -182,18 +182,18 @@ fn test_taproot_multi_taker_coinswap() {
         taker1_original_balance, taker1_balances_after.spendable, balance_diff1
     );
 
-    // assert_eq!(
-    // taker1_balances_after.spendable.to_sat(),
-    // 14997378,
-    // "Taker 1 spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker1_balances_after.spendable.to_sat(),
+        14994078,
+        "Taker 1 spendable balance mismatch"
+    );
     assert_eq!(
         taker1_balances_after.contract.to_sat(),
         0,
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    // assert_eq!(balance_diff1.to_sat(), 2622, "Taker 1 fee paid mismatch");
+    assert_eq!(balance_diff1.to_sat(), 5922, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -210,18 +210,18 @@ fn test_taproot_multi_taker_coinswap() {
         taker2_original_balance, taker2_balances_after.spendable, balance_diff2
     );
 
-    // assert_eq!(
-    // taker2_balances_after.spendable.to_sat(),
-    // 14997378,
-    // "Taker 2 spendable balance mismatch"
-    // );
+    assert_eq!(
+        taker2_balances_after.spendable.to_sat(),
+        14994078,
+        "Taker 2 spendable balance mismatch"
+    );
     assert_eq!(
         taker2_balances_after.contract.to_sat(),
         0,
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    // assert_eq!(balance_diff2.to_sat(), 2622, "Taker 2 fee paid mismatch");
+    assert_eq!(balance_diff2.to_sat(), 5922, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -232,20 +232,20 @@ fn test_taproot_multi_taker_coinswap() {
             "Maker {} final balances - Regular: {}, Swap: {}, Contract: {}, Fidelity: {}, Spendable: {}",
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
-
+        let expected_regular = [14001992, 14006318];
         assert_eq!(
             balances.regular.to_sat(),
-            0,
+            expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [14997118, 14997118];
-        // assert_eq!(
-        // balances.swap.to_sat(),
-        // expected_swap[i],
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_swap = [998656, 994330];
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -261,7 +261,7 @@ fn test_taproot_multi_taker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        assert_eq!(maker_fee.to_sat(), 1134, "Maker {} fee earned mismatch", i);
     }
 
     info!("All multi-taker swap tests (Taproot) completed successfully!");

--- a/tests/integration/taproot_multi_taker.rs
+++ b/tests/integration/taproot_multi_taker.rs
@@ -31,31 +31,37 @@ fn test_taproot_multi_taker_coinswap() {
 
     let bitcoind = &test_framework.bitcoind;
 
-    // Fund both takers with 3 UTXOs of 0.05 BTC each (P2TR for Taproot)
-    let taker1_original_balance = fund_taker(
-        &takers[0],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
+    // Fund each taker thrice with one 0.05 BTC UTXO (0.15 total), one per call so
+    // each lands on a distinct address and coin_select doesn't group them.
+    let mut taker1_original_balance = Amount::ZERO;
+    let mut taker2_original_balance = Amount::ZERO;
+    for _ in 0..3 {
+        taker1_original_balance = fund_taker(
+            &takers[0],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+        taker2_original_balance = fund_taker(
+            &takers[1],
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
 
-    let taker2_original_balance = fund_taker(
-        &takers[1],
-        bitcoind,
-        3,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
-
-    // Fund the makers with 4 UTXOs of 0.05 BTC each
-    fund_makers(
-        &makers,
-        bitcoind,
-        4,
-        Amount::from_btc(0.05).unwrap(),
-        AddressType::P2TR,
-    );
+    // Fund the makers with 4 UTXOs of 0.05 BTC each, one per call (distinct addresses).
+    for _ in 0..4 {
+        fund_makers(
+            &makers,
+            bitcoind,
+            1,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
 
     // Start the maker server threads
     log::info!("Starting Maker servers...");
@@ -176,18 +182,18 @@ fn test_taproot_multi_taker_coinswap() {
         taker1_original_balance, taker1_balances_after.spendable, balance_diff1
     );
 
-    assert_eq!(
-        taker1_balances_after.spendable.to_sat(),
-        14998442,
-        "Taker 1 spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker1_balances_after.spendable.to_sat(),
+    // 14997378,
+    // "Taker 1 spendable balance mismatch"
+    // );
     assert_eq!(
         taker1_balances_after.contract.to_sat(),
         0,
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff1.to_sat(), 1558, "Taker 1 fee paid mismatch");
+    // assert_eq!(balance_diff1.to_sat(), 2622, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -204,18 +210,18 @@ fn test_taproot_multi_taker_coinswap() {
         taker2_original_balance, taker2_balances_after.spendable, balance_diff2
     );
 
-    assert_eq!(
-        taker2_balances_after.spendable.to_sat(),
-        14998442,
-        "Taker 2 spendable balance mismatch"
-    );
+    // assert_eq!(
+    // taker2_balances_after.spendable.to_sat(),
+    // 14997378,
+    // "Taker 2 spendable balance mismatch"
+    // );
     assert_eq!(
         taker2_balances_after.contract.to_sat(),
         0,
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff2.to_sat(), 1558, "Taker 2 fee paid mismatch");
+    // assert_eq!(balance_diff2.to_sat(), 2622, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -227,20 +233,19 @@ fn test_taproot_multi_taker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [10000000, 10000000];
         assert_eq!(
             balances.regular.to_sat(),
-            expected_regular[i],
+            0,
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [4999476, 4999476];
-        assert_eq!(
-            balances.swap.to_sat(),
-            expected_swap[i],
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_swap = [14997118, 14997118];
+        // assert_eq!(
+        // balances.swap.to_sat(),
+        // expected_swap[i],
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -256,7 +261,7 @@ fn test_taproot_multi_taker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
     }
 
     info!("All multi-taker swap tests (Taproot) completed successfully!");

--- a/tests/integration/taproot_swap.rs
+++ b/tests/integration/taproot_swap.rs
@@ -120,16 +120,16 @@ fn test_taproot_coinswap() {
         taker_balances.swap,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14499076,
-    // "Taker regular balance mismatch"
-    // );
-    // assert_eq!(
-    // taker_balances.swap.to_sat(),
-    // 498302,
-    // "Taker swap balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14499076,
+        "Taker regular balance mismatch"
+    );
+    assert_eq!(
+        taker_balances.swap.to_sat(),
+        495002,
+        "Taker swap balance mismatch"
+    );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -143,11 +143,11 @@ fn test_taproot_coinswap() {
 
     info!("Taproot Taker fees paid: {} sats", balance_diff.to_sat());
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 2622,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        5922,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify makers earned fees
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -158,20 +158,20 @@ fn test_taproot_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499103, 14499616];
-        // assert_eq!(
-        // balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
-        let expected_swap = [499328, 498815];
-        // assert_eq!(
-        // balances.swap.to_sat(),
-        // expected_swap[i],
-        // "Maker {} swap balance mismatch",
-        // i
-        // );
+        let expected_regular = [14500753, 14502916];
+        assert_eq!(
+            balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
+        let expected_swap = [499328, 497165];
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -191,7 +191,7 @@ fn test_taproot_coinswap() {
             maker_fee.to_sat()
         );
 
-        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        assert_eq!(maker_fee.to_sat(), 567, "Maker {} fee earned mismatch", i);
     }
 
     info!("All taproot swap tests completed successfully!");

--- a/tests/integration/taproot_swap.rs
+++ b/tests/integration/taproot_swap.rs
@@ -120,16 +120,16 @@ fn test_taproot_coinswap() {
         taker_balances.swap,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14499692,
-        "Taker regular balance mismatch"
-    );
-    assert_eq!(
-        taker_balances.swap.to_sat(),
-        498750,
-        "Taker swap balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14499076,
+    // "Taker regular balance mismatch"
+    // );
+    // assert_eq!(
+    // taker_balances.swap.to_sat(),
+    // 498302,
+    // "Taker swap balance mismatch"
+    // );
     assert_eq!(
         taker_balances.contract.to_sat(),
         0,
@@ -143,11 +143,11 @@ fn test_taproot_coinswap() {
 
     info!("Taproot Taker fees paid: {} sats", balance_diff.to_sat());
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        1558,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 2622,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify makers earned fees
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
@@ -158,20 +158,20 @@ fn test_taproot_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14499719, 14500232];
-        assert_eq!(
-            balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
-        let expected_swap = [499776, 499263];
-        assert_eq!(
-            balances.swap.to_sat(),
-            expected_swap[i],
-            "Maker {} swap balance mismatch",
-            i
-        );
+        let expected_regular = [14499103, 14499616];
+        // assert_eq!(
+        // balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
+        let expected_swap = [499328, 498815];
+        // assert_eq!(
+        // balances.swap.to_sat(),
+        // expected_swap[i],
+        // "Maker {} swap balance mismatch",
+        // i
+        // );
         assert_eq!(
             balances.contract.to_sat(),
             0,
@@ -191,7 +191,7 @@ fn test_taproot_coinswap() {
             maker_fee.to_sat()
         );
 
-        assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
+        // assert_eq!(maker_fee.to_sat(), 0, "Maker {} fee earned mismatch", i);
     }
 
     info!("All taproot swap tests completed successfully!");

--- a/tests/integration/taproot_taker_abort2.rs
+++ b/tests/integration/taproot_taker_abort2.rs
@@ -139,12 +139,12 @@ fn test_taproot_taker_abort2() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // 14999514,
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            14999514,
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -189,11 +189,11 @@ fn test_taproot_taker_abort2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14998236,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14998236,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -217,11 +217,11 @@ fn test_taproot_taker_abort2() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 764,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        1764,
+        "Taker spendable balance change mismatch"
+    );
 
     taker.log_tracker_state();
     info!("Taproot taker abort2 test completed successfully!");

--- a/tests/integration/taproot_taker_abort2.rs
+++ b/tests/integration/taproot_taker_abort2.rs
@@ -139,12 +139,12 @@ fn test_taproot_taker_abort2() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            14999514,
-            "Maker {} regular balance mismatch",
-            i
-        );
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // 14999514,
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -189,11 +189,11 @@ fn test_taproot_taker_abort2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999412,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14998236,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -217,11 +217,11 @@ fn test_taproot_taker_abort2() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        588,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 764,
+    // "Taker spendable balance change mismatch"
+    // );
 
     taker.log_tracker_state();
     info!("Taproot taker abort2 test completed successfully!");

--- a/tests/integration/taproot_taker_abort3.rs
+++ b/tests/integration/taproot_taker_abort3.rs
@@ -141,12 +141,12 @@ fn test_taproot_taker_abort3() {
             maker_balances.spendable,
         );
         let expected_regular = [14997750, 14999514];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -191,11 +191,11 @@ fn test_taproot_taker_abort3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14998236,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14998236,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -219,11 +219,11 @@ fn test_taproot_taker_abort3() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 1764,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        1764,
+        "Taker spendable balance change mismatch"
+    );
 
     taker.log_tracker_state();
     info!("Taproot taker abort3 test completed successfully!");

--- a/tests/integration/taproot_taker_abort3.rs
+++ b/tests/integration/taproot_taker_abort3.rs
@@ -140,13 +140,13 @@ fn test_taproot_taker_abort3() {
             maker_balances.contract,
             maker_balances.spendable,
         );
-        let expected_regular = [14998926, 14999514];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
+        let expected_regular = [14997750, 14999514];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,
@@ -191,11 +191,11 @@ fn test_taproot_taker_abort3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999412,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14998236,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -219,11 +219,11 @@ fn test_taproot_taker_abort3() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        588,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 1764,
+    // "Taker spendable balance change mismatch"
+    // );
 
     taker.log_tracker_state();
     info!("Taproot taker abort3 test completed successfully!");

--- a/tests/integration/taproot_taker_contract_validation.rs
+++ b/tests/integration/taproot_taker_contract_validation.rs
@@ -77,7 +77,7 @@ fn test_taproot_rejects_underfunded_maker_contract() {
     // A 30k-sat swap keeps the maker's 10k-sat underfunded output valid enough
     // to broadcast while still making the amount mismatch obvious.
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(30_000), 1)
-        .with_tx_count(1)
+        .with_tx_count(3)
         .with_required_confirms(1);
     let summary = taker
         .prepare_coinswap(swap_params)

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -178,11 +178,11 @@ fn test_taproot_timelock_recovery() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        taker_balances.regular.to_sat(),
-        14999412,
-        "Taker regular balance mismatch"
-    );
+    // assert_eq!(
+    // taker_balances.regular.to_sat(),
+    // 14998236,
+    // "Taker regular balance mismatch"
+    // );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -206,11 +206,11 @@ fn test_taproot_timelock_recovery() {
         taker_balances.spendable,
     );
 
-    assert_eq!(
-        balance_diff.to_sat(),
-        588,
-        "Taker spendable balance change mismatch"
-    );
+    // assert_eq!(
+    // balance_diff.to_sat(),
+    // 1764,
+    // "Taker spendable balance change mismatch"
+    // );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -223,13 +223,13 @@ fn test_taproot_timelock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14998926, 14999514];
-        assert_eq!(
-            maker_balances.regular.to_sat(),
-            expected_regular[i],
-            "Maker {} regular balance mismatch",
-            i
-        );
+        let expected_regular = [14997750, 14999514];
+        // assert_eq!(
+        // maker_balances.regular.to_sat(),
+        // expected_regular[i],
+        // "Maker {} regular balance mismatch",
+        // i
+        // );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -178,11 +178,11 @@ fn test_taproot_timelock_recovery() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // taker_balances.regular.to_sat(),
-    // 14998236,
-    // "Taker regular balance mismatch"
-    // );
+    assert_eq!(
+        taker_balances.regular.to_sat(),
+        14998236,
+        "Taker regular balance mismatch"
+    );
     assert_eq!(
         taker_balances.swap.to_sat(),
         0,
@@ -206,11 +206,11 @@ fn test_taproot_timelock_recovery() {
         taker_balances.spendable,
     );
 
-    // assert_eq!(
-    // balance_diff.to_sat(),
-    // 1764,
-    // "Taker spendable balance change mismatch"
-    // );
+    assert_eq!(
+        balance_diff.to_sat(),
+        1764,
+        "Taker spendable balance change mismatch"
+    );
 
     // Verify maker balances
     for (i, maker) in makers.iter().enumerate() {
@@ -224,12 +224,12 @@ fn test_taproot_timelock_recovery() {
         );
 
         let expected_regular = [14997750, 14999514];
-        // assert_eq!(
-        // maker_balances.regular.to_sat(),
-        // expected_regular[i],
-        // "Maker {} regular balance mismatch",
-        // i
-        // );
+        assert_eq!(
+            maker_balances.regular.to_sat(),
+            expected_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
         assert_eq!(
             maker_balances.swap.to_sat(),
             0,

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -245,25 +245,22 @@ pub fn fund_taker(
 ) -> Amount {
     log::info!("💰 Funding Taker...");
 
+    let mut wallet = taker.get_wallet().write().unwrap();
+    let prev_balances = wallet.get_balances().unwrap();
+
     // Fund with UTXOs
     for _ in 0..utxo_count {
-        let addr = taker
-            .get_wallet()
-            .write()
-            .unwrap()
-            .get_next_external_address(address_type)
-            .unwrap();
+        let addr = wallet.get_next_external_address(address_type).unwrap();
         send_to_address(bitcoind, &addr, utxo_value);
     }
 
     generate_blocks(bitcoind, 1);
 
-    let mut wallet = taker.get_wallet().write().unwrap();
     wallet.sync_and_save().unwrap();
 
     // Verify balances
     let balances = wallet.get_balances().unwrap();
-    let expected_regular = utxo_value * utxo_count.into();
+    let expected_regular = (utxo_value * utxo_count.into()) + prev_balances.regular;
 
     assert_eq!(balances.regular, expected_regular);
 

--- a/tests/integration/utxo_behavior.rs
+++ b/tests/integration/utxo_behavior.rs
@@ -247,7 +247,7 @@ fn test_separated_utxo_coin_selection() {
     // Perform coinswap to create swap coins
     info!("Performing coinswap to create swap coins");
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(35000000), 2)
-        .with_tx_count(3)
+        .with_tx_count(1)
         .with_required_confirms(1);
 
     let summary = taker
@@ -348,7 +348,7 @@ fn test_separated_utxo_coin_selection() {
             } => {
                 println!("Correctly failed with InsufficientFund");
                 println!("   Available: {available} sats, Required: {required} sats");
-                assert_eq!(*required, target_3.to_sat() + 222); // Should include 308 sats estimated fee
+                // assert_eq!(*required, target_3.to_sat() + 222); // Should include 308 sats estimated fee
                 assert_eq!(*available, balances.swap.to_sat());
                 println!("Confirmed: Only swap balance reported in insufficient funds error");
             }

--- a/tests/integration/utxo_behavior.rs
+++ b/tests/integration/utxo_behavior.rs
@@ -348,7 +348,7 @@ fn test_separated_utxo_coin_selection() {
             } => {
                 println!("Correctly failed with InsufficientFund");
                 println!("   Available: {available} sats, Required: {required} sats");
-                // assert_eq!(*required, target_3.to_sat() + 222); // Should include 308 sats estimated fee
+                assert_eq!(*required, target_3.to_sat() + 222); // Should include 308 sats estimated fee
                 assert_eq!(*available, balances.swap.to_sat());
                 println!("Confirmed: Only swap balance reported in insufficient funds error");
             }
@@ -484,7 +484,7 @@ fn test_manual_coinselection() {
     }
 
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_btc(0.01).unwrap(), 2)
-        .with_tx_count(3)
+        .with_tx_count(1)
         .with_required_confirms(1)
         .with_utxos(manually_selected_utxos.clone());
 


### PR DESCRIPTION
# Pull Request
Multi-txn pathway now live for p2tr & p2wpkh

## Description

`Multi-transaction` swaps for `Legacy` (`P2WSH`) and `Taproot` (`MuSig2`)  
Enables splitting a single `coinswap` into `tx_count` parallel contracts per hop (the teleport-style amount-splitting privacy feature), for both protocol families.

`tx_count` wired from the CLI/`SwapParams` through funding, exchange, and settlement; the swap amount is split across `N` contracts (random split, ≥ dust).  

`Legacy`: generate `N` per-contract keys; fund `N` addresses in one `create_funding_txes` call; per-contract nonces in `ReqContractSigsForSender`; `vec`-based private-key handover. (Maker side was already generic.)  
`Taproot`: `TaprootContractData` vec-ified (`internal_keys`/`tap_tweaks`/`timelock_scripts`) so each contract gets a distinct address; maker handler rewritten `N→N` with proportional fee distribution; per-contract verification. 
 
Recovery (multi-tx fixes): persist all `N` incoming swapcoins (not just the last); keep the maker recovering until all contract outputs resolve instead of self-shutting-down after the first; use each swapcoin's real contract `vout` instead of hardcoding `0`; broadcast aborts/handling hardened.  

## Behavioural changes for multi-txn arch
1. Added a `WalletStore` derived counter for internal address generation. This is because, changes in multi-txns go to the same index of address since they are unconfirmed. Current behaviour looks to update the counter via looking at the confirmed txns on the blockchain. Consider the following flow : 
```
iteration 0:
  ask for next change address
  → scan blockchain → highest change index on-chain = 4 → return index 5
  build funding tx #0, change goes to index 5
  ⚠️ this tx is NOT mined yet : it's unconfirmed

iteration 1:
  ask for next change address
  → scan blockchain AGAIN → highest change index on-chain is STILL 4
    (because tx #0 hasn't confirmed, so index 5 isn't on-chain yet)
  → returns index 5 AGAIN  ← same address!

iteration 2:
  same story → index 5 AGAIN
```

2. Added a maker-only method `all_swap_contracts_resolved` to notify the recovery loop of completion of recovery in a timelock path. This uses `gettxout` to verify whether an UTXO is unspent or nah. Once every contract is verified that it's either spent by some txn or simply remained unconfirmed, the method returns a bool to recovery loop, closing it. Before, due to a single txn, we didn't need such a thing. Albeit, Taker has this in form of its own internal logic for recovery. The difference is, Taker relies on the recovery flags, and this method directly upholds on-chain activity as it's source of truth.

3. Now, swapcoins, Regular coins(Changes or HL) don't form groups together. This prevents clustering and address reuse. 

## Bug fixes
1. New method `estimate_funding_tx_fee_sats` now gives a txn template to maker handlers for calculating `mining_fee` and deduct it from the `outgoing_amount`. It assumes a single legacy input (bigger of the two, to prevent understating the fee), a payment (weight for both protocols is equivalent) output, a P2TR change. And similar values for sweep txn minus the change.

```
/// Estimated on-chain miner cost (sats) a maker bears per swap contract: a funding tx
/// (overhead 11 + P2WPKH input 68 + P2TR change 31 + (P2TR/P2WSPK) payment output 43 = 153 vB)
/// plus a sweep tx (overhead 11 + input 68 + self-payment output 43 = 122 vB).
///
/// Used both by the maker (for routed amount) and by taker's `min_expected_amount_for_hop`
pub fn estimate_funding_tx_fee_sats() -> u64 {
    calculate_fee_sats((11 + 68 + 31 + 43) + (11 + 68 + 43))
}
```

## Testing

All tests (malices, aborts, swaps) run at `tx_count = 3` end-to-end (`fund → swap → settle → sweep`), with balance assertions updated for the `N`-tx fee structure.  ONLY exception is `utxo_behaviour` test which still runs at 1 tx_count, since it tests the very distribution of UTXO which we might distort.

## Related Issue(s)
Closes #921, #922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--tx-count`/`tx-count` to the Coinswap CLI to control split transactions.
  * Enabled multi-part swap handling across multiple contract transactions, including Taproot flows.
* **Bug Fixes**
  * Improved Taproot verification and contract consistency checks.
  * Updated fee/outgoing amount calculations for multi-part contracts, with deterministic split handling.
  * Generalized private-key handover and updated wallet persistence so all related swapcoins are retained; timelock recovery now completes after all contract outputs resolve.
* **Tests**
  * Refreshed integration test expectations and balance/fee assertions for the multi-transaction behavior.
* **Chores**
  * Improved CI reliability for Rust dependency downloads (HTTP/1.1 + retries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->