### PR TITLE
fix orphaned bitcoind when a test panics

### DIFF
--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -502,15 +502,20 @@ impl TestFramework {
 
         // Start the block generation thread
         log::info!("⛏️ Spawning block generation thread");
-        let tf_clone = test_framework.clone();
+        let tf_weak = Arc::downgrade(&test_framework);
         let generate_blocks_handle = thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(3));
 
-            if tf_clone.shutdown.load(Relaxed) {
+            let Some(tf) = tf_weak.upgrade() else {
+                log::info!("🔚 Test framework dropped, ending block generation thread");
+                return;
+            };
+
+            if tf.shutdown.load(Relaxed) {
                 log::info!("🔚 Ending block generation thread");
                 return;
             }
-            generate_blocks(&tf_clone.bitcoind, 10);
+            generate_blocks(&tf.bitcoind, 10);
         });
 
         log::info!("✅ Test Framework initialization complete");


### PR DESCRIPTION

## Description
The block generation thread held a strong Arc<TestFramework>, so on
panic the refcount never hit zero and Drop never killed bitcoind.
Use a Weak reference and upgrade per iteration instead.

## Related Issue(s)
Closes #930

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background processing shutdown so it stops cleanly when the framework is no longer available.
  * Reduced the chance of hanging or lingering test activity during teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->