### PR TITLE
fix(taker): keep Taproot maker sessions alive during funding waits

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -84,9 +84,9 @@ pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 
 /// Keep active funding waits comfortably below the maker's idle timeout.
 #[cfg(feature = "integration-test")]
-pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(not(feature = "integration-test"))]
-pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(300);
+pub(crate) const FUNDING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Base refund locktime (in blocks) for the innermost hop.
 ///

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -454,30 +454,18 @@ impl Taker {
                         .collect();
                     let required_confirms = self.swap_state()?.params.required_confirms;
                     log::info!(
-                        "Waiting for maker {}'s Taproot funding to confirm ({} tx)...",
+                        "Waiting for maker {}'s Taproot funding to confirm ({} tx), keeping the swap alive...",
                         i,
                         maker_funding_txids.len()
                     );
-                    let abort_check = || {
-                        self.breach_detector
-                            .as_ref()
-                            .is_some_and(|d| d.is_breached())
-                    };
-                    {
-                        let wallet = self.read_wallet()?;
-                        match wallet.wait_for_tx_confirmation(
-                            &maker_funding_txids,
-                            required_confirms,
-                            None,
-                            Some(&abort_check),
-                        ) {
-                            Ok(_) => {}
-                            Err(crate::wallet::WalletError::Interrupted(_)) => {
-                                return Err(TakerError::ContractsBroadcasted(vec![]));
-                            }
-                            Err(e) => return Err(e.into()),
-                        }
-                    }
+                    let swap_id = self.swap_state()?.id.clone();
+                    // Keep the session alive so the maker's idle checker does not start recovery.
+                    self.wait_for_funding_with_keepalive(
+                        &mut stream,
+                        &maker_funding_txids,
+                        required_confirms,
+                        &swap_id,
+                    )?;
 
                     received_contracts.push(*maker_contract);
                     self.swap_state_mut()?.makers[i]
@@ -710,7 +698,7 @@ impl Taker {
         }
 
         log::info!(
-            "Waiting for {} confirmation(s) on {} contract tx(s), keeping maker 0 warm...",
+            "Waiting for {} confirmation(s) on {} contract tx(s), keeping maker warm...",
             required_confirms,
             contract_txids.len()
         );
@@ -749,7 +737,7 @@ impl Taker {
                 // error instead of waiting out the full confirmation and then
                 // hitting EOF on the contract exchange.
                 return Err(TakerError::General(format!(
-                    "Maker 0 closed connection during funding wait: {:?}",
+                    "Maker closed connection during funding wait: {:?}",
                     e
                 )));
             }


### PR DESCRIPTION
- Keep Taproot maker sessions alive while waiting for maker funding transactions to confirm, preventing idle-timeout recovery and EOF errors in multi-transaction swaps.  
- Reduce `FUNDING_KEEPALIVE_INTERVAL`  to 60 seconds in production and 10 seconds in integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funding confirmation handling to keep the trading connection active while waiting.
  * Added faster detection when the other party closes the connection during funding.
  * Reduced keepalive intervals to improve connection responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->