### PR TITLE
fix: reject duplicate funding proofs in legacy and taproot swaps

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1289,6 +1289,7 @@ impl MakerTrait for MakerServer {
         };
         use bitcoin::{hashes::Hash, OutPoint};
         use bitcoind::bitcoincore_rpc::RpcApi;
+        use std::collections::HashSet;
 
         log::info!(
             "[{}] Verifying proof of funding for swap {}",
@@ -1302,6 +1303,9 @@ impl MakerTrait for MakerServer {
 
         let min_reaction_time = MIN_CONTRACT_REACTION_TIME;
         let mut hashvalue: Option<crate::protocol::Hash160> = None;
+        // Each proof can be valid on its own, but repeating one outpoint makes the
+        // maker count the same incoming value twice and fund excess outgoing value.
+        let mut seen_outpoints = HashSet::with_capacity(message.confirmed_funding_txes.len());
 
         for funding_info in &message.confirmed_funding_txes {
             // Check that the new locktime is sufficiently short enough
@@ -1325,6 +1329,13 @@ impl MakerTrait for MakerServer {
                 as u32;
 
             let funding_txid = funding_info.funding_tx.compute_txid();
+            let funding_outpoint = OutPoint {
+                txid: funding_txid,
+                vout: funding_output_index,
+            };
+            if !seen_outpoints.insert(funding_outpoint) {
+                return Err(MakerError::General("Duplicate funding outpoint"));
+            }
 
             // Check the funding_tx is confirmed to required depth
             let wallet_read = self
@@ -1368,13 +1379,7 @@ impl MakerTrait for MakerServer {
             // Check that the provided contract matches the scriptpubkey from the cache
             let contract_spk = redeemscript_to_scriptpubkey(&funding_info.contract_redeemscript)?;
 
-            wallet_read.ensure_prevout_matches_cached_contract(
-                &OutPoint {
-                    txid: funding_txid,
-                    vout: funding_output_index,
-                },
-                &contract_spk,
-            )?;
+            wallet_read.ensure_prevout_matches_cached_contract(&funding_outpoint, &contract_spk)?;
 
             // Extract and verify hashvalue
             let this_hashvalue = read_hashvalue_from_contract(&funding_info.contract_redeemscript)?;

--- a/src/maker/taproot_verification.rs
+++ b/src/maker/taproot_verification.rs
@@ -3,7 +3,9 @@
 //! Verifies taker messages received during the Taproot swap flow, mirroring
 //! the taker's `taproot_verification.rs` but from the maker's perspective.
 
-use bitcoin::{secp256k1::Secp256k1, PublicKey};
+use std::collections::HashSet;
+
+use bitcoin::{secp256k1::Secp256k1, OutPoint, PublicKey};
 
 use crate::{
     protocol::{
@@ -86,6 +88,16 @@ pub(crate) fn verify_taproot_contract_data(
         return Err(MakerError::General(
             "Taproot per-contract vectors have inconsistent lengths",
         ));
+    }
+
+    // Individually valid duplicate contracts would inflate total incoming value,
+    // causing the maker to allocate outgoing funds that the taker never provided.
+    let mut seen_outpoints = HashSet::with_capacity(data.contract_txs.len());
+    for tx in &data.contract_txs {
+        let contract_outpoint = OutPoint::new(tx.compute_txid(), 0);
+        if !seen_outpoints.insert(contract_outpoint) {
+            return Err(MakerError::General("Duplicate Taproot contract outpoint"));
+        }
     }
 
     let secp = Secp256k1::verification_only();
@@ -413,6 +425,23 @@ mod tests {
         data.amounts[0] += Amount::from_sat(1);
 
         assert!(verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_contract_outpoints() {
+        let mut data = valid_contract_data();
+        data.pubkeys.push(data.pubkeys[0]);
+        data.internal_keys.push(data.internal_keys[0]);
+        data.tap_tweaks.push(data.tap_tweaks[0].clone());
+        data.timelock_scripts.push(data.timelock_scripts[0].clone());
+        data.contract_txs.push(data.contract_txs[0].clone());
+        data.amounts.push(data.amounts[0]);
+
+        let error = verify_taproot_contract_data(&data, MAKER_TIMELOCK, 0).unwrap_err();
+        assert!(matches!(
+            error,
+            MakerError::General("Duplicate Taproot contract outpoint")
+        ));
     }
 
     #[test]

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -2590,6 +2590,8 @@ pub enum TakerBehavior {
     CloseAtSendersContract,
     /// Send a Taproot contract amount that does not match the transaction output.
     InvalidTaprootContractAmount,
+    /// Repeat the same incoming funding outpoint in the maker request.
+    DuplicateFundingOutpoint,
     /// Close connection when receiving maker's contract data response (taproot taker abort).
     CloseAtSendersContractFromMaker,
     /// Skip the Legacy sender-signature request, broadcast real funding, and

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1019,6 +1019,19 @@ impl Taker {
                 .collect::<Result<Vec<_>, TakerError>>()?
         };
 
+        #[cfg(feature = "integration-test")]
+        let mut confirmed_funding_txes = confirmed_funding_txes;
+        #[cfg(feature = "integration-test")]
+        if self.behavior == super::api::TakerBehavior::DuplicateFundingOutpoint {
+            if let Some(first) = confirmed_funding_txes.first().cloned() {
+                log::warn!(
+                    "Test behavior: duplicating funding outpoint in ProofOfFunding for maker {}",
+                    maker_idx
+                );
+                confirmed_funding_txes.push(first);
+            }
+        }
+
         let next_coinswap_info: Vec<NextHopInfo> = next_multisig_pubkeys
             .iter()
             .zip(next_hashlock_pubkeys.iter())

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -257,12 +257,51 @@ impl Taker {
             };
 
             #[cfg(feature = "integration-test")]
-            let amounts =
+            let (pubkeys, timelock_scripts, internal_keys, tap_tweaks, contract_txs, amounts) = {
+                let (
+                    mut pubkeys,
+                    mut timelock_scripts,
+                    mut internal_keys,
+                    mut tap_tweaks,
+                    mut contract_txs,
+                    mut amounts,
+                ) = (
+                    pubkeys,
+                    timelock_scripts,
+                    internal_keys,
+                    tap_tweaks,
+                    contract_txs,
+                    amounts,
+                );
+
+                if self.behavior == super::api::TakerBehavior::DuplicateFundingOutpoint {
+                    if let Some(first) = contract_txs.first().cloned() {
+                        log::warn!(
+                            "Test behavior: duplicating Taproot contract outpoint for maker {}",
+                            i
+                        );
+                        pubkeys.push(pubkeys[0]);
+                        timelock_scripts.push(timelock_scripts[0].clone());
+                        internal_keys.push(internal_keys[0]);
+                        tap_tweaks.push(tap_tweaks[0].clone());
+                        contract_txs.push(first);
+                        amounts.push(amounts[0]);
+                    }
+                }
+
                 if self.behavior == super::api::TakerBehavior::InvalidTaprootContractAmount {
-                    vec![Amount::from_sat(50_000); amounts.len()]
-                } else {
-                    amounts
-                };
+                    amounts = vec![Amount::from_sat(50_000); amounts.len()];
+                }
+
+                (
+                    pubkeys,
+                    timelock_scripts,
+                    internal_keys,
+                    tap_tweaks,
+                    contract_txs,
+                    amounts,
+                )
+            };
 
             let secp = Secp256k1::new();
             let my_privkey = SecretKey::new(&mut OsRng);

--- a/tests/integration/duplicate_funding_outpoint.rs
+++ b/tests/integration/duplicate_funding_outpoint.rs
@@ -1,0 +1,122 @@
+//! A malicious taker can repeat one or more valid on-chain output and its matching
+//! metadata. Without an explicit uniqueness check, each entry passes individual
+//! verification and the maker counts the same value twice when funding the next
+//! hop. The rejection must therefore happen before the maker creates or
+//! broadcasts any outgoing funding transaction.
+
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+#[test]
+fn makers_reject_duplicate_funding_outpoints() {
+    let makers_config_map = vec![(8802, Some(21301)), (18802, Some(21302))];
+    let taker_behaviors = vec![
+        TakerBehavior::DuplicateFundingOutpoint,
+        TakerBehavior::DuplicateFundingOutpoint,
+    ];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init(makers_config_map, taker_behaviors, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    for taker in &mut takers {
+        fund_taker(
+            taker,
+            bitcoind,
+            3,
+            Amount::from_btc(0.05).unwrap(),
+            AddressType::P2TR,
+        );
+    }
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker.wallet.write().unwrap().sync_and_save().unwrap();
+    }
+    generate_blocks(bitcoind, 1);
+
+    // The Legacy behavior repeats one complete FundingTxInfo entry in
+    // ProofOfFunding, causing two entries to reference the same txid:vout.
+    let legacy_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    let legacy_summary = takers[0]
+        .prepare_coinswap(legacy_params)
+        .expect("Legacy prepare_coinswap should succeed");
+    assert!(
+        takers[0].start_coinswap(&legacy_summary.swap_id).is_err(),
+        "Legacy maker must reject a duplicated funding outpoint"
+    );
+
+    // The Taproot behavior repeats one contract transaction together with all
+    // aligned per-contract vectors, so length and script checks still pass.
+    let taproot_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    let taproot_summary = takers[1]
+        .prepare_coinswap(taproot_params)
+        .expect("Taproot prepare_coinswap should succeed");
+    assert!(
+        takers[1].start_coinswap(&taproot_summary.swap_id).is_err(),
+        "Taproot maker must reject a duplicated contract outpoint"
+    );
+
+    // Assert both the taker side duplicate contract passing and the maker-side rejection.
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    test_framework.assert_log(
+        "Test behavior: duplicating funding outpoint in ProofOfFunding",
+        &log_path,
+    );
+    test_framework.assert_log("Duplicate funding outpoint", &log_path);
+    test_framework.assert_log(
+        "Test behavior: duplicating Taproot contract outpoint",
+        &log_path,
+    );
+    test_framework.assert_log("Duplicate Taproot contract outpoint", &log_path);
+
+    let log_contents = std::fs::read_to_string(&log_path).unwrap();
+    assert!(
+        !log_contents.contains("SECURITY: Broadcasting"),
+        "Legacy maker must reject before broadcasting outgoing funding"
+    );
+    assert!(
+        !log_contents.contains("Broadcast Taproot contract tx"),
+        "Taproot maker must reject before broadcasting outgoing funding"
+    );
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    drop(takers);
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -33,6 +33,7 @@ mod taproot_timelock_recovery;
 mod wallet_backup;
 
 mod concurrent_takers;
+mod duplicate_funding_outpoint;
 mod fidelity_timelock_violation;
 mod funding_dynamic_splits;
 #[cfg(feature = "hotpath")]


### PR DESCRIPTION
# Pull Request

## Description

Reject duplicate funding outpoints submitted by malicious takers in both Legacy and Taproot swaps.

Adds integration-only taker behavior and coverage verifying that makers reject duplicate proofs before creating or broadcasting outgoing funding transactions.

## Related Issue(s)
Fixes #950 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):


## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Coinswap proof verification to reject duplicate funding outpoints during legacy proof-of-funding checks.
  - Added stricter validation to reject duplicate Taproot contract outpoints in Taproot contract data.
  - Ensures swaps fail early (before any funding-related broadcast) for both Legacy and Taproot.
- **Tests**
  - Added an integration regression test covering the duplicate-outpoint scenario across both protocol variants, asserting early rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->