### PR TITLE
fix(wallet): reject plaintext stores when password is supplied

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -289,7 +289,9 @@ pub fn decrypt_struct<T: DeserializeOwned>(
 }
 /// Loads a sensitive struct from a file, supporting both encrypted and plaintext formats.
 ///
-/// This function tries to deserialize the file contents in two steps:
+/// When a non-empty password is supplied, this function requires the file to
+/// deserialize as [`EncryptedData`] and never attempts a plaintext fallback.
+/// Without a password, it tries to deserialize the file contents in two steps:
 ///
 /// 1. **Unencrypted:** Attempts to deserialize the file directly as `T`.
 /// 2. **Encrypted:** If that fails, attempts to deserialize as [`EncryptedData`],
@@ -306,6 +308,24 @@ pub fn load_sensitive_struct<T: DeserializeOwned, F: SerdeFormat>(
     password: Option<String>,
 ) -> (T, Option<KeyMaterial>) {
     let content = fs::read(file).unwrap_or_else(|_| panic!("Failed to read the file: {:?}", file));
+
+    if let Some(encryption_password) = password.as_ref().filter(|password| !password.is_empty()) {
+        let encrypted_struct = F::from_slice::<EncryptedData>(&content).unwrap_or_else(|err| {
+            panic!(
+                "Expected encrypted file {:?} because a password was supplied: {}",
+                file, err
+            )
+        });
+        let enc_material = KeyMaterial::existing(
+            encryption_password.clone(),
+            encrypted_struct.nonce,
+            encrypted_struct.pbkdf2_salt,
+        );
+        let decrypted = decrypt_struct::<T>(encrypted_struct, &enc_material)
+            .unwrap_or_else(|err| panic!("Failed to decrypt file {:?}: {:?}", file, err));
+
+        return (decrypted, Some(enc_material));
+    }
 
     let (sensitive_struct, encryption_material) = match F::from_slice::<T>(&content) {
         Ok(unencrypted_struct) => (unencrypted_struct, None),

--- a/src/security.rs
+++ b/src/security.rs
@@ -18,6 +18,44 @@ use sha2::Sha256;
 use crate::utill;
 use std::{fs, path::Path};
 
+/// Errors returned while loading or decrypting sensitive data.
+#[derive(Debug)]
+pub enum SecurityError {
+    /// The sensitive file could not be read.
+    Io(std::io::Error),
+    /// The file did not match the required serialization format.
+    Format(String),
+    /// Authentication or decryption failed.
+    Decryption,
+    /// The decrypted CBOR payload was invalid.
+    Cbor(serde_cbor::Error),
+}
+
+impl std::fmt::Display for SecurityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "I/O error: {err}"),
+            Self::Format(err) => write!(f, "format error: {err}"),
+            Self::Decryption => write!(f, "decryption failed; wrong password or corrupted data"),
+            Self::Cbor(err) => write!(f, "CBOR error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for SecurityError {}
+
+impl From<std::io::Error> for SecurityError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<serde_cbor::Error> for SecurityError {
+    fn from(err: serde_cbor::Error) -> Self {
+        Self::Cbor(err)
+    }
+}
+
 /// Errors that can occur during the encryption process.
 ///
 /// This enum covers serialization errors from CBOR encoding as well as
@@ -269,7 +307,7 @@ pub fn encrypt_struct<T: Serialize>(
 pub fn decrypt_struct<T: DeserializeOwned>(
     encrypted_struct: EncryptedData,
     enc_material: &KeyMaterial,
-) -> Result<T, serde_cbor::Error> {
+) -> Result<T, SecurityError> {
     // Deserialize the outer EncryptedWalletStore wrapper.
 
     let nonce_vec = encrypted_struct.nonce;
@@ -282,10 +320,10 @@ pub fn decrypt_struct<T: DeserializeOwned>(
     // Decrypt the inner CBOR bytes.
     let plaintext_cbor = cipher
         .decrypt(&nonce, encrypted_struct.encrypted_payload.as_ref())
-        .expect("Error decrypting wallet, wrong passphrase?");
+        .map_err(|_| SecurityError::Decryption)?;
 
     // Deserialize the inner CBOR into the original type
-    utill::deserialize_from_cbor::<T>(plaintext_cbor)
+    Ok(utill::deserialize_from_cbor::<T>(plaintext_cbor)?)
 }
 /// Loads a sensitive struct from a file, supporting both encrypted and plaintext formats.
 ///
@@ -306,26 +344,27 @@ pub fn decrypt_struct<T: DeserializeOwned>(
 pub fn load_sensitive_struct<T: DeserializeOwned, F: SerdeFormat>(
     file: &Path,
     password: Option<String>,
-) -> (T, Option<KeyMaterial>) {
-    let content = fs::read(file).unwrap_or_else(|_| panic!("Failed to read the file: {:?}", file));
+) -> Result<(T, Option<KeyMaterial>), SecurityError> {
+    let content = fs::read(file)?;
 
-    if let Some(encryption_password) = password.as_ref().filter(|password| !password.is_empty()) {
-        let encrypted_struct = F::from_slice::<EncryptedData>(&content).unwrap_or_else(|err| {
-            panic!(
-                "Expected encrypted file {:?} because a password was supplied: {}",
-                file, err
-            )
-        });
-        let enc_material = KeyMaterial::existing(
-            encryption_password.clone(),
-            encrypted_struct.nonce,
-            encrypted_struct.pbkdf2_salt,
-        );
-        let decrypted = decrypt_struct::<T>(encrypted_struct, &enc_material)
-            .unwrap_or_else(|err| panic!("Failed to decrypt file {:?}: {:?}", file, err));
+    let password = match password {
+        Some(encryption_password) if !encryption_password.is_empty() => {
+            let encrypted_struct = F::from_slice::<EncryptedData>(&content).map_err(|err| {
+                SecurityError::Format(format!(
+                    "expected encrypted file {file:?} because a password was supplied: {err}"
+                ))
+            })?;
+            let enc_material = KeyMaterial::existing(
+                encryption_password,
+                encrypted_struct.nonce,
+                encrypted_struct.pbkdf2_salt,
+            );
+            let decrypted = decrypt_struct::<T>(encrypted_struct, &enc_material)?;
 
-        return (decrypted, Some(enc_material));
-    }
+            return Ok((decrypted, Some(enc_material)));
+        }
+        password => password,
+    };
 
     let (sensitive_struct, encryption_material) = match F::from_slice::<T>(&content) {
         Ok(unencrypted_struct) => (unencrypted_struct, None),
@@ -333,8 +372,7 @@ pub fn load_sensitive_struct<T: DeserializeOwned, F: SerdeFormat>(
             Ok(encrypted_struct) => {
                 let encryption_password = match password {
                     Some(p) => p,
-                    None => utill::prompt_password("Enter encryption passphrase: ".to_string())
-                        .expect("Failed to read password"),
+                    None => utill::prompt_password("Enter encryption passphrase: ".to_string())?,
                 };
                 let enc_material = KeyMaterial::existing(
                     encryption_password,
@@ -342,21 +380,19 @@ pub fn load_sensitive_struct<T: DeserializeOwned, F: SerdeFormat>(
                     encrypted_struct.pbkdf2_salt,
                 );
 
-                let decrypted = decrypt_struct::<T>(encrypted_struct, &enc_material)
-                    .unwrap_or_else(|err| panic!("Failed to decrypt file {:?}: {:?}", file, err));
+                let decrypted = decrypt_struct::<T>(encrypted_struct, &enc_material)?;
 
                 (decrypted, Some(enc_material))
             }
             Err(encrypted_err) => {
-                panic!(
-                    "Failed to deserialize file {:?}:\n- As unencrypted: {}\n- As encrypted: {}",
-                    file, unencrypted_err, encrypted_err
-                );
+                return Err(SecurityError::Format(format!(
+                    "failed to deserialize file {file:?}; as plaintext: {unencrypted_err}; as encrypted: {encrypted_err}"
+                )));
             }
         },
     };
 
-    (sensitive_struct, encryption_material)
+    Ok((sensitive_struct, encryption_material))
 }
 
 #[cfg(test)]

--- a/src/wallet/backup.rs
+++ b/src/wallet/backup.rs
@@ -154,7 +154,14 @@ impl Wallet {
             restored_path.file_name()
         );
 
-        let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(backup_file_path, None);
+        let (backup, _) =
+            match load_sensitive_struct::<WalletBackup, SerdeJson>(backup_file_path, None) {
+                Ok(backup) => backup,
+                Err(err) => {
+                    log::error!("Wallet backup load failed: {err}");
+                    return;
+                }
+            };
         let restore_enc_material = KeyMaterial::new_interactive(Some(
             "Enter restored walled encryption passphrase(empty for no encryption): ".to_string(),
         ));

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -1,6 +1,6 @@
 //! All Wallet-related errors.
 
-use crate::protocol::error::ProtocolError;
+use crate::{protocol::error::ProtocolError, security::SecurityError};
 
 use super::fidelity::FidelityError;
 
@@ -24,6 +24,9 @@ pub enum WalletError {
     ///
     /// This is used for encoding/decoding the wallet backup.
     Json(serde_json::Error),
+
+    /// Represents an error while loading or decrypting sensitive wallet data.
+    Security(SecurityError),
 
     /// Represents an error returned by the Bitcoin Core RPC client.
     ///
@@ -149,6 +152,12 @@ impl From<serde_json::Error> for WalletError {
     }
 }
 
+impl From<SecurityError> for WalletError {
+    fn from(value: SecurityError) -> Self {
+        Self::Security(value)
+    }
+}
+
 impl From<FidelityError> for WalletError {
     fn from(value: FidelityError) -> Self {
         Self::Fidelity(value)
@@ -215,6 +224,7 @@ impl std::fmt::Display for WalletError {
             WalletError::IO(e) => write!(f, "I/O error: {}", e),
             WalletError::Cbor(e) => write!(f, "CBOR error: {}", e),
             WalletError::Json(e) => write!(f, "JSON error: {}", e),
+            WalletError::Security(e) => write!(f, "Security error: {}", e),
             WalletError::Rpc(e) => write!(f, "Bitcoin RPC error: {}", e),
             WalletError::BIP32(e) => write!(f, "BIP32 error: {}", e),
             WalletError::BIP39(e) => write!(f, "BIP39 error: {}", e),
@@ -254,6 +264,7 @@ impl std::error::Error for WalletError {
             WalletError::IO(e) => Some(e),
             WalletError::Cbor(e) => Some(e),
             WalletError::Json(e) => Some(e),
+            WalletError::Security(e) => Some(e),
             WalletError::Rpc(e) => Some(e),
             WalletError::BIP32(e) => Some(e),
             WalletError::BIP39(e) => Some(e),

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -36,7 +36,8 @@ pub use super::report::{
 /// - `data_dir`: Target directory, defaults to `~/.coinswap/taker`
 /// - `wallet_file_name`: Restored wallet filename, defaults to name from backup if empty
 /// - `backup_file_path`: Path to the JSON file containing the wallet backup (encrypted or plain)
-/// - `password`: Required if backup is encrypted, ignored otherwise
+/// - `password`: Required if the backup is encrypted. Supplying a non-empty password
+///   also requires the backup file itself to be encrypted; plaintext is rejected.
 pub fn restore_wallet_gui_app(
     data_dir: Option<PathBuf>,
     wallet_file_name: Option<String>,

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -45,10 +45,16 @@ pub fn restore_wallet_gui_app(
     backup_file_path: PathBuf,
     password: Option<String>,
 ) {
-    let (backup, encryption_material) = load_sensitive_struct::<WalletBackup, SerdeJson>(
+    let (backup, encryption_material) = match load_sensitive_struct::<WalletBackup, SerdeJson>(
         &backup_file_path,
         Some(password.unwrap_or_default()),
-    );
+    ) {
+        Ok(backup) => backup,
+        Err(err) => {
+            log::error!("Wallet backup load failed: {err}");
+            return;
+        }
+    };
     let restored_wallet_filename = wallet_file_name.unwrap_or("".to_string());
 
     let restored_wallet_path = data_dir

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -149,10 +149,8 @@ impl WalletStore {
         backup_file_path: &Path,
         password: String,
     ) -> Result<(Self, Option<KeyMaterial>), WalletError> {
-        Ok(load_sensitive_struct::<Self, SerdeCbor>(
-            backup_file_path,
-            Some(password),
-        ))
+        load_sensitive_struct::<Self, SerdeCbor>(backup_file_path, Some(password))
+            .map_err(Into::into)
     }
 }
 
@@ -207,22 +205,12 @@ mod tests {
         )
         .unwrap();
 
-        let load_result = std::panic::catch_unwind(|| {
-            WalletStore::read_from_disk(&file_path, "wallet password".to_string())
-        });
-        let panic_payload =
-            load_result.expect_err("a password must require an encrypted wallet file");
-        let panic_msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
-            s.as_str()
-        } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-            *s
-        } else {
-            "<non-string panic payload>"
-        };
+        let load_result = WalletStore::read_from_disk(&file_path, "wallet password".to_string());
+        let error = load_result.expect_err("a password must require an encrypted wallet file");
         assert!(
-            panic_msg.contains("Expected encrypted file"),
-            "unexpected panic message: {}",
-            panic_msg
+            error.to_string().contains("expected encrypted file"),
+            "unexpected error: {}",
+            error
         );
     }
 
@@ -244,6 +232,10 @@ mod tests {
             &encryption_material,
         )
         .unwrap();
+
+        let error = WalletStore::read_from_disk(&file_path, "wrong password".to_string())
+            .expect_err("a wrong password must fail authentication");
+        assert!(error.to_string().contains("decryption failed"));
 
         let (read_wallet, read_encryption_material) =
             WalletStore::read_from_disk(&file_path, password).unwrap();

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -149,10 +149,10 @@ impl WalletStore {
         backup_file_path: &Path,
         password: String,
     ) -> Result<(Self, Option<KeyMaterial>), WalletError> {
-        let (wallet_store, store_enc_material) =
-            load_sensitive_struct::<Self, SerdeCbor>(backup_file_path, Some(password));
-
-        Ok((wallet_store, store_enc_material))
+        Ok(load_sensitive_struct::<Self, SerdeCbor>(
+            backup_file_path,
+            Some(password),
+        ))
     }
 }
 
@@ -188,5 +188,66 @@ mod tests {
 
         let (read_wallet, _nonce) = WalletStore::read_from_disk(&file_path, String::new()).unwrap();
         assert_eq!(original_wallet_store, read_wallet);
+    }
+
+    #[test]
+    fn rejects_plaintext_wallet_when_password_is_supplied() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("test_wallet.cbor");
+        let seed: [u8; 16] = thread_rng().gen();
+        let master_key = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+
+        WalletStore::init(
+            "test_wallet".to_string(),
+            &file_path,
+            Network::Bitcoin,
+            master_key,
+            None,
+            &None,
+        )
+        .unwrap();
+
+        let load_result = std::panic::catch_unwind(|| {
+            WalletStore::read_from_disk(&file_path, "wallet password".to_string())
+        });
+        let panic_payload =
+            load_result.expect_err("a password must require an encrypted wallet file");
+        let panic_msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
+            s.as_str()
+        } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
+            *s
+        } else {
+            "<non-string panic payload>"
+        };
+        assert!(
+            panic_msg.contains("Expected encrypted file"),
+            "unexpected panic message: {}",
+            panic_msg
+        );
+    }
+
+    #[test]
+    fn reads_encrypted_wallet_when_password_is_supplied() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("test_wallet.cbor");
+        let seed: [u8; 16] = thread_rng().gen();
+        let master_key = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+        let password = "wallet password".to_string();
+        let encryption_material = KeyMaterial::new_from_password(Some(password.clone()));
+
+        let original_wallet_store = WalletStore::init(
+            "test_wallet".to_string(),
+            &file_path,
+            Network::Bitcoin,
+            master_key,
+            None,
+            &encryption_material,
+        )
+        .unwrap();
+
+        let (read_wallet, read_encryption_material) =
+            WalletStore::read_from_disk(&file_path, password).unwrap();
+        assert_eq!(original_wallet_store, read_wallet);
+        assert!(read_encryption_material.is_some());
     }
 }

--- a/tests/integration/wallet_backup.rs
+++ b/tests/integration/wallet_backup.rs
@@ -101,7 +101,8 @@ fn plainwallet_plainbackup_plainrestore() {
 
     wallet.sync_and_save().unwrap();
 
-    let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None);
+    let (backup, _) =
+        load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None).unwrap();
 
     let restored_wallet =
         Wallet::restore(&backup, &restored_wallet_file, &rpc_config, None).unwrap();
@@ -139,7 +140,8 @@ fn encwallet_encbackup_encrestore() {
 
     wallet.sync_and_save().unwrap();
 
-    let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None);
+    let (backup, _) =
+        load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None).unwrap();
 
     let restored_wallet =
         Wallet::restore(&backup, &restored_wallet_file, &rpc_config, km.clone()).unwrap();


### PR DESCRIPTION
Fixes #941 

This prevents an encrypted wallet from being replaced with a plaintext store that bypasses password authentication and silently disables encryption for subsequent saves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encrypted wallet backups now reliably require a password and decrypt correctly with valid credentials.
  * If a non-empty password is provided for a plaintext backup, it’s rejected instead of being accepted silently.
  * Wallet storage and restore flows now fail fast with clearer error reporting when sensitive backup loading or decryption fails.
* **Documentation**
  * Clarified that non-empty passwords imply encrypted backups during wallet restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->