### PR TITLE
Propagate maker's taproot contract broadcast error

### DIFF
--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use bitcoin::{secp256k1::SecretKey, Amount, PublicKey, ScriptBuf};
+use bitcoind::bitcoincore_rpc::{jsonrpc::error::Error as JsonRpcError, Error as BitcoinRpcError};
 
 use super::{
     error::MakerError,
@@ -18,7 +19,7 @@ use crate::{
         legacy_messages::{FundingTxInfo, LegacyTakerMessage},
     },
     utill::{estimate_funding_tx_fee_sats, redeemscript_to_scriptpubkey},
-    wallet::{swapcoin::IncomingSwapCoin, MakerReport},
+    wallet::{swapcoin::IncomingSwapCoin, MakerReport, WalletError},
 };
 
 /// Handle a Legacy protocol message.
@@ -516,8 +517,34 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
     );
 
     for funding_tx in &state.pending_funding_txes {
-        let txid = maker.broadcast_transaction(funding_tx)?;
-        log::info!("[{}] Broadcast funding tx: {}", maker.network_port(), txid);
+        match maker.broadcast_transaction(funding_tx) {
+            Ok(txid) => {
+                log::info!(
+                    "[{}] Broadcast Legacy funding tx: {}",
+                    maker.network_port(),
+                    txid
+                );
+            }
+            Err(MakerError::Wallet(WalletError::Rpc(BitcoinRpcError::JsonRpc(
+                JsonRpcError::Rpc(rpc_error),
+            )))) if rpc_error.code == -27 || {
+                let message = rpc_error.message.to_ascii_lowercase();
+                message.contains("already in block chain")
+                    || message.contains("already in mempool")
+                    || message.contains("already in utxo set")
+                    || message.contains("txn-already-in-mempool")
+            } =>
+            {
+                let txid = funding_tx.compute_txid();
+                log::info!(
+                    "[{}] Legacy funding tx {} for swap {} was already broadcast",
+                    maker.network_port(),
+                    txid,
+                    resp.id,
+                );
+            }
+            Err(e) => return Err(e),
+        }
     }
 
     state.pending_funding_txes.clear();

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -355,36 +355,29 @@ fn process_taproot_contract<M: Maker>(
         }
     }
 
-    for (outgoing, contract_outpoint) in outgoing_swapcoins.iter().zip(reserved.iter()) {
-        match maker.broadcast_transaction(&outgoing.contract_tx) {
-            Ok(txid) => {
-                log::info!(
-                    "[{}] Broadcast Taproot contract tx {} for swap {}",
-                    maker.network_port(),
-                    txid,
-                    data.id
-                );
-            }
-            Err(e) => {
-                log::warn!(
-                    "[{}] Failed to broadcast Taproot contract tx (may already be broadcast): {:?}",
-                    maker.network_port(),
-                    e
-                );
-            }
-        }
-        maker.register_watch_outpoint(*contract_outpoint);
-    }
-
-    state.funding_broadcast = true;
-    state.phase = SwapPhase::AwaitingPrivateKeyHandover;
-
+    // Persist swapcoins before broadcasting contract txs. A later broadcast
+    // failure can leave earlier Taproot contract txs on-chain, and the wallet
+    // needs these records for timelock recovery after a restart.
     for incoming in &incoming_swapcoins {
         maker.save_incoming_swapcoin(incoming)?;
     }
     for outgoing in &outgoing_swapcoins {
         maker.save_outgoing_swapcoin(outgoing)?;
     }
+
+    for (outgoing, contract_outpoint) in outgoing_swapcoins.iter().zip(reserved.iter()) {
+        let txid = maker.broadcast_transaction(&outgoing.contract_tx)?;
+        log::info!(
+            "[{}] Broadcast Taproot contract tx {} for swap {}",
+            maker.network_port(),
+            txid,
+            data.id
+        );
+        maker.register_watch_outpoint(*contract_outpoint);
+    }
+
+    state.funding_broadcast = true;
+    state.phase = SwapPhase::AwaitingPrivateKeyHandover;
 
     maker.store_connection_state(&data.id, state)?;
 

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use bitcoin::{Amount, OutPoint, PublicKey};
+use bitcoind::bitcoincore_rpc::{jsonrpc::error::Error as JsonRpcError, Error as BitcoinRpcError};
 
 use super::{
     error::MakerError,
@@ -21,7 +22,7 @@ use crate::{
     utill::estimate_funding_tx_fee_sats,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
-        MakerReport,
+        MakerReport, WalletError,
     },
 };
 
@@ -366,13 +367,35 @@ fn process_taproot_contract<M: Maker>(
     }
 
     for (outgoing, contract_outpoint) in outgoing_swapcoins.iter().zip(reserved.iter()) {
-        let txid = maker.broadcast_transaction(&outgoing.contract_tx)?;
-        log::info!(
-            "[{}] Broadcast Taproot contract tx {} for swap {}",
-            maker.network_port(),
-            txid,
-            data.id
-        );
+        match maker.broadcast_transaction(&outgoing.contract_tx) {
+            Ok(txid) => {
+                log::info!(
+                    "[{}] Broadcast Taproot contract tx {} for swap {}",
+                    maker.network_port(),
+                    txid,
+                    data.id
+                );
+            }
+            Err(MakerError::Wallet(WalletError::Rpc(BitcoinRpcError::JsonRpc(
+                JsonRpcError::Rpc(rpc_error),
+            )))) if rpc_error.code == -27 || {
+                let message = rpc_error.message.to_ascii_lowercase();
+                message.contains("already in block chain")
+                    || message.contains("already in mempool")
+                    || message.contains("already in utxo set")
+                    || message.contains("txn-already-in-mempool")
+            } =>
+            {
+                let txid = outgoing.contract_tx.compute_txid();
+                log::info!(
+                    "[{}] Taproot contract tx {} for swap {} was already broadcast",
+                    maker.network_port(),
+                    txid,
+                    data.id
+                );
+            }
+            Err(e) => return Err(e),
+        }
         maker.register_watch_outpoint(*contract_outpoint);
     }
 


### PR DESCRIPTION
Fixes #924 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swapcoin record consistency by persisting incoming and outgoing wallet entries before any on-chain broadcasting, reducing mismatches when broadcasts later fail.
  * Taproot broadcasting now halts on the first non-recoverable error to prevent partial progression.
  * Funding transaction “already broadcast/known” cases are now detected and treated as non-fatal, with clearer logging, while watch setup continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->