### PR TITLE
CoinSwap service between BIP-128 chain and original Core chain

### DIFF
--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -2789,6 +2789,9 @@ impl Wallet {
 
     /// Separates coins by sending them to a specific address with a large OP_RETURN.
     /// This is useful to split coins across chain forks (e.g., Core vs BIP-128).
+    /// By utilizing consensus divergence, this large OP_RETURN ensures the sweep
+    /// transaction is valid only on the Bitcoin Core chain and rejected on the fork.
+    /// This acts as a reliable, decentralized replay-protection mechanism for swaps.
     pub fn separate_chain_coins(
         &mut self,
         feerate: f64,

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -2786,4 +2786,34 @@ impl Wallet {
             }
         }
     }
+
+    /// Separates coins by sending them to a specific address with a large OP_RETURN.
+    /// This is useful to split coins across chain forks (e.g., Core vs BIP-128).
+    pub fn separate_chain_coins(
+        &mut self,
+        feerate: f64,
+        destination_address: Option<Address>,
+        op_return_payload: &[u8],
+    ) -> Result<Txid, WalletError> {
+        let mut coins_to_spend = self.list_descriptor_utxo_spend_info();
+        coins_to_spend.extend(self.list_swept_incoming_swap_utxos());
+
+        if coins_to_spend.is_empty() {
+            return Err(WalletError::General("No spendable coins to separate".to_owned()));
+        }
+
+        let change_type = AddressType::P2WPKH;
+        let dest_addr = match destination_address {
+            Some(addr) => addr,
+            None => self.get_next_internal_addresses(1, change_type)?[0].clone(),
+        };
+
+        let destination = crate::wallet::spend::Destination::Sweep(dest_addr, Some(op_return_payload.into()));
+        
+        let tx = self.spend_coins(&coins_to_spend, destination, feerate)?;
+        let txid = self.send_tx(&tx)?;
+
+        log::info!("Separation transaction broadcasted. txid: {}", txid);
+        Ok(txid)
+    }
 }

--- a/src/wallet/spend.rs
+++ b/src/wallet/spend.rs
@@ -21,7 +21,7 @@ use super::{error::WalletError, AddressType, Wallet};
 #[derive(Debug, Clone, PartialEq)]
 pub enum Destination {
     /// Sweep
-    Sweep(Address),
+    Sweep(Address, Option<Box<[u8]>>),
     /// Multi
     Multi {
         /// List of outputs (address, amounts)
@@ -107,7 +107,7 @@ impl Wallet {
         };
 
         let change_addr = &self.get_next_internal_addresses(1, destination_address_type)?[0];
-        let destination = Destination::Sweep(change_addr.clone());
+        let destination = Destination::Sweep(change_addr.clone(), None);
 
         // Find utxo corresponding to expired fidelity bond.
         let utxo = self
@@ -266,13 +266,29 @@ impl Wallet {
         }
 
         match destination {
-            Destination::Sweep(addr) => {
+            Destination::Sweep(addr, op_return_data) => {
                 // Send Max Amount case
                 let txout = TxOut {
                     script_pubkey: addr.script_pubkey(),
                     value: Amount::ZERO, // Temp Value
                 };
                 tx.output.push(txout);
+
+                if let Some(data) = op_return_data {
+                    let mut push_bytes = PushBytesBuf::new();
+                    push_bytes.extend_from_slice(&data).map_err(|_| {
+                        WalletError::General(
+                            "Failed to add OP_RETURN data to transaction output".to_owned(),
+                        )
+                    })?;
+                    let op_return_script = ScriptBuf::new_op_return(&push_bytes);
+                    let txout = TxOut {
+                        script_pubkey: op_return_script,
+                        value: Amount::ZERO,
+                    };
+                    tx.output.push(txout);
+                }
+
                 let base_size = tx.base_size();
                 let vsize = (base_size * 4 + total_witness_size + 2).div_ceil(4); // base * 4 + witness size + marker + flag
 


### PR DESCRIPTION
This PR implements a decentralized Coin Separation (UTXO Splitter) Service directly inside the CoinSwap Wallet API. The simplest and most robust way to separate coins is by creating a sweep transaction that includes a large OP_RETURN payload. By leveraging consensus divergence, this transaction will confirm on the Bitcoin Core chain but will be rejected by the BIP-128 chain, cleanly splitting the UTXOs. 

Extended Destination::Sweep:
Modified the Destination::Sweep enum in src/wallet/spend.rs to accept an optional OP_RETURN data payload (Option<Box<[u8]>>).
Updated the underlying spend_coins transaction generation logic to correctly construct and serialize this custom OP_RETURN output alongside the sweep transaction.
New Wallet API (separate_chain_coins):
Added the Wallet::separate_chain_coins API in src/wallet/api.rs.
This method aggregates all available standard spendable UTXOs (filtering out active contracts and fidelity bonds).
It executes a sweep to a specified destination address (or dynamically generates a new internal change address) and attaches the large OP_RETURN payload to invalidate the transaction on the BIP-128 fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to separate wallet coins into a chosen or automatically generated destination.
  * Separation transactions can include optional OP_RETURN data.
  * The resulting transaction is broadcast automatically, with its transaction ID returned.

* **Bug Fixes**
  * Existing sweep operations continue to work without OP_RETURN data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->