### PR TITLE
remove prompt from load_sensitive_struct

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -29,6 +29,10 @@ pub enum SecurityError {
     Decryption,
     /// The decrypted CBOR payload was invalid.
     Cbor(serde_cbor::Error),
+    /// The file is encrypted but no password was supplied. The caller is
+    /// responsible for obtaining a password (e.g. by prompting the user)
+    /// and retrying with `Some(password)`.
+    PasswordRequired,
 }
 
 impl std::fmt::Display for SecurityError {
@@ -38,6 +42,7 @@ impl std::fmt::Display for SecurityError {
             Self::Format(err) => write!(f, "format error: {err}"),
             Self::Decryption => write!(f, "decryption failed; wrong password or corrupted data"),
             Self::Cbor(err) => write!(f, "CBOR error: {err}"),
+            Self::PasswordRequired => write!(f, "file is encrypted but no password was supplied"),
         }
     }
 }
@@ -332,8 +337,9 @@ pub fn decrypt_struct<T: DeserializeOwned>(
 /// Without a password, it tries to deserialize the file contents in two steps:
 ///
 /// 1. **Unencrypted:** Attempts to deserialize the file directly as `T`.
-/// 2. **Encrypted:** If that fails, attempts to deserialize as [`EncryptedData`],
-///    then decrypts it using a user-supplied passphrase (prompted interactively).
+/// 2. **Encrypted:** If that fails, attempts to deserialize as [`EncryptedData`].
+///    If no password was supplied, returns [`SecurityError::PasswordRequired`]
+///    so the caller can obtain one (e.g. by prompting the user) and retry.
 ///
 /// The deserialization format (CBOR or JSON) is defined by the [`SerdeFormat`] trait
 /// implementation passed via the type parameter `F`.
@@ -372,7 +378,7 @@ pub fn load_sensitive_struct<T: DeserializeOwned, F: SerdeFormat>(
             Ok(encrypted_struct) => {
                 let encryption_password = match password {
                     Some(p) => p,
-                    None => utill::prompt_password("Enter encryption passphrase: ".to_string())?,
+                    None => return Err(SecurityError::PasswordRequired),
                 };
                 let enc_material = KeyMaterial::existing(
                     encryption_password,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -559,10 +559,8 @@ pub(crate) fn check_tor_status(control_port: u16, password: &str) -> Result<(), 
     Ok(())
 }
 
-#[cfg(not(any(feature = "integration-test", test)))]
 struct RawModeGuard;
 
-#[cfg(not(any(feature = "integration-test", test)))]
 impl RawModeGuard {
     fn new() -> io::Result<Self> {
         enable_raw_mode()?;
@@ -570,7 +568,6 @@ impl RawModeGuard {
     }
 }
 
-#[cfg(not(any(feature = "integration-test", test)))]
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
@@ -588,59 +585,50 @@ pub(crate) fn now_unix_secs() -> u64 {
 /// Temporarily disables canonical mode and echo to mask each typed
 /// character with `*` as feedback.
 pub fn prompt_password(message: String) -> io::Result<String> {
-    #[cfg(any(feature = "integration-test", test))]
-    {
-        let _ = message;
-        Ok("integration-test".to_string())
-    }
+    let mut stdout = io::stdout();
+    let stdin = io::stdin();
 
-    #[cfg(not(any(feature = "integration-test", test)))]
-    {
-        let mut stdout = io::stdout();
-        let stdin = io::stdin();
+    print!("{message}");
+    stdout.flush()?; // Ensure the prompt is printed
 
-        print!("{message}");
-        stdout.flush()?; // Ensure the prompt is printed
+    let _guard = RawModeGuard::new()?;
 
-        let _guard = RawModeGuard::new()?;
+    let mut password = String::new();
+    let mut buf = [0u8; 1];
 
-        let mut password = String::new();
-        let mut buf = [0u8; 1];
+    while stdin.lock().read(&mut buf)? == 1 {
+        let c = buf[0] as char;
 
-        while stdin.lock().read(&mut buf)? == 1 {
-            let c = buf[0] as char;
-
-            match c {
-                '\n' | '\r' => {
-                    // - If the byte is newline (`\n`, ASCII 0x0A) or carriage return (`\r`, ASCII 0x0D),
-                    //   it signals the end of input, so we break the loop.
-                    println!();
-                    break;
-                }
-                '\x08' | '\x7f' => {
-                    // - If the byte is Backspace (ASCII 0x08 or 0x7f),
-                    //   we remove the last character from the password (if any),
-                    //   and erase the asterisk from the terminal by moving the cursor back,
-                    //   writing a space to overwrite, then moving the cursor back again.
-                    if !password.is_empty() {
-                        password.pop();
-                        print!("\x08 \x08");
-                        stdout.flush()?;
-                    }
-                }
-                _ => {
-                    // - Otherwise, for any other character, we append it to the password string
-                    //   and print an asterisk '*' as a visual placeholder for the typed character.
-                    password.push(c);
-                    print!("*");
+        match c {
+            '\n' | '\r' => {
+                // - If the byte is newline (`\n`, ASCII 0x0A) or carriage return (`\r`, ASCII 0x0D),
+                //   it signals the end of input, so we break the loop.
+                println!();
+                break;
+            }
+            '\x08' | '\x7f' => {
+                // - If the byte is Backspace (ASCII 0x08 or 0x7f),
+                //   we remove the last character from the password (if any),
+                //   and erase the asterisk from the terminal by moving the cursor back,
+                //   writing a space to overwrite, then moving the cursor back again.
+                if !password.is_empty() {
+                    password.pop();
+                    print!("\x08 \x08");
                     stdout.flush()?;
                 }
             }
+            _ => {
+                // - Otherwise, for any other character, we append it to the password string
+                //   and print an asterisk '*' as a visual placeholder for the typed character.
+                password.push(c);
+                print!("*");
+                stdout.flush()?;
+            }
         }
-
-        println!(); // move to next line after input
-        Ok(password.trim_end().to_string())
     }
+
+    println!(); // move to next line after input
+    Ok(password.trim_end().to_string())
 }
 
 #[cfg(not(feature = "integration-test"))]

--- a/src/wallet/backup.rs
+++ b/src/wallet/backup.rs
@@ -1,7 +1,8 @@
 use std::{convert::TryFrom, env, ffi::OsStr, fs, io::Write, path::PathBuf};
 
 use crate::{
-    security::{encrypt_struct, load_sensitive_struct, KeyMaterial, SerdeJson},
+    security::{encrypt_struct, load_sensitive_struct, KeyMaterial, SecurityError, SerdeJson},
+    utill::prompt_password,
     wallet::{Wallet, WalletError},
 };
 
@@ -157,6 +158,26 @@ impl Wallet {
         let (backup, _) =
             match load_sensitive_struct::<WalletBackup, SerdeJson>(backup_file_path, None) {
                 Ok(backup) => backup,
+                Err(SecurityError::PasswordRequired) => {
+                    let password =
+                        match prompt_password("Enter encryption passphrase: ".to_string()) {
+                            Ok(password) => password,
+                            Err(err) => {
+                                log::error!("Failed to read passphrase: {err}");
+                                return;
+                            }
+                        };
+                    match load_sensitive_struct::<WalletBackup, SerdeJson>(
+                        backup_file_path,
+                        Some(password),
+                    ) {
+                        Ok(backup) => backup,
+                        Err(err) => {
+                            log::error!("Wallet backup load failed: {err}");
+                            return;
+                        }
+                    }
+                }
                 Err(err) => {
                     log::error!("Wallet backup load failed: {err}");
                     return;

--- a/tests/integration/wallet_backup.rs
+++ b/tests/integration/wallet_backup.rs
@@ -125,7 +125,7 @@ fn encwallet_encbackup_encrestore() {
         root_dir,
     ) = setup("encwallet_encbackup_encrestore".to_string());
 
-    let km = KeyMaterial::new_interactive(None);
+    let km = KeyMaterial::new_from_password(Some("integration-test".to_string()));
 
     let mut wallet =
         coinswap::wallet::Wallet::init(&original_wallet, &rpc_config, km.clone()).unwrap();
@@ -140,8 +140,11 @@ fn encwallet_encbackup_encrestore() {
 
     wallet.sync_and_save().unwrap();
 
-    let (backup, _) =
-        load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None).unwrap();
+    let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(
+        &wallet_backup_file,
+        Some("integration-test".to_string()),
+    )
+    .unwrap();
 
     let restored_wallet =
         Wallet::restore(&backup, &restored_wallet_file, &rpc_config, km.clone()).unwrap();


### PR DESCRIPTION
# Pull Request

## Description
load_sensitive_struct prompted for a password directly, mixing terminal I/O into a decrypt helper. Now it returns SecurityError::PasswordRequired instead, and the one caller that needs interactive prompting (restore_interactive) handles it itself.

## Related Issue(s)
#956 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [*] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [*] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [*] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [*] I ran `cargo +nightly fmt --all` and committed the result
- [*] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [*] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
cargo build --lib
cargo test --lib security::
```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted wallet backups can now be restored interactively by prompting for the required encryption password when it’s missing.
* **Bug Fixes**
  * Improved handling of encrypted wallet files when no password is initially supplied, with clearer “password required” guidance instead of unexpected behavior.
  * Password prompts are more robust: typed characters are masked and backspace editing is supported during entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->