### PR TITLE
feat: Authenticate maker RPC requests with a local cookie

### DIFF
--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -1,9 +1,9 @@
-use std::{net::TcpStream, time::Duration};
+use std::{fs, net::TcpStream, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use coinswap::{
-    maker::{MakerError, RpcMsgReq, RpcMsgResp},
-    utill::{read_message, send_message, MIN_FEE_RATE},
+    maker::{AuthenticatedRpcRequest, MakerError, RpcMsgReq, RpcMsgResp},
+    utill::{get_maker_dir, read_message, send_message, MIN_FEE_RATE},
 };
 
 /// A simple command line app to operate the makerd server.
@@ -20,6 +20,9 @@ struct App {
     /// Sets the rpc-port of Makerd
     #[arg(long, short = 'p', default_value = "127.0.0.1:6103")]
     rpc_port: String,
+    /// Maker data directory used to read the RPC authentication cookie
+    #[arg(long, short = 'd')]
+    data_directory: Option<PathBuf>,
     /// The command to execute
     #[command(subcommand)]
     command: Commands,
@@ -78,30 +81,37 @@ enum Commands {
 
 fn main() -> Result<(), MakerError> {
     let cli = App::parse();
+    let rpc_cookie = fs::read_to_string(
+        cli.data_directory
+            .unwrap_or_else(get_maker_dir)
+            .join("rpc_cookie"),
+    )?
+    .trim()
+    .to_owned();
 
     let stream = TcpStream::connect(cli.rpc_port)?;
 
     match cli.command {
         Commands::SendPing => {
-            send_rpc_req(stream, RpcMsgReq::Ping)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::Ping)?;
         }
         Commands::ListUtxoContract => {
-            send_rpc_req(stream, RpcMsgReq::ContractUtxo)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::ContractUtxo)?;
         }
         Commands::ListUtxoFidelity => {
-            send_rpc_req(stream, RpcMsgReq::FidelityUtxo)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::FidelityUtxo)?;
         }
         Commands::GetBalances => {
-            send_rpc_req(stream, RpcMsgReq::Balances)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::Balances)?;
         }
         Commands::ListUtxo => {
-            send_rpc_req(stream, RpcMsgReq::Utxo)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::Utxo)?;
         }
         Commands::ListUtxoSwap => {
-            send_rpc_req(stream, RpcMsgReq::SwapUtxo)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::SwapUtxo)?;
         }
         Commands::GetNewAddress => {
-            send_rpc_req(stream, RpcMsgReq::NewAddress)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::NewAddress)?;
         }
         Commands::SendToAddress {
             address,
@@ -110,6 +120,7 @@ fn main() -> Result<(), MakerError> {
         } => {
             send_rpc_req(
                 stream,
+                &rpc_cookie,
                 RpcMsgReq::SendToAddress {
                     address,
                     amount,
@@ -118,33 +129,47 @@ fn main() -> Result<(), MakerError> {
             )?;
         }
         Commands::ShowTorAddress => {
-            send_rpc_req(stream, RpcMsgReq::GetTorAddress)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::GetTorAddress)?;
         }
         Commands::ShowDataDir => {
-            send_rpc_req(stream, RpcMsgReq::GetDataDir)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::GetDataDir)?;
         }
         Commands::Stop => {
-            send_rpc_req(stream, RpcMsgReq::Stop)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::Stop)?;
         }
         Commands::ShowFidelity => {
-            send_rpc_req(stream, RpcMsgReq::ListFidelity)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::ListFidelity)?;
         }
         Commands::SyncWallet => {
-            send_rpc_req(stream, RpcMsgReq::SyncWallet)?;
+            send_rpc_req(stream, &rpc_cookie, RpcMsgReq::SyncWallet)?;
         }
         Commands::VerifyDeniability { swap_id } => {
-            send_rpc_req(stream, RpcMsgReq::VerifyDeniability { swap_id })?;
+            send_rpc_req(
+                stream,
+                &rpc_cookie,
+                RpcMsgReq::VerifyDeniability { swap_id },
+            )?;
         }
     }
 
     Ok(())
 }
 
