### PR TITLE
Improve concurrent Legacy and Taproot swap handling

### DIFF
--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -384,6 +384,9 @@ pub fn handle_message<M: Maker>(
                 maker.network_port(),
                 id
             );
+            if let Some(stored_state) = maker.get_connection_state(id) {
+                maker.store_connection_state(id, &stored_state)?;
+            }
             state.touch();
             Ok(None)
         }
@@ -544,6 +547,21 @@ fn restore_state_if_needed<M: Maker>(maker: &Arc<M>, state: &mut ConnectionState
     }
 }
 
+/// Ensure a protocol-specific message matches the protocol negotiated for this swap.
+fn ensure_negotiated_protocol(
+    state: &ConnectionState,
+    message_protocol: ProtocolVersion,
+) -> Result<(), MakerError> {
+    if state.protocol != message_protocol {
+        return Err(MakerError::UnexpectedMessage {
+            expected: format!("{:?} protocol message", state.protocol),
+            got: format!("{:?} protocol message", message_protocol),
+        });
+    }
+
+    Ok(())
+}
+
 /// Dispatch to Legacy handlers.
 #[hotpath::measure]
 fn handle_legacy_dispatch<M: Maker>(
@@ -561,6 +579,7 @@ fn handle_legacy_dispatch<M: Maker>(
     );
 
     restore_state_if_needed(maker, state, &swap_id);
+    ensure_negotiated_protocol(state, ProtocolVersion::Legacy)?;
 
     super::legacy_handlers::handle_legacy_message(maker, state, legacy_msg)
 }
@@ -582,6 +601,7 @@ fn handle_taproot_dispatch<M: Maker>(
     );
 
     restore_state_if_needed(maker, state, &swap_id);
+    ensure_negotiated_protocol(state, ProtocolVersion::Taproot)?;
 
     super::taproot_handlers::handle_taproot_message(maker, state, taproot_msg)
 }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -372,6 +372,13 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
         }
 
         if state.phase == super::handlers::SwapPhase::Completed {
+            // Remove the completed in-memory state before slow wallet sweeping/syncing.
+            // Otherwise the idle checker can race the sweep and launch recovery for
+            // a swap that has already completed successfully.
+            if let Some(ref swap_id) = state.swap_id {
+                maker.remove_connection_state(swap_id);
+            }
+
             log::info!(
                 "[{}] Swap completed, sweeping incoming swapcoins",
                 maker.config.network_port
@@ -411,10 +418,6 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
                         vout: vout as u32,
                     });
                 }
-            }
-
-            if let Some(ref swap_id) = state.swap_id {
-                maker.remove_connection_state(swap_id);
             }
 
             #[cfg(feature = "hotpath")]

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -82,6 +82,12 @@ pub enum ConnectionType {
 /// Timeout for connecting to makers.
 pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 
+/// Keep active funding waits comfortably below the maker's idle timeout.
+#[cfg(feature = "integration-test")]
+pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+#[cfg(not(feature = "integration-test"))]
+pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(300);
+
 /// Base refund locktime (in blocks) for the innermost hop.
 ///
 /// In integration tests the idle-connection timeout fires after ~200 blocks

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1,6 +1,9 @@
 //! Legacy (ECDSA) specific swap methods for the Taker.
 
-use std::time::Duration;
+use std::{
+    cell::Cell,
+    time::{Duration, Instant},
+};
 
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
@@ -30,7 +33,10 @@ use crate::{
     },
 };
 
-use super::{api::Taker, error::TakerError};
+use super::{
+    api::{Taker, FUNDING_KEEPALIVE_INTERVAL},
+    error::TakerError,
+};
 
 /// Delay to allow the Maker to broadcast its funding transactions before we poll.
 const MAKER_BROADCAST_DELAY: Duration = Duration::from_secs(2);
