### PR TITLE
Use cfg attributes for integration-test feature gates

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -398,7 +398,8 @@ fn main() -> Result<(), TakerError> {
         } => {
             let amount = Amount::from_sat(*amount);
 
-            let manually_selected_outpoints = if cfg!(not(feature = "integration-test")) {
+            #[cfg(not(feature = "integration-test"))]
+            let manually_selected_outpoints = {
                 let wallet = taker.get_wallet().read().unwrap();
                 Some(
                     coinswap::utill::interactive_select(wallet.list_all_utxo_spend_info(), amount)?
@@ -406,9 +407,9 @@ fn main() -> Result<(), TakerError> {
                         .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
                         .collect::<Vec<_>>(),
                 )
-            } else {
-                None
             };
+            #[cfg(feature = "integration-test")]
+            let manually_selected_outpoints = None;
 
             let mut wallet = taker.get_wallet().write().unwrap();
             let txid = wallet.send_to_address(
@@ -485,22 +486,27 @@ fn main() -> Result<(), TakerError> {
         } => {
             let protocol_version = parse_protocol(protocol)?;
 
-            let manually_selected_outpoints =
-                if !auto_select && cfg!(not(feature = "integration-test")) {
-                    let target_amount = Amount::from_sat(*amount);
-                    let wallet = taker.get_wallet().read().unwrap();
-                    Some(
-                        coinswap::utill::interactive_select(
-                            wallet.list_all_utxo_spend_info(),
-                            target_amount,
-                        )?
-                        .iter()
-                        .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
-                        .collect::<Vec<_>>(),
-                    )
-                } else {
-                    None
-                };
+            #[cfg(not(feature = "integration-test"))]
+            let manually_selected_outpoints = if !auto_select {
+                let target_amount = Amount::from_sat(*amount);
+                let wallet = taker.get_wallet().read().unwrap();
+                Some(
+                    coinswap::utill::interactive_select(
+                        wallet.list_all_utxo_spend_info(),
+                        target_amount,
+                    )?
+                    .iter()
+                    .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
+                    .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            };
+            #[cfg(feature = "integration-test")]
+            let manually_selected_outpoints = {
+                let _ = auto_select;
+                None
+            };
 
             let mut swap_params =
                 SwapParams::new(protocol_version, Amount::from_sat(*amount), *makers);
@@ -535,7 +541,10 @@ fn main() -> Result<(), TakerError> {
             println!("==================================\n");
 
             // In integration tests, skip the confirmation prompt.
-            if !yes && cfg!(not(feature = "integration-test")) {
+            #[cfg(feature = "integration-test")]
+            let _ = yes;
+            #[cfg(not(feature = "integration-test"))]
+            if !yes {
                 print!("Proceed with this swap? [y/N] ");
                 use std::io::{self, Write};
                 io::stdout().flush().unwrap();

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1560,6 +1560,7 @@ impl MakerRpc for MakerServer {
         &self.shutdown
     }
 
+    #[cfg(not(feature = "integration-test"))]
     fn get_tor_hostname(&self) -> Result<String, crate::utill::TorError> {
         let tor_key_bytes = self
             .wallet

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -12,11 +12,11 @@ use std::{
 use bitcoin::Amount;
 
 use super::messages::RpcMsgReq;
+#[cfg(not(feature = "integration-test"))]
+use crate::utill::TorError;
 use crate::{
     maker::{api::MakerServerConfig, error::MakerError, rpc::messages::RpcMsgResp},
-    utill::{
-        parse_checked_address, read_message, send_message, TorError, HEART_BEAT_INTERVAL, UTXO,
-    },
+    utill::{parse_checked_address, read_message, send_message, HEART_BEAT_INTERVAL, UTXO},
     wallet::{infer_address_type, AddressType, Destination, Wallet},
 };
 use std::{path::Path, sync::RwLock};
@@ -26,6 +26,7 @@ pub trait MakerRpc {
     fn data_dir(&self) -> &Path;
     fn config(&self) -> &MakerServerConfig;
     fn shutdown(&self) -> &AtomicBool;
+    #[cfg(not(feature = "integration-test"))]
     fn get_tor_hostname(&self) -> Result<String, TorError>;
 }
 
@@ -125,9 +126,12 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
         }
         RpcMsgReq::GetDataDir => RpcMsgResp::GetDataDirResp(maker.data_dir().to_path_buf()),
         RpcMsgReq::GetTorAddress => {
-            if cfg!(feature = "integration-test") {
+            #[cfg(feature = "integration-test")]
+            {
                 RpcMsgResp::GetTorAddressResp("Maker is not running on TOR".to_string())
-            } else {
+            }
+            #[cfg(not(feature = "integration-test"))]
+            {
                 let hostname = maker.get_tor_hostname()?;
                 RpcMsgResp::GetTorAddressResp(hostname)
             }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -11,8 +11,9 @@ use std::{
     time::Duration,
 };
 
+#[cfg(not(feature = "integration-test"))]
+use crate::maker::rpc::server::MakerRpc;
 use crate::{
-    maker::rpc::server::MakerRpc,
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
     utill::HEART_BEAT_INTERVAL,
@@ -58,11 +59,10 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     };
     listener.set_nonblocking(true).map_err(MakerError::IO)?;
 
-    let maker_address = if cfg!(feature = "integration-test") {
-        format!("127.0.0.1:{}", maker.config.network_port)
-    } else {
-        maker.get_tor_hostname()?
-    };
+    #[cfg(feature = "integration-test")]
+    let maker_address = format!("127.0.0.1:{}", maker.config.network_port);
+    #[cfg(not(feature = "integration-test"))]
+    let maker_address = maker.get_tor_hostname()?;
 
     log::info!(
         "[{}] Setting up fidelity bond...",

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -5,8 +5,9 @@
 //! fidelity bond information and other coordination signals required
 //! by the Coinswap protocol.
 
+#[cfg(not(feature = "integration-test"))]
+use std::io;
 use std::{
-    io,
     net::TcpStream,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -19,8 +20,11 @@ use nostr::{
     types::Timestamp,
     util::JsonUtil,
 };
+#[cfg(not(feature = "integration-test"))]
 use socks::Socks5Stream;
-use tungstenite::{http::Uri, stream::MaybeTlsStream, Message, WebSocket};
+#[cfg(not(feature = "integration-test"))]
+use tungstenite::http::Uri;
+use tungstenite::{stream::MaybeTlsStream, Message, WebSocket};
 
 use crate::{
     maker::{MakerError, MakerServerConfig},
@@ -52,44 +56,49 @@ pub(crate) fn connect_nostr_websocket(
     socks_port: u16,
     tor_auth_password: &str,
 ) -> Result<WebSocket<MaybeTlsStream<TcpStream>>, tungstenite::Error> {
-    if cfg!(feature = "integration-test") {
-        return tungstenite::connect(relay_url).map(|(ws, _)| ws);
+    #[cfg(feature = "integration-test")]
+    {
+        let _ = (socks_port, tor_auth_password);
+        tungstenite::connect(relay_url).map(|(ws, _)| ws)
     }
 
-    let invalid_relay = || io::Error::new(io::ErrorKind::InvalidInput, "invalid relay url");
-    let uri: Uri = relay_url.parse().map_err(|_| invalid_relay())?;
-    let scheme = uri.scheme_str().ok_or_else(invalid_relay)?;
-    if scheme != "ws" && scheme != "wss" {
-        return Err(invalid_relay().into());
-    }
-    let authority = uri.authority().ok_or_else(invalid_relay)?;
-    let host = authority.host();
-    let port = authority
-        .port_u16()
-        .unwrap_or(if scheme == "wss" { 443 } else { 80 });
+    #[cfg(not(feature = "integration-test"))]
+    {
+        let invalid_relay = || io::Error::new(io::ErrorKind::InvalidInput, "invalid relay url");
+        let uri: Uri = relay_url.parse().map_err(|_| invalid_relay())?;
+        let scheme = uri.scheme_str().ok_or_else(invalid_relay)?;
+        if scheme != "ws" && scheme != "wss" {
+            return Err(invalid_relay().into());
+        }
+        let authority = uri.authority().ok_or_else(invalid_relay)?;
+        let host = authority.host();
+        let port = authority
+            .port_u16()
+            .unwrap_or(if scheme == "wss" { 443 } else { 80 });
 
-    let socks_addr = format!("127.0.0.1:{socks_port}");
-    let target_addr = format!("{host}:{port}");
-    let tcp = if tor_auth_password.is_empty() {
-        Socks5Stream::connect(socks_addr.as_str(), target_addr.as_str())
-    } else {
-        Socks5Stream::connect_with_password(
-            socks_addr.as_str(),
-            target_addr.as_str(),
-            host,
-            tor_auth_password,
-        )
-    }
-    .map_err(|e| io::Error::other(e.to_string()))?
-    .into_inner();
+        let socks_addr = format!("127.0.0.1:{socks_port}");
+        let target_addr = format!("{host}:{port}");
+        let tcp = if tor_auth_password.is_empty() {
+            Socks5Stream::connect(socks_addr.as_str(), target_addr.as_str())
+        } else {
+            Socks5Stream::connect_with_password(
+                socks_addr.as_str(),
+                target_addr.as_str(),
+                host,
+                tor_auth_password,
+            )
+        }
+        .map_err(|e| io::Error::other(e.to_string()))?
+        .into_inner();
 
-    tcp.set_read_timeout(Some(Duration::from_secs(30)))?;
-    tcp.set_write_timeout(Some(Duration::from_secs(30)))?;
-    match tungstenite::client_tls_with_config(relay_url, tcp, None, None) {
-        Ok((ws, _)) => Ok(ws),
-        Err(tungstenite::HandshakeError::Failure(e)) => Err(e),
-        Err(tungstenite::HandshakeError::Interrupted(_)) => {
-            Err(io::Error::other("tls handshake interrupted").into())
+        tcp.set_read_timeout(Some(Duration::from_secs(30)))?;
+        tcp.set_write_timeout(Some(Duration::from_secs(30)))?;
+        match tungstenite::client_tls_with_config(relay_url, tcp, None, None) {
+            Ok((ws, _)) => Ok(ws),
+            Err(tungstenite::HandshakeError::Failure(e)) => Err(e),
+            Err(tungstenite::HandshakeError::Interrupted(_)) => {
+                Err(io::Error::other("tls handshake interrupted").into())
+            }
         }
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -119,11 +119,10 @@ type EncryptionKey = [u8; 32];
 ///
 /// During testing or integration tests, the iteration count is reduced to 1
 /// for performance.
-const PBKDF2_ITERATIONS: u32 = if cfg!(feature = "integration-test") || cfg!(test) {
-    1
-} else {
-    600_000
-};
+#[cfg(any(feature = "integration-test", test))]
+const PBKDF2_ITERATIONS: u32 = 1;
+#[cfg(not(any(feature = "integration-test", test)))]
+const PBKDF2_ITERATIONS: u32 = 600_000;
 
 /// Holds derived cryptographic key material used for encrypting and decrypting wallet data.
 #[derive(Debug, Clone)]

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -27,6 +27,7 @@ use bitcoin::{
     Amount, OutPoint, PublicKey,
 };
 use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RpcApi};
+#[cfg(not(feature = "integration-test"))]
 use socks::Socks5Stream;
 
 use crate::{
@@ -39,8 +40,8 @@ use crate::{
         contract::calculate_pubkey_from_nonce,
     },
     utill::{
-        check_tor_status, estimate_funding_tx_fee_sats, generate_maker_keys, get_taker_dir,
-        read_message, send_message,
+        estimate_funding_tx_fee_sats, generate_maker_keys, get_taker_dir, read_message,
+        send_message,
     },
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
@@ -65,6 +66,9 @@ use super::{
         OfferBookHandle, OfferSyncClient, OfferSyncHandle, OfferSyncService,
     },
 };
+
+#[cfg(not(feature = "integration-test"))]
+use crate::utill::check_tor_status;
 
 /// Connection type for the taker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -678,7 +682,8 @@ impl Taker {
             taker_config.tor_auth_password = tor_auth_password.clone();
         }
 
-        if !cfg!(feature = "integration-test") && config.connection_type == ConnectionType::Tor {
+        #[cfg(not(feature = "integration-test"))]
+        if config.connection_type == ConnectionType::Tor {
             check_tor_status(
                 taker_config.control_port,
                 taker_config.tor_auth_password.as_str(),
@@ -1748,22 +1753,21 @@ impl Taker {
     /// Connect to a maker using either direct connection or Tor proxy.
     #[hotpath::measure]
     pub(crate) fn net_connect(&self, address: &str) -> Result<TcpStream, TakerError> {
-        use crate::protocol::common_messages::COINSWAP_PORT;
-
         log::debug!("Connecting to maker at {}", address);
         let timeout = Duration::from_secs(CONNECT_TIMEOUT_SECS);
 
-        let connection_type = if cfg!(feature = "integration-test") {
-            ConnectionType::Clearnet
-        } else {
-            self.config.connection_type
-        };
+        #[cfg(feature = "integration-test")]
+        let socket = TcpStream::connect(address)
+            .map_err(|e| TakerError::General(format!("Failed to connect to {}: {}", address, e)))?;
 
-        let socket = match connection_type {
+        #[cfg(not(feature = "integration-test"))]
+        let socket = match self.config.connection_type {
             ConnectionType::Clearnet => TcpStream::connect(address).map_err(|e| {
                 TakerError::General(format!("Failed to connect to {}: {}", address, e))
             })?,
             ConnectionType::Tor => {
+                use crate::protocol::common_messages::COINSWAP_PORT;
+
                 let socks_addr = format!("127.0.0.1:{}", self.config.socks_port);
                 let tor_target = format!("{}:{}", address, COINSWAP_PORT);
                 Socks5Stream::connect(socks_addr.as_str(), tor_target.as_str())

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -21,6 +21,7 @@ use std::{
 
 use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
+#[cfg(not(feature = "integration-test"))]
 use socks::Socks5Stream;
 
 use crate::{
@@ -1030,14 +1031,18 @@ impl MakerAddress {
 
     /// Download a single offer from a maker.
     fn fetch_offer(&self, socks_port: u16) -> Result<(Offer, MakerProtocol), TakerError> {
-        use crate::protocol::common_messages::COINSWAP_PORT;
-
         log::debug!("Downloading offer from maker: {}", self);
 
-        let mut socket = if cfg!(feature = "integration-test") {
+        #[cfg(feature = "integration-test")]
+        let mut socket = {
+            let _ = socks_port;
             // Integration test: self.0 is "ip:port"
             TcpStream::connect(self.to_string())?
-        } else {
+        };
+        #[cfg(not(feature = "integration-test"))]
+        let mut socket = {
+            use crate::protocol::common_messages::COINSWAP_PORT;
+
             // Production: self.0 is a .onion hostname, append the well-known port
             let addr = format!("{}:{}", self.0, COINSWAP_PORT);
             Socks5Stream::connect(format!("127.0.0.1:{socks_port}").as_str(), addr.as_ref())?

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -6,7 +6,9 @@ use bitcoin::{
     secp256k1::{Secp256k1, SecretKey},
     Address, Amount, FeeRate, Network, PublicKey, ScriptBuf, WitnessProgram, WitnessVersion,
 };
-use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, jsonrpc::base64};
+use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
+#[cfg(not(feature = "integration-test"))]
+use bitcoind::bitcoincore_rpc::jsonrpc::base64;
 use crossterm::{
     cursor::MoveTo,
     event::{
@@ -505,6 +507,7 @@ impl From<serde_cbor::Error> for TorError {
     }
 }
 
+#[cfg(not(feature = "integration-test"))]
 pub(crate) fn check_tor_status(control_port: u16, password: &str) -> Result<(), TorError> {
     use std::{
         io::BufRead,
@@ -556,8 +559,10 @@ pub(crate) fn check_tor_status(control_port: u16, password: &str) -> Result<(), 
     Ok(())
 }
 
+#[cfg(not(any(feature = "integration-test", test)))]
 struct RawModeGuard;
 
+#[cfg(not(any(feature = "integration-test", test)))]
 impl RawModeGuard {
     fn new() -> io::Result<Self> {
         enable_raw_mode()?;
@@ -565,6 +570,7 @@ impl RawModeGuard {
     }
 }
 
+#[cfg(not(any(feature = "integration-test", test)))]
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
@@ -582,56 +588,62 @@ pub(crate) fn now_unix_secs() -> u64 {
 /// Temporarily disables canonical mode and echo to mask each typed
 /// character with `*` as feedback.
 pub fn prompt_password(message: String) -> io::Result<String> {
-    if cfg!(feature = "integration-test") || cfg!(test) {
-        return Ok("integration-test".to_string());
+    #[cfg(any(feature = "integration-test", test))]
+    {
+        let _ = message;
+        Ok("integration-test".to_string())
     }
 
-    let mut stdout = io::stdout();
-    let stdin = io::stdin();
+    #[cfg(not(any(feature = "integration-test", test)))]
+    {
+        let mut stdout = io::stdout();
+        let stdin = io::stdin();
 
-    print!("{message}");
-    stdout.flush()?; // Ensure the prompt is printed
+        print!("{message}");
+        stdout.flush()?; // Ensure the prompt is printed
 
-    let _guard = RawModeGuard::new()?;
+        let _guard = RawModeGuard::new()?;
 
-    let mut password = String::new();
-    let mut buf = [0u8; 1];
+        let mut password = String::new();
+        let mut buf = [0u8; 1];
 
-    while stdin.lock().read(&mut buf)? == 1 {
-        let c = buf[0] as char;
+        while stdin.lock().read(&mut buf)? == 1 {
+            let c = buf[0] as char;
 
-        match c {
-            '\n' | '\r' => {
-                // - If the byte is newline (`\n`, ASCII 0x0A) or carriage return (`\r`, ASCII 0x0D),
-                //   it signals the end of input, so we break the loop.
-                println!();
-                break;
-            }
-            '\x08' | '\x7f' => {
-                // - If the byte is Backspace (ASCII 0x08 or 0x7f),
-                //   we remove the last character from the password (if any),
-                //   and erase the asterisk from the terminal by moving the cursor back,
-                //   writing a space to overwrite, then moving the cursor back again.
-                if !password.is_empty() {
-                    password.pop();
-                    print!("\x08 \x08");
+            match c {
+                '\n' | '\r' => {
+                    // - If the byte is newline (`\n`, ASCII 0x0A) or carriage return (`\r`, ASCII 0x0D),
+                    //   it signals the end of input, so we break the loop.
+                    println!();
+                    break;
+                }
+                '\x08' | '\x7f' => {
+                    // - If the byte is Backspace (ASCII 0x08 or 0x7f),
+                    //   we remove the last character from the password (if any),
+                    //   and erase the asterisk from the terminal by moving the cursor back,
+                    //   writing a space to overwrite, then moving the cursor back again.
+                    if !password.is_empty() {
+                        password.pop();
+                        print!("\x08 \x08");
+                        stdout.flush()?;
+                    }
+                }
+                _ => {
+                    // - Otherwise, for any other character, we append it to the password string
+                    //   and print an asterisk '*' as a visual placeholder for the typed character.
+                    password.push(c);
+                    print!("*");
                     stdout.flush()?;
                 }
             }
-            _ => {
-                // - Otherwise, for any other character, we append it to the password string
-                //   and print an asterisk '*' as a visual placeholder for the typed character.
-                password.push(c);
-                print!("*");
-                stdout.flush()?;
-            }
         }
-    }
 
-    println!(); // move to next line after input
-    Ok(password.trim_end().to_string())
+        println!(); // move to next line after input
+        Ok(password.trim_end().to_string())
+    }
 }
 
+#[cfg(not(feature = "integration-test"))]
 pub(crate) fn get_ephemeral_address(
     control_port: u16,
     local_port: u16,
@@ -677,6 +689,7 @@ pub(crate) fn get_ephemeral_address(
     Ok(format!("{service_id}.onion"))
 }
 
+#[cfg(not(feature = "integration-test"))]
 pub(crate) fn get_tor_hostname(
     data_dir: &Path,
     control_port: u16,

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -12,9 +12,10 @@ use std::collections::{HashMap, HashSet};
 use crate::security::KeyMaterial;
 
 use bip39::Mnemonic;
+#[cfg(not(feature = "integration-test"))]
+use bitcoin::hashes::{sha512, Hash};
 use bitcoin::{
     bip32::{ChainCode, ChildNumber, DerivationPath, Xpriv, Xpub},
-    hashes::{sha512, Hash},
     key::TapTweak,
     secp256k1,
     secp256k1::{Keypair, Secp256k1, SecretKey},
@@ -1069,9 +1070,12 @@ impl Wallet {
 
     /// Dynamic address import count function. 10 for tests, 5000 for production.
     pub(crate) fn get_addrss_import_count(&self) -> u32 {
-        if cfg!(feature = "integration-test") {
+        #[cfg(feature = "integration-test")]
+        {
             10
-        } else {
+        }
+        #[cfg(not(feature = "integration-test"))]
+        {
             5000
         }
     }
@@ -1617,6 +1621,7 @@ impl Wallet {
 
     //expose a deterministically-derived 64-byte Ed25519-V3 Tor key
     // built from the wallet's master_key
+    #[cfg(not(feature = "integration-test"))]
     pub(crate) fn derive_tor_key(&self) -> [u8; 64] {
         // Hash the 32-byte secp256k1 private key bytes RFC 8032 per 5.1.5,
         // then clamp into a valid Ed25519 expanded key.


### PR DESCRIPTION
# Pull Request

## Description
Replace `cfg!` runtime-style checks for the `integration-test` feature with `#[cfg(...)]` attribute gates.

This is mainly a `compile-time` hygiene improvement. Any binary-size or compile-time gains are expected to be modest, but the cfg boundaries are now clearer and stricter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for Tor and direct network paths, with more reliable behavior across different build modes.
  * Made password prompts and confirmation steps behave consistently without affecting automated test runs.
  * Adjusted key-derivation and address-import settings for faster test execution while preserving normal production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->