### PR TITLE
fix: restore refund_locktime_offset in maker reconnect state

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -18,6 +18,7 @@ use bitcoind::bitcoincore_rpc::RpcApi;
 use crate::{
     nostr_coinswap::NOSTR_RELAYS,
     protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
+    taker::api::REFUND_LOCKTIME_STEP,
     utill::{get_maker_dir, parse_field, parse_toml, MIN_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
@@ -70,6 +71,9 @@ struct SwapState {
     last_activity: Instant,
     /// Time when this swap was accepted by the maker.
     swap_start_time: Instant,
+    /// How many blocks the funds stay locked, derived from `timelock` when the swap was
+    /// accepted. This value is persisted across connection so swap fee calculation remains consistent.
+    refund_locktime_offset: u16,
 }
 
 impl Default for SwapState {
@@ -88,6 +92,7 @@ impl Default for SwapState {
             reserve_utxo: Vec::new(),
             last_activity: Instant::now(),
             swap_start_time: Instant::now(),
+            refund_locktime_offset: 0,
         }
     }
 }
@@ -826,7 +831,7 @@ impl MakerTrait for MakerServer {
     }
 
     #[hotpath::measure]
-    fn validate_swap_parameters(&self, details: &SwapDetails) -> Result<(), MakerError> {
+    fn validate_swap_parameters(&self, details: &SwapDetails) -> Result<u16, MakerError> {
         use super::handlers::MIN_CONTRACT_REACTION_TIME;
 
         let config = self.get_config();
@@ -861,8 +866,9 @@ impl MakerTrait for MakerServer {
             }
         }
 
-        // Check timelock bounds
-        if details.protocol_version == ProtocolVersion::Legacy {
+        // Check timelock bounds and work out how long the funds stay locked. Taproot reads the
+        // tip once for both, so a block arriving mid-check cannot price the swap differently.
+        let locked_blocks = if details.protocol_version == ProtocolVersion::Legacy {
             if details.timelock < MIN_CONTRACT_REACTION_TIME as u32 {
                 log::warn!(
                     "Legacy timelock {} is below minimum reaction time {}",
@@ -873,11 +879,30 @@ impl MakerTrait for MakerServer {
                     "Legacy timelock is below minimum reaction time",
                 ));
             }
-        } else if details.timelock == 0 {
-            return Err(MakerError::General("Taproot timelock is zero"));
+            details.timelock
+        } else {
+            let current_height = self.get_current_height()?;
+            if details.timelock.saturating_add(REFUND_LOCKTIME_STEP as u32)
+                < current_height.saturating_add(MIN_CONTRACT_REACTION_TIME as u32)
+            {
+                log::error!(
+                    "Taproot timelock {} leaves less than {} blocks of reaction time at height {}",
+                    details.timelock,
+                    MIN_CONTRACT_REACTION_TIME,
+                    current_height
+                );
+                return Err(MakerError::General(
+                    "Taproot timelock leaves too little contract reaction time",
+                ));
+            }
+            details.timelock.saturating_sub(current_height)
+        };
+
+        if locked_blocks == 0 || locked_blocks > u16::MAX as u32 {
+            return Err(MakerError::General("Swap timelock out of range"));
         }
 
-        Ok(())
+        Ok(locked_blocks as u16)
     }
 
     fn calculate_swap_fee(&self, amount: Amount, timelock: u32) -> Amount {
@@ -1151,6 +1176,7 @@ impl MakerTrait for MakerServer {
         swap_state.reserve_utxo = state.reserve_utxo.clone();
         swap_state.last_activity = Instant::now();
         swap_state.swap_start_time = state.swap_start_time;
+        swap_state.refund_locktime_offset = state.refund_locktime_offset;
         log::debug!(
             "[{}] Stored connection state for {}: amount={}, timelock={}, protocol={:?}, outgoing_count={}",
             self.config.network_port,
@@ -1180,6 +1206,7 @@ impl MakerTrait for MakerServer {
             state.service_fee_sats = s.service_fee_sats;
             state.reserve_utxo = s.reserve_utxo.clone();
             state.swap_start_time = s.swap_start_time;
+            state.refund_locktime_offset = s.refund_locktime_offset;
             state
         })
     }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -205,8 +205,8 @@ pub trait Maker: Send + Sync {
     /// Get maker configuration values.
     fn get_config(&self) -> MakerConfig;
 
-    /// Validate swap parameters.
-    fn validate_swap_parameters(&self, details: &SwapDetails) -> Result<(), MakerError>;
+    /// Validate swap parameters and return how many blocks the funds stay locked.
+    fn validate_swap_parameters(&self, details: &SwapDetails) -> Result<u16, MakerError>;
 
     /// Calculate the swap fee.
     fn calculate_swap_fee(&self, amount: Amount, timelock: u32) -> Amount;
@@ -481,15 +481,17 @@ fn handle_swap_details<M: Maker>(
         details.protocol_version
     );
 
-    maker.validate_swap_parameters(&details)?;
+    // The fee pays for how long our funds stay locked, so use the length derived from the
+    // timelock. Otherwise the taker could ask for a long lock and pay for a short one.
+    let refund_locktime_offset = maker.validate_swap_parameters(&details)?;
 
     state.swap_id = Some(details.id.clone());
     state.swap_amount = details.amount;
     state.timelock = details.timelock;
-    state.refund_locktime_offset = details.refund_locktime_offset;
+    state.refund_locktime_offset = refund_locktime_offset;
     state.protocol = details.protocol_version;
     state.swap_start_time = Instant::now();
-    let swap_fee = maker.calculate_swap_fee(details.amount, details.refund_locktime_offset as u32);
+    let swap_fee = maker.calculate_swap_fee(details.amount, state.refund_locktime_offset as u32);
     state.service_fee_sats = swap_fee.to_sat();
     state.phase = SwapPhase::AwaitingContractData;
 
@@ -543,6 +545,7 @@ fn restore_state_if_needed<M: Maker>(maker: &Arc<M>, state: &mut ConnectionState
             state.contract_feerate = stored.contract_feerate;
             state.service_fee_sats = stored.service_fee_sats;
             state.swap_start_time = stored.swap_start_time;
+            state.refund_locktime_offset = stored.refund_locktime_offset;
         }
     }
 }

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -132,6 +132,20 @@ fn process_proof_of_funding<M: Maker>(
     ])?;
     state.check_swap_id(&pof.id)?;
 
+    // The fee is charged on `pof.refund_locktime`, so a taker could shrink it here
+    // and pay less than what it agreed to. Reject before we build anything from it.
+    if pof.refund_locktime as u32 != state.timelock {
+        log::error!(
+            "[{}] ProofOfFunding refund_locktime {} does not match negotiated timelock {}",
+            maker.network_port(),
+            pof.refund_locktime,
+            state.timelock
+        );
+        return Err(MakerError::General(
+            "ProofOfFunding refund locktime does not match the negotiated timelock",
+        ));
+    }
+
     #[cfg(feature = "integration-test")]
     {
         use super::handlers::MakerBehavior;

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -7,7 +7,7 @@ use bitcoind::bitcoincore_rpc::{jsonrpc::error::Error as JsonRpcError, Error as 
 
 use super::{
     error::MakerError,
-    handlers::{ConnectionState, Maker, SwapPhase},
+    handlers::{ConnectionState, Maker, SwapPhase, MIN_CONTRACT_REACTION_TIME},
 };
 use crate::{
     protocol::{
@@ -19,6 +19,7 @@ use crate::{
         },
         taproot_messages::{SerializableScalar, TaprootContractData, TaprootTakerMessage},
     },
+    taker::api::REFUND_LOCKTIME_STEP,
     utill::estimate_funding_tx_fee_sats,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
@@ -99,6 +100,24 @@ fn process_taproot_contract<M: Maker>(
         state.timelock,
         maker.network_port(),
     )?;
+
+    // The taker picks when to send this message, so blocks have passed since we agreed the swap.
+    // We can only sweep our incoming contract until `timelock + REFUND_LOCKTIME_STEP`, so
+    // check time is still left - a stalling taker would otherwise strand our funds.
+    let current_height = maker.get_current_height()?;
+    if state.timelock.saturating_add(REFUND_LOCKTIME_STEP as u32)
+        < current_height.saturating_add(MIN_CONTRACT_REACTION_TIME as u32)
+    {
+        log::warn!(
+            "[{}] Contract data arrived too late: timelock {} at height {}",
+            maker.network_port(),
+            state.timelock,
+            current_height
+        );
+        return Err(MakerError::General(
+            "Taproot contract data arrived too late to sweep safely",
+        ));
+    }
     #[cfg(debug_assertions)]
     log::debug!(
         "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | ContractTxs: {} | Amounts: {} | Timelock: {} | Status: verified",

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -95,10 +95,10 @@ pub struct SwapDetails {
     /// Timelock value.
     /// - Legacy: relative block count (CSV).
     /// - Taproot: absolute block height (CLTV).
+    ///
+    /// The maker charges its time fee off this value, so the taker cannot claim a
+    /// shorter lock than the one it commits to.
     pub timelock: u32,
-    /// Relative locktime offset used for fee calculation.
-    /// Ensures deterministic fees regardless of block height at processing time.
-    pub refund_locktime_offset: u16,
 }
 
 /// Acknowledgment of swap details from Maker.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1391,7 +1391,6 @@ impl Taker {
             amount: send_amount,
             tx_count,
             timelock,
-            refund_locktime_offset,
         };
 
         send_message(&mut stream, &TakerToMakerMessage::SwapDetails(swap_details))?;

--- a/tests/integration/mixed_protocol_concurrent_swaps.rs
+++ b/tests/integration/mixed_protocol_concurrent_swaps.rs
@@ -141,8 +141,8 @@ fn test_concurrent_legacy_and_taproot_swaps() {
         .for_each(|handle| handle.join().unwrap());
 
     let expected_taker_regular = [14_499_076, 14_299_076];
-    let expected_taker_swap = [494_587, 694_992];
-    let expected_taker_fees = [6_337, 5_932];
+    let expected_taker_swap = [494_587, 694_730];
+    let expected_taker_fees = [6_337, 6_194];
 
     for (i, (taker, original_balance)) in takers
         .iter()
@@ -198,9 +198,9 @@ fn test_concurrent_legacy_and_taproot_swaps() {
     }
 
     generate_blocks(bitcoind, 1);
-    let expected_maker_regular = [13_802_109, 13_806_515];
-    let expected_maker_swap = [1_198_428, 1_193_985];
-    let expected_maker_earnings = [1_023, 986];
+    let expected_maker_regular = [13_802_266, 13_806_777];
+    let expected_maker_swap = [1_198_428, 1_193_828];
+    let expected_maker_earnings = [1_180, 1_091];
 
     for (i, (maker, original_balance)) in makers
         .iter()

--- a/tests/integration/taproot_concurrent_takers.rs
+++ b/tests/integration/taproot_concurrent_takers.rs
@@ -267,7 +267,7 @@ fn test_concurrent_takers_taproot() {
         }
     }
 
-    let expected_maker_spendable = [1250197, 1250197];
+    let expected_maker_spendable = [1250309, 1250272];
 
     // Verify maker balances
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {

--- a/tests/integration/taproot_hashlock_recovery.rs
+++ b/tests/integration/taproot_hashlock_recovery.rs
@@ -182,7 +182,7 @@ fn test_taproot_hashlock_recovery() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        494744,
+        494557,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -205,11 +205,14 @@ fn test_taproot_hashlock_recovery() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        6180,
+        6367,
         "Taker spendable balance change mismatch"
     );
 
     // Verify maker balances
+    let expected_regular = [14500865, 14503103];
+    let expected_swap = [499328, 497053];
+    let expected_spendable = [15000193, 15000156];
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
@@ -220,14 +223,12 @@ fn test_taproot_hashlock_recovery() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14500753, 14502916];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499328, 497165];
         assert_eq!(
             maker_balances.swap.to_sat(),
             expected_swap[i],
@@ -242,7 +243,6 @@ fn test_taproot_hashlock_recovery() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [15000081, 15000081];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_maker_abort2.rs
+++ b/tests/integration/taproot_maker_abort2.rs
@@ -185,7 +185,7 @@ fn test_taproot_maker_abort2() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        494744,
+        494557,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -208,11 +208,14 @@ fn test_taproot_maker_abort2() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        6180,
+        6367,
         "Taker spendable balance change mismatch"
     );
 
     // Verify maker balances
+    let expected_regular = [14500865, 14503103];
+    let expected_swap = [499328, 496795];
+    let expected_spendable = [15000193, 14999898];
     for (i, maker) in makers.iter().enumerate() {
         maker.wallet.write().unwrap().sync_and_save().unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
@@ -223,14 +226,12 @@ fn test_taproot_maker_abort2() {
             i, original, maker_balances.spendable,
         );
 
-        let expected_regular = [14500753, 14502916];
         assert_eq!(
             maker_balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499328, 496907];
         assert_eq!(
             maker_balances.swap.to_sat(),
             expected_swap[i],
@@ -245,7 +246,6 @@ fn test_taproot_maker_abort2() {
         );
         assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
 
-        let expected_spendable = [15000081, 14999823];
         assert_eq!(
             maker_balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_maker_abort3.rs
+++ b/tests/integration/taproot_maker_abort3.rs
@@ -129,7 +129,7 @@ fn test_taproot_maker_abort3() {
 
     assert_eq!(
         taker_balances.spendable.to_sat(),
-        14994078,
+        14993891,
         "Taker spendable balance mismatch"
     );
     assert_eq!(
@@ -140,13 +140,13 @@ fn test_taproot_maker_abort3() {
     assert_eq!(taker_balances.fidelity, Amount::ZERO);
 
     // Verify makers earned fees (only the two that participated)
+    let expected_spendable = [15000193, 14999514, 15000156];
     for (i, (maker, original)) in makers.iter().zip(maker_spendable_balance).enumerate() {
         let balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
             "Maker {} balances: original={}, after={}",
             i, original, balances.spendable
         );
-        let expected_spendable = [15000081, 14999514, 15000081];
         assert_eq!(
             balances.spendable.to_sat(),
             expected_spendable[i],

--- a/tests/integration/taproot_multi_maker.rs
+++ b/tests/integration/taproot_multi_maker.rs
@@ -150,7 +150,7 @@ fn test_taproot_multi_maker_coinswap() {
 
     assert_eq!(
         taker_balances_after.spendable.to_sat(),
-        24989752,
+        24989231,
         "Taker spendable balance mismatch"
     );
     assert_eq!(
@@ -159,9 +159,12 @@ fn test_taproot_multi_maker_coinswap() {
         "Taker contract balance mismatch"
     );
     assert_eq!(taker_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff.to_sat(), 10248, "Taker fee paid mismatch");
+    assert_eq!(balance_diff.to_sat(), 10769, "Taker fee paid mismatch");
 
     // Verify all 4 makers earned fees
+    let expected_regular = [14500940, 14503252, 14505526, 14507763];
+    let expected_swap = [499328, 496978, 494666, 492392];
+    let expected_fees = [754, 716, 678, 641];
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
         let wallet = maker.wallet.read().unwrap();
         let balances = wallet.get_balances().unwrap();
@@ -171,14 +174,12 @@ fn test_taproot_multi_maker_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14500753, 14502916, 14505079, 14507242];
         assert_eq!(
             balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499328, 497165, 495002, 492839];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],
@@ -200,7 +201,12 @@ fn test_taproot_multi_maker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        assert_eq!(maker_fee.to_sat(), 567, "Maker {} fee earned mismatch", i);
+        assert_eq!(
+            maker_fee.to_sat(),
+            expected_fees[i],
+            "Maker {} fee earned mismatch",
+            i
+        );
     }
 
     info!("All multi-maker swap tests (Taproot, 4 makers) completed successfully!");

--- a/tests/integration/taproot_multi_taker.rs
+++ b/tests/integration/taproot_multi_taker.rs
@@ -184,7 +184,7 @@ fn test_taproot_multi_taker_coinswap() {
 
     assert_eq!(
         taker1_balances_after.spendable.to_sat(),
-        14994078,
+        14993891,
         "Taker 1 spendable balance mismatch"
     );
     assert_eq!(
@@ -193,7 +193,7 @@ fn test_taproot_multi_taker_coinswap() {
         "Taker 1 contract balance mismatch"
     );
     assert_eq!(taker1_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff1.to_sat(), 5922, "Taker 1 fee paid mismatch");
+    assert_eq!(balance_diff1.to_sat(), 6109, "Taker 1 fee paid mismatch");
 
     // ---- Verify Taker 2 ----
     let taker2_balances_after = takers[1]
@@ -212,7 +212,7 @@ fn test_taproot_multi_taker_coinswap() {
 
     assert_eq!(
         taker2_balances_after.spendable.to_sat(),
-        14994078,
+        14993891,
         "Taker 2 spendable balance mismatch"
     );
     assert_eq!(
@@ -221,9 +221,12 @@ fn test_taproot_multi_taker_coinswap() {
         "Taker 2 contract balance mismatch"
     );
     assert_eq!(taker2_balances_after.fidelity, Amount::ZERO);
-    assert_eq!(balance_diff2.to_sat(), 5922, "Taker 2 fee paid mismatch");
+    assert_eq!(balance_diff2.to_sat(), 6109, "Taker 2 fee paid mismatch");
 
     // ---- Verify Makers earned fees ----
+    let expected_regular = [14002216, 14006692];
+    let expected_swap = [998656, 994106];
+    let expected_fee = [1358, 1284];
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
         let wallet = maker.wallet.read().unwrap();
         let balances = wallet.get_balances().unwrap();
@@ -232,14 +235,12 @@ fn test_taproot_multi_taker_coinswap() {
             "Maker {} final balances - Regular: {}, Swap: {}, Contract: {}, Fidelity: {}, Spendable: {}",
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
-        let expected_regular = [14001992, 14006318];
         assert_eq!(
             balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [998656, 994330];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],
@@ -261,7 +262,12 @@ fn test_taproot_multi_taker_coinswap() {
 
         info!("Maker {} fee earned: {} sats", i, maker_fee.to_sat());
 
-        assert_eq!(maker_fee.to_sat(), 1134, "Maker {} fee earned mismatch", i);
+        assert_eq!(
+            maker_fee.to_sat(),
+            expected_fee[i],
+            "Maker {} fee earned mismatch",
+            i
+        );
     }
 
     info!("All multi-taker swap tests (Taproot) completed successfully!");

--- a/tests/integration/taproot_swap.rs
+++ b/tests/integration/taproot_swap.rs
@@ -127,7 +127,7 @@ fn test_taproot_coinswap() {
     );
     assert_eq!(
         taker_balances.swap.to_sat(),
-        495002,
+        494815,
         "Taker swap balance mismatch"
     );
     assert_eq!(
@@ -145,11 +145,14 @@ fn test_taproot_coinswap() {
 
     assert_eq!(
         balance_diff.to_sat(),
-        5922,
+        6109,
         "Taker spendable balance change mismatch"
     );
 
     // Verify makers earned fees
+    let expected_regular = [14500865, 14503103];
+    let expected_swap = [499328, 497053];
+    let expected_fee = [679, 642];
     for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
         let balances = maker.wallet.read().unwrap().get_balances().unwrap();
 
@@ -158,14 +161,12 @@ fn test_taproot_coinswap() {
             i, balances.regular, balances.swap, balances.contract, balances.fidelity, balances.spendable,
         );
 
-        let expected_regular = [14500753, 14502916];
         assert_eq!(
             balances.regular.to_sat(),
             expected_regular[i],
             "Maker {} regular balance mismatch",
             i
         );
-        let expected_swap = [499328, 497165];
         assert_eq!(
             balances.swap.to_sat(),
             expected_swap[i],
@@ -191,7 +192,12 @@ fn test_taproot_coinswap() {
             maker_fee.to_sat()
         );
 
-        assert_eq!(maker_fee.to_sat(), 567, "Maker {} fee earned mismatch", i);
+        assert_eq!(
+            maker_fee.to_sat(),
+            expected_fee[i],
+            "Maker {} fee earned mismatch",
+            i
+        );
     }
 
     info!("All taproot swap tests completed successfully!");


### PR DESCRIPTION
# Pull Request

## Description
- Added refund_locktime_offset to SwapState in src/maker/api.rs
- Persist it in store_connection_state and restore it in restore_state_if_needed
- Updated test assertions
## Related Issue(s)
Closes #946 
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [X] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [X] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [X] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [X] I ran `cargo +nightly fmt --all` and committed the result
- [X] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [X] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [X] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap resumption by persisting and restoring refund timing/offset so recovered swaps settle with correct fee behavior.
  * Strengthened Taproot timelock validation by rejecting contract details that arrive too late to sweep safely.
  * Added stricter Proof-of-Funding checks to ensure refund locktime matches the negotiated timelock.

* **Tests**
  * Updated Taproot and mixed-protocol integration test assertions for corrected fee and balance outcomes across recovery, concurrency, and abort/retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->