@@ -638,10 +644,40 @@ impl Taker {
                 .collect();
 
             let required_confirms = self.swap_state()?.params.required_confirms;
+            // Legacy may wait longer than the maker's idle timeout for funding
+            // confirmations. Keep this swap alive so the maker does not mistake
+            // it for a dropped taker and start contract recovery.
+            let mut keepalive_stream = self.net_connect(&maker_address)?;
+            self.net_handshake(&mut keepalive_stream)?;
+            let keepalive_stream = std::cell::RefCell::new(keepalive_stream);
+            let last_keepalive = Cell::new(Instant::now());
+            let keepalive_failed = Cell::new(false);
             let abort_check = || {
-                self.breach_detector
+                if keepalive_failed.get() {
+                    return true;
+                }
+
+                let breached = self
+                    .breach_detector
                     .as_ref()
-                    .is_some_and(|d| d.is_breached())
+                    .is_some_and(|d| d.is_breached());
+                if !breached && last_keepalive.get().elapsed() >= FUNDING_KEEPALIVE_INTERVAL {
+                    if let Err(error) = send_message(
+                        &mut keepalive_stream.borrow_mut(),
+                        &TakerToMakerMessage::WaitingFundingConfirmation(swap_id.clone()),
+                    ) {
+                        log::error!(
+                            "Maker closed keepalive connection during funding wait: {:?}",
+                            error
+                        );
+                        // Do not mask a confirmation that may already be visible
+                        // in this polling iteration; interrupt on the next check.
+                        keepalive_failed.set(true);
+                        return false;
+                    }
+                    last_keepalive.set(Instant::now());
+                }
+                breached
             };
             let maker_confirm_height = {
                 let wallet = self.read_wallet()?;
@@ -652,6 +688,11 @@ impl Taker {
                     Some(&abort_check),
                 ) {
                     Ok(h) => h,
+                    Err(crate::wallet::WalletError::Interrupted(_)) if keepalive_failed.get() => {
+                        return Err(TakerError::General(
+                            "Maker closed keepalive connection during funding wait".to_string(),
+                        ));
+                    }
                     Err(crate::wallet::WalletError::Interrupted(_)) => {
                         return Err(TakerError::ContractsBroadcasted(vec![]));
                     }

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -21,7 +21,11 @@ use crate::{
     },
 };
 
-use super::{api::Taker, error::TakerError, swap_tracker::SwapPhase};
+use super::{
+    api::{Taker, FUNDING_KEEPALIVE_INTERVAL},
+    error::TakerError,
+    swap_tracker::SwapPhase,
+};
 
 impl Taker {
     /// Build contract data from a previous maker's response (for forwarding to the next maker).
@@ -750,7 +754,7 @@ impl Taker {
                 )));
             }
 
-            std::thread::sleep(crate::utill::HEART_BEAT_INTERVAL);
+            std::thread::sleep(FUNDING_KEEPALIVE_INTERVAL);
         }
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod fidelity;
 mod fidelity_renewal;
 mod malice1;
 mod malice2;
+mod mixed_protocol_concurrent_swaps;
 mod multi_taker;
 mod skip_funding_recovery;
 mod standard_swap;

