### PR TITLE
fix: reject unbound legacy proof-of-funding contracts

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1228,17 +1228,22 @@ impl MakerTrait for MakerServer {
             self.config.network_port,
         )?;
 
-        let mut sigs = Vec::new();
-
-        for txinfo in txs_info {
-            self.wallet
-                .write()
-                .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .cache_prevout_to_contract(
+        let bindings = txs_info
+            .iter()
+            .map(|txinfo| {
+                (
                     txinfo.senders_contract_tx.input[0].previous_output,
                     txinfo.senders_contract_tx.output[0].script_pubkey.clone(),
-                )?;
+                )
+            })
+            .collect::<Vec<_>>();
+        self.wallet
+            .write()
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?
+            .cache_prevout_to_contracts(&bindings)?;
 
+        let mut sigs = Vec::new();
+        for txinfo in txs_info {
             // Derive multisig privkey using the nonce
             let multisig_privkey = tweakable_privkey
                 .add_tweak(&txinfo.multisig_nonce.into())
@@ -1363,17 +1368,13 @@ impl MakerTrait for MakerServer {
             // Check that the provided contract matches the scriptpubkey from the cache
             let contract_spk = redeemscript_to_scriptpubkey(&funding_info.contract_redeemscript)?;
 
-            if !wallet_read.does_prevout_match_cached_contract(
+            wallet_read.ensure_prevout_matches_cached_contract(
                 &OutPoint {
                     txid: funding_txid,
                     vout: funding_output_index,
                 },
                 &contract_spk,
-            )? {
-                return Err(MakerError::General(
-                    "Provided contract does not match sender contract tx, rejecting",
-                ));
-            }
+            )?;
 
             // Extract and verify hashvalue
             let this_hashvalue = read_hashvalue_from_contract(&funding_info.contract_redeemscript)?;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -2586,4 +2586,7 @@ pub enum TakerBehavior {
     InvalidTaprootContractAmount,
     /// Close connection when receiving maker's contract data response (taproot taker abort).
     CloseAtSendersContractFromMaker,
+    /// Skip the Legacy sender-signature request, broadcast real funding, and
+    /// send ProofOfFunding directly (maker_rejects_proof_of_funding_with_missing_contract_cache).
+    SkipSenderContractSigs,
 }

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -266,7 +266,22 @@ impl Taker {
                 )
             };
 
-            if is_first_peer {
+            #[cfg(feature = "integration-test")]
+            let skip_sender_contract_sigs =
+                is_first_peer && self.behavior == super::api::TakerBehavior::SkipSenderContractSigs;
+            #[cfg(not(feature = "integration-test"))]
+            let skip_sender_contract_sigs = false;
+
+            if skip_sender_contract_sigs {
+                // IT path: leave the maker's prevout-to-contract map
+                // empty, but continue through real funding confirmation and
+                // ProofOfFunding construction to exercise its fail-closed check.
+                log::warn!(
+                    "Test behavior: skipping sender contract signature request before funding"
+                );
+            }
+
+            if is_first_peer && !skip_sender_contract_sigs {
                 log::info!(
                     "Step 1: Requesting sender contract signatures from maker {}",
                     maker_idx

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1039,33 +1039,24 @@ impl Wallet {
         })
     }
 
-    /// Checks if the previous output (prevout) matches the cached contract in the wallet.
+    /// Ensures a funding prevout is bound to the expected cached contract.
     ///
-    /// This function is used in two scenarios:
-    /// 1. When the Maker has received the message `signsendercontracttx`.
-    /// 2. When the Maker receives the message `proofoffunding`.
-    ///
-    /// ## Cases when receiving `signsendercontracttx`:
-    /// - Case 1: Previous output in cache doesn't have any contract => Ok
-    /// - Case 2: Previous output has a contract, and it matches the given contract => Ok
-    /// - Case 3: Previous output has a contract, but it doesn't match the given contract => Reject
-    ///
-    /// ## Cases when receiving `proofoffunding`:
-    /// - Case 1: Previous output doesn't have an entry => Weird, how did they get a signature?
-    /// - Case 2: Previous output has an entry that matches the contract => Ok
-    /// - Case 3: Previous output has an entry that doesn't match the contract => Reject
-    ///
-    /// The two cases are mostly the same, except for Case 1 in `proofoffunding`, which shouldn't happen.
-    pub(crate) fn does_prevout_match_cached_contract(
+    /// Proof-of-funding verification must fail closed when the binding is absent:
+    /// the maker only caches it after approving the sender contract transaction.
+    pub(crate) fn ensure_prevout_matches_cached_contract(
         &self,
         prevout: &OutPoint,
         contract_scriptpubkey: &Script,
-    ) -> Result<bool, WalletError> {
-        //let wallet_file_data = Wallet::load_wallet_file_data(&self.wallet_file_path[..])?;
-        Ok(match self.store.prevout_to_contract_map.get(prevout) {
-            Some(c) => c == contract_scriptpubkey,
-            None => true,
-        })
+    ) -> Result<(), WalletError> {
+        match self.store.prevout_to_contract_map.get(prevout) {
+            Some(cached_contract) if cached_contract == contract_scriptpubkey => Ok(()),
+            Some(_) => Err(WalletError::General(
+                "Provided contract does not match the cached sender contract".to_string(),
+            )),
+            None => Err(WalletError::General(format!(
+                "No cached sender contract for funding prevout {prevout}"
+            ))),
+        }
     }
 
     /// Dynamic address import count function. 10 for tests, 5000 for production.
@@ -1080,17 +1071,32 @@ impl Wallet {
         }
     }
 
-    /// Stores an entry into [`WalletStore`]'s prevout-to-contract map.
-    /// If the prevout already existed with a contract script, this will update the existing contract.
-    pub(crate) fn cache_prevout_to_contract(
+    /// Persistently binds funding prevouts to contracts after the maker approves them.
+    ///
+    /// The full batch is checked before mutation and saved with one disk write.
+    /// Repeating identical bindings is idempotent, but rebinding an outpoint to
+    /// a different contract is rejected because a signature may already exist.
+    pub(crate) fn cache_prevout_to_contracts(
         &mut self,
-        prevout: OutPoint,
-        contract: ScriptBuf,
+        bindings: &[(OutPoint, ScriptBuf)],
     ) -> Result<(), WalletError> {
-        if let Some(contract) = self.store.prevout_to_contract_map.insert(prevout, contract) {
-            log::warn!("Prevout to Contract map updated.\nExisting Contract: {contract}");
+        for (prevout, contract) in bindings {
+            if self
+                .store
+                .prevout_to_contract_map
+                .get(prevout)
+                .is_some_and(|cached_contract| cached_contract != contract)
+            {
+                return Err(WalletError::General(format!(
+                    "Refusing to rebind funding prevout {prevout} to a different contract"
+                )));
+            }
         }
-        Ok(())
+
+        self.store
+            .prevout_to_contract_map
+            .extend(bindings.iter().cloned());
+        self.save_to_disk()
     }
 
     //pub(crate) fn get_recovery_phrase_from_file()
@@ -2790,5 +2796,105 @@ impl Wallet {
                 thread::sleep(Duration::from_secs(1));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod prevout_contract_tests {
+    use super::*;
+    use bitcoind::tempfile::tempdir;
+
+    fn test_wallet(path: &Path) -> Wallet {
+        let master_key = Xpriv::new_master(bitcoin::Network::Regtest, &[42; 32]).unwrap();
+        let store = WalletStore::init(
+            "prevout-contract-test".to_string(),
+            path,
+            bitcoin::Network::Regtest,
+            master_key,
+            None,
+            &None,
+        )
+        .unwrap();
+
+        Wallet {
+            rpc: Client::try_from(&RPCConfig::default()).unwrap(),
+            wallet_file_path: path.to_path_buf(),
+            store,
+            store_enc_material: None,
+        }
+    }
+
+    #[test]
+    fn proof_of_funding_rejects_missing_cached_contract() {
+        let temp_dir = tempdir().unwrap();
+        let wallet = test_wallet(&temp_dir.path().join("wallet.cbor"));
+
+        let error = wallet
+            .ensure_prevout_matches_cached_contract(
+                &OutPoint::null(),
+                ScriptBuf::from_bytes(vec![0x51]).as_script(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            WalletError::General(message) if message.contains("No cached sender contract")
+        ));
+    }
+
+    #[test]
+    fn cached_contract_matches_only_the_approved_script() {
+        let temp_dir = tempdir().unwrap();
+        let mut wallet = test_wallet(&temp_dir.path().join("wallet.cbor"));
+        let prevout = OutPoint::null();
+        let approved_contract = ScriptBuf::from_bytes(vec![0x51]);
+        let different_contract = ScriptBuf::from_bytes(vec![0x52]);
+
+        wallet
+            .cache_prevout_to_contracts(&[(prevout, approved_contract.clone())])
+            .unwrap();
+
+        wallet
+            .ensure_prevout_matches_cached_contract(&prevout, approved_contract.as_script())
+            .unwrap();
+        assert!(wallet
+            .ensure_prevout_matches_cached_contract(&prevout, different_contract.as_script())
+            .is_err());
+    }
+
+    #[test]
+    fn cached_contract_is_idempotent_immutable_and_persistent() {
+        let temp_dir = tempdir().unwrap();
+        let wallet_path = temp_dir.path().join("wallet.cbor");
+        let mut wallet = test_wallet(&wallet_path);
+        let prevout = OutPoint::null();
+        let new_prevout = OutPoint {
+            txid: prevout.txid,
+            vout: 1,
+        };
+        let approved_contract = ScriptBuf::from_bytes(vec![0x51]);
+
+        wallet
+            .cache_prevout_to_contracts(&[(prevout, approved_contract.clone())])
+            .unwrap();
+        wallet
+            .cache_prevout_to_contracts(&[(prevout, approved_contract.clone())])
+            .unwrap();
+        assert!(wallet
+            .cache_prevout_to_contracts(&[
+                (new_prevout, ScriptBuf::from_bytes(vec![0x53])),
+                (prevout, ScriptBuf::from_bytes(vec![0x52])),
+            ])
+            .is_err());
+        assert!(!wallet
+            .store
+            .prevout_to_contract_map
+            .contains_key(&new_prevout));
+
+        let (reloaded_store, _) = WalletStore::read_from_disk(&wallet_path, String::new()).unwrap();
+        assert_eq!(
+            reloaded_store.prevout_to_contract_map.get(&prevout),
+            Some(&approved_contract)
+        );
     }
 }

--- a/tests/integration/legacy_missing_contract_cache.rs
+++ b/tests/integration/legacy_missing_contract_cache.rs
@@ -1,0 +1,128 @@
+//! Legacy proof-of-funding must fail closed when no sender-contract binding exists.
+//!
+//! Normally, `ReqContractSigsForSender` makes the first maker bind each funding
+//! outpoint to its approved contract before funding is broadcast.
+//!
+//! This test keeps both makers unmodified and makes a malicious taker:
+//! 1. Negotiate a normal two-maker Legacy swap.
+//! 2. Skip `ReqContractSigsForSender`, leaving maker 0's cache empty.
+//! 3. Confirm funding, then send valid transactions and SPV proofs to maker 0.
+//!
+//! The test asserts rejection, the operator-visible error, no maker outgoing
+//! broadcast, and unchanged maker liquidity.
+//! The taker intentionally gives up its recovery signature using disposable regtest funds.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+#[test]
+fn maker_rejects_proof_of_funding_with_missing_contract_cache() {
+    let makers_config_map = vec![(6102, None), (16102, None)];
+    let taker_behavior = vec![TakerBehavior::SkipSenderContractSigs];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+
+    let maker_spendable_before = makers[0]
+        .wallet
+        .read()
+        .unwrap()
+        .get_balances()
+        .unwrap()
+        .spendable;
+
+    let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_coinswap(swap_params)
+        .expect("prepare_coinswap should succeed");
+
+    let result = taker.start_coinswap(&summary.swap_id);
+    assert!(
+        result.is_err(),
+        "maker must reject ProofOfFunding without a cached contract binding"
+    );
+
+    // Assert both the adversarial action and the maker's fail-closed reason.
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    test_framework.assert_log(
+        "Test behavior: skipping sender contract signature request before funding",
+        &log_path,
+    );
+    test_framework.assert_log("No cached sender contract for funding prevout", &log_path);
+
+    // Rejection must happen before the maker reaches the outgoing broadcast
+    // boundary in process_resp_contract_sigs_for_recvr_and_sender.
+    let log_contents = std::fs::read_to_string(&log_path).unwrap();
+    assert!(
+        !log_contents.contains("SECURITY: Broadcasting"),
+        "maker must reject before broadcasting outgoing funding transactions"
+    );
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    makers[0].wallet.write().unwrap().sync_and_save().unwrap();
+    let maker_spendable_after = makers[0]
+        .wallet
+        .read()
+        .unwrap()
+        .get_balances()
+        .unwrap()
+        .spendable;
+    assert_eq!(
+        maker_spendable_after, maker_spendable_before,
+        "rejected proof must not spend maker liquidity"
+    );
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -37,6 +37,7 @@ mod funding_dynamic_splits;
 #[cfg(feature = "hotpath")]
 mod hotpath_profile;
 mod legacy_malformed_contract;
+mod legacy_missing_contract_cache;
 mod liquidity_test;
 mod offerbook_sync_race;
 mod taker_cli;


### PR DESCRIPTION
# Pull Request

## Description
Previously, `does_prevout_match_cached_contract` returned `true` even when no contract was stored for the given funding outpoint. During Legacy proof-of-funding checks, this meant a missing contract binding was incorrectly treated as a valid match. A malicious taker could use this to submit confirmed funding for a contract that the maker had never approved.

This change makes the check fail safely. Missing or incorrect bindings are now rejected. Bindings are stored before signatures are returned, repeated requests with the same contract are allowed, and an outpoint cannot later be linked to a different contract.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):


## Protocol Version(s) Affected
- [x] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)


## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Strengthened funding verification to reject transactions when required contract bindings are missing or mismatched.
  * Prevented conflicting contract reassignment and ensured contract bindings are safely persisted.

* **Bug Fixes**
  * Improved legacy contract-signing workflows through consistent batch processing.

* **Tests**
  * Added coverage confirming invalid funding proofs are rejected before broadcasts occur.
  * Added tests for contract-binding persistence, immutability, and reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->