-fn send_rpc_req(mut stream: TcpStream, req: RpcMsgReq) -> Result<(), MakerError> {
+fn send_rpc_req(
+    mut stream: TcpStream,
+    rpc_cookie: &str,
+    request: RpcMsgReq,
+) -> Result<(), MakerError> {
     // stream.set_read_timeout(Some(Duration::from_secs(20)))?;
     stream.set_write_timeout(Some(Duration::from_secs(20)))?;
 
-    send_message(&mut stream, &req)?;
+    send_message(
+        &mut stream,
+        &AuthenticatedRpcRequest {
+            token: rpc_cookie.to_owned(),
+            request,
+        },
+    )?;
 
     let response_bytes = read_message(&mut stream)?;
     let response: RpcMsgResp = serde_cbor::from_slice(&response_bytes)?;

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -24,7 +24,7 @@ pub mod server;
 pub mod swap_tracker;
 
 pub use error::MakerError;
-pub use rpc::{RpcMsgReq, RpcMsgResp};
+pub use rpc::{AuthenticatedRpcRequest, RpcMsgReq, RpcMsgResp};
 
 #[cfg(feature = "integration-test")]
 pub use api::MakerBehavior;

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -8,6 +8,15 @@ use std::path::PathBuf;
 
 use crate::wallet::Balances;
 
+/// An RPC request authenticated with the cookie owned by `makerd`.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AuthenticatedRpcRequest {
+    /// Authentication token read from the maker data directory.
+    pub token: String,
+    /// Requested operation.
+    pub request: RpcMsgReq,
+}
+
 /// Enum representing RPC message requests.
 ///
 /// These messages are used for various operations in the Maker-rpc communication.

--- a/src/maker/rpc/mod.rs
+++ b/src/maker/rpc/mod.rs
@@ -1,4 +1,4 @@
 mod messages;
 pub mod server;
 
-pub use messages::{RpcMsgReq, RpcMsgResp};
+pub use messages::{AuthenticatedRpcRequest, RpcMsgReq, RpcMsgResp};

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -79,8 +79,8 @@ fn handle_request<M: MakerRpc>(
         Ok(envelope) if cookie_matches(&envelope.token, rpc_cookie) => envelope,
         _ => {
             log::warn!(
-                "Rejected unauthenticated RPC request from {:?}",
-                socket.peer_addr()
+                "Rejected unauthenticated RPC request from {}",
+                socket.peer_addr().unwrap()
             );
             send_message(socket, &RpcMsgResp::ServerError("unauthorized".to_string()))?;
             return Ok(());
@@ -266,6 +266,12 @@ pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerEr
         }
 
         sleep(HEART_BEAT_INTERVAL);
+    }
+
+    if let Err(e) = fs::remove_file(maker.data_dir().join(RPC_COOKIE_FILE)) {
+        if e.kind() != ErrorKind::NotFound {
+            log::warn!("Failed to remove RPC cookie during shutdown: {e}");
+        }
     }
 
     Ok(())

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -1,5 +1,6 @@
 use std::{
-    io::ErrorKind,
+    fs::{self, OpenOptions},
+    io::{ErrorKind, Write},
     net::{TcpListener, TcpStream},
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
@@ -9,9 +10,12 @@ use std::{
     time::Duration,
 };
 
-use bitcoin::Amount;
+use bitcoin::{
+    secp256k1::rand::{rngs::OsRng, RngCore},
+    Amount,
+};
 
-use super::messages::RpcMsgReq;
+use super::messages::{AuthenticatedRpcRequest, RpcMsgReq};
 #[cfg(not(feature = "integration-test"))]
 use crate::utill::TorError;
 use crate::{
@@ -20,6 +24,41 @@ use crate::{
     wallet::{infer_address_type, AddressType, Destination, Wallet},
 };
 use std::{path::Path, sync::RwLock};
+
+const RPC_COOKIE_FILE: &str = "rpc_cookie";
+
+fn write_rpc_cookie(data_dir: &Path) -> Result<String, MakerError> {
+    let mut bytes = [0_u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    let token: String = bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(data_dir.join(RPC_COOKIE_FILE))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(token.as_bytes())?;
+    file.sync_all()?;
+    Ok(token)
+}
+
+fn cookie_matches(provided: &str, expected: &str) -> bool {
+    provided.len() == expected.len()
+        && provided
+            .bytes()
+            .zip(expected.bytes())
+            .fold(0_u8, |diff, (a, b)| diff | (a ^ b))
+            == 0
+}
 
 pub trait MakerRpc {
     fn wallet(&self) -> &RwLock<Wallet>;
@@ -30,9 +69,24 @@ pub trait MakerRpc {
     fn get_tor_hostname(&self) -> Result<String, TorError>;
 }
 
-fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result<(), MakerError> {
+fn handle_request<M: MakerRpc>(
+    maker: &Arc<M>,
+    socket: &mut TcpStream,
+    rpc_cookie: &str,
+) -> Result<(), MakerError> {
     let msg_bytes = read_message(socket)?;
-    let rpc_request: RpcMsgReq = serde_cbor::from_slice(&msg_bytes)?;
+    let envelope = match serde_cbor::from_slice::<AuthenticatedRpcRequest>(&msg_bytes) {
+        Ok(envelope) if cookie_matches(&envelope.token, rpc_cookie) => envelope,
+        _ => {
+            log::warn!(
+                "Rejected unauthenticated RPC request from {:?}",
+                socket.peer_addr()
+            );
+            send_message(socket, &RpcMsgResp::ServerError("unauthorized".to_string()))?;
+            return Ok(());
+        }
+    };
+    let rpc_request = envelope.request;
     log::info!("RPC request received: {rpc_request:?}");
 
     let resp = match rpc_request {
@@ -173,6 +227,7 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
 pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerError> {
     let rpc_port = maker.config().rpc_port;
     let listener = TcpListener::bind(("127.0.0.1", rpc_port))?;
+    let rpc_cookie = write_rpc_cookie(maker.data_dir())?;
     let rpc_socket = format!("127.0.0.1:{rpc_port}");
     let listener = Arc::new(listener);
     log::info!(
@@ -190,7 +245,7 @@ pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerEr
                 stream.set_read_timeout(Some(Duration::from_secs(20)))?;
                 stream.set_write_timeout(Some(Duration::from_secs(20)))?;
                 // Do not cause hard error if a rpc request fails
-                if let Err(e) = handle_request(&maker, &mut stream) {
+                if let Err(e) = handle_request(&maker, &mut stream, &rpc_cookie) {
                     log::error!("Error processing RPC Request: {e:?}");
                     // Send the error back to client.
                     if let Err(e) =
@@ -214,4 +269,31 @@ pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerEr
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_cookie_is_random_and_authenticated() {
+        let dir = bitcoind::tempfile::tempdir().unwrap();
+
+        let first = write_rpc_cookie(dir.path()).unwrap();
+        let second = write_rpc_cookie(dir.path()).unwrap();
+        assert_eq!(second.len(), 64);
+        assert_ne!(first, second);
+        assert!(cookie_matches(&second, &second));
+        assert!(!cookie_matches(&first, &second));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(dir.path().join(RPC_COOKIE_FILE))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request

## Description
 Adds cookie-based authentication to the `makerd` RPC control plane. `makerd` generates a fresh 256-bit cookie with owner-only permissions, while `maker-cli` reads it from the matching maker data directory and includes it with every request. Requests with missing or invalid authentication are rejected before privileged command dispatch. This keeps the change focused on authentication without introducing a new RPC API or configuration layer.

## Related Issue(s)
Fixes #877 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [x] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **signet**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cookie-based authentication for local RPC calls made by the CLI.
  * Added a `--data-directory` option to control where the RPC authentication cookie is read from.
  * RPC servers now generate, persist, and use a unique authentication cookie for connection validation.
* **Bug Fixes**
  * Unauthenticated RPC requests are now rejected with an authorization error.
  * Cookie files are written with restricted permissions to protect the token.
* **Tests**
  * Added coverage for cookie uniqueness, matching, and (on Unix) secure file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->