--- a/tests/integration/mixed_protocol_concurrent_swaps.rs
+++ b/tests/integration/mixed_protocol_concurrent_swaps.rs
@@ -1,0 +1,262 @@
+//! Concurrent mixed-protocol integration test.
+//!
+//! Two takers use the same two makers at the same time: one swap uses Legacy
+//! and the other uses Taproot. This verifies that makers keep protocol state
+//! isolated per swap instead of treating the negotiated protocol as a
+//! maker-wide setting.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::start_server,
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use log::{info, warn};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering::Relaxed},
+        Arc, Barrier,
+    },
+    thread,
+};
+
+#[test]
+fn test_concurrent_legacy_and_taproot_swaps() {
+    warn!("Running Test: Concurrent Legacy and Taproot swaps through the same makers");
+
+    let (test_framework, mut takers, makers, block_generation_handle) = TestFramework::init(
+        vec![(8002, Some(21001)), (18002, Some(21002))],
+        vec![TakerBehavior::Normal, TakerBehavior::Normal],
+        vec![],
+    );
+    let bitcoind = &test_framework.bitcoind;
+
+    let taker_original_balances = takers
+        .iter()
+        .map(|taker| {
+            fund_taker(
+                taker,
+                bitcoind,
+                3,
+                Amount::from_btc(0.05).unwrap(),
+                AddressType::P2TR,
+            )
+        })
+        .collect::<Vec<_>>();
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+    let maker_original_balances = verify_maker_pre_swap_balances(&makers);
+    generate_blocks(bitcoind, 1);
+
+    let start = Arc::new(Barrier::new(2));
+    let legacy_succeeded = AtomicBool::new(false);
+    let taproot_succeeded = AtomicBool::new(false);
+
+    thread::scope(|scope| {
+        let (legacy_takers, taproot_takers) = takers.split_at_mut(1);
+        let legacy_taker = &mut legacy_takers[0];
+        let taproot_taker = &mut taproot_takers[0];
+
+        let legacy_start = start.clone();
+        let legacy_result = &legacy_succeeded;
+        scope.spawn(move || {
+            legacy_start.wait();
+            info!("Starting Legacy swap concurrently");
+
+            let params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 2)
+                .with_tx_count(3)
+                .with_required_confirms(1);
+            let result = legacy_taker
+                .prepare_coinswap(params)
+                .and_then(|summary| legacy_taker.start_coinswap(&summary.swap_id));
+
+            match result {
+                Ok(report) => {
+                    info!("Concurrent Legacy swap completed: {:?}", report);
+                    legacy_result.store(true, Relaxed);
+                }
+                Err(error) => warn!("Concurrent Legacy swap failed: {:?}", error),
+            }
+        });
+
+        let taproot_start = start.clone();
+        let taproot_result = &taproot_succeeded;
+        scope.spawn(move || {
+            taproot_start.wait();
+            info!("Starting Taproot swap concurrently");
+
+            let params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(700_000), 2)
+                .with_tx_count(3)
+                .with_required_confirms(1);
+            let result = taproot_taker
+                .prepare_coinswap(params)
+                .and_then(|summary| taproot_taker.start_coinswap(&summary.swap_id));
+
+            match result {
+                Ok(report) => {
+                    info!("Concurrent Taproot swap completed: {:?}", report);
+                    taproot_result.store(true, Relaxed);
+                }
+                Err(error) => warn!("Concurrent Taproot swap failed: {:?}", error),
+            }
+        });
+    });
+
+    assert!(
+        legacy_succeeded.load(Relaxed),
+        "Legacy swap should succeed while the makers also process a Taproot swap"
+    );
+    assert!(
+        taproot_succeeded.load(Relaxed),
+        "Taproot swap should succeed while the makers also process a Legacy swap"
+    );
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+
+    let expected_taker_regular = [14_499_076, 14_299_076];
+    let expected_taker_swap = [494_587, 694_992];
+    let expected_taker_fees = [6_337, 5_932];
+
+    for (i, (taker, original_balance)) in takers
+        .iter()
+        .zip(taker_original_balances.iter())
+        .enumerate()
+    {
+        taker.get_wallet().write().unwrap().sync_and_save().unwrap();
+        let balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
+
+        info!(
+            "Taker {} final balances: Regular: {}, Swap: {}, Contract: {}, Fidelity: {}, Spendable: {}",
+            i,
+            balances.regular,
+            balances.swap,
+            balances.contract,
+            balances.fidelity,
+            balances.spendable,
+        );
+
+        assert_eq!(
+            balances.regular.to_sat(),
+            expected_taker_regular[i],
+            "Taker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_taker_swap[i],
+            "Taker {} swap balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.contract,
+            Amount::ZERO,
+            "Taker {} contract balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.fidelity,
+            Amount::ZERO,
+            "Taker {} fidelity balance mismatch",
+            i
+        );
+        assert_eq!(
+            original_balance
+                .checked_sub(balances.spendable)
+                .unwrap()
+                .to_sat(),
+            expected_taker_fees[i],
+            "Taker {} spendable balance change mismatch",
+            i
+        );
+    }
+
+    generate_blocks(bitcoind, 1);
+    let expected_maker_regular = [13_802_109, 13_806_515];
+    let expected_maker_swap = [1_198_428, 1_193_985];
+    let expected_maker_earnings = [1_023, 986];
+
+    for (i, (maker, original_balance)) in makers
+        .iter()
+        .zip(maker_original_balances.iter())
+        .enumerate()
+    {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+        let balances = maker.wallet.read().unwrap().get_balances().unwrap();
+
+        info!(
+            "Maker {} final balances: Regular: {}, Swap: {}, Contract: {}, Fidelity: {}, Spendable: {}",
+            i,
+            balances.regular,
+            balances.swap,
+            balances.contract,
+            balances.fidelity,
+            balances.spendable,
+        );
+
+        assert_eq!(
+            balances.regular.to_sat(),
+            expected_maker_regular[i],
+            "Maker {} regular balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.swap.to_sat(),
+            expected_maker_swap[i],
+            "Maker {} swap balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.contract,
+            Amount::ZERO,
+            "Maker {} contract balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances.fidelity,
+            Amount::from_btc(0.05).unwrap(),
+            "Maker {} fidelity balance mismatch",
+            i
+        );
+        assert_eq!(
+            balances
+                .spendable
+                .checked_sub(*original_balance)
+                .unwrap()
+                .to_sat(),
+            expected_maker_earnings[i],
+            "Maker {} earnings mismatch",
+            i
+        );
+    }
+
+    drop(takers);
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}


### PR DESCRIPTION
# Pull Request

## Description
- Maker: enforce each swap’s negotiated protocol before dispatch and prevent completed swaps from racing idle recovery.
- Taker: keep Legacy and Taproot funding-confirmation waits active using appropriately timed keepalives.
- Tests: add a concurrent two-taker/two-maker Legacy and Taproot integration test.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added periodic keepalive messages during maker funding confirmation, with timing adjusted for integration testing vs production.

- **Bug Fixes**
  - Added protocol validation to abort dispatch when messages don’t match the negotiated swap protocol.
  - Improved state handling during funding confirmation and when waiting on keeper messages.
  - Cleaned up completed-swap connection state earlier to reduce recovery races.

- **Tests**
  - Added integration coverage for concurrent Legacy and Taproot swaps executed in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->