### PR TITLE
ci: dispatch FFI compatibility builds from master

### DIFF
--- a/.github/workflows/notify-coinswap-ffi.yml
+++ b/.github/workflows/notify-coinswap-ffi.yml
@@ -1,0 +1,56 @@
+name: Notify coinswap-ffi
+
+# Dispatch the exact upstream commit to coinswap-ffi.
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  dispatch:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dispatch compatibility test
+        env:
+          GH_TOKEN: ${{ secrets.COINSWAP_FFI_DISPATCH_TOKEN }}
+          COINSWAP_SHA: ${{ github.sha }}
+          COINSWAP_REF: ${{ github.ref }}
+          COINSWAP_REPOSITORY: ${{ github.repository }}
+          COINSWAP_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::error::The COINSWAP_FFI_DISPATCH_TOKEN secret is not configured."
+            exit 1
+          fi
+
+          payload_file="${RUNNER_TEMP}/coinswap-ffi-dispatch.json"
+          jq -n \
+            --arg event_type "coinswap-updated" \
+            --arg coinswap_sha "${COINSWAP_SHA}" \
+            --arg coinswap_ref "${COINSWAP_REF}" \
+            --arg coinswap_repository "${COINSWAP_REPOSITORY}" \
+            --arg coinswap_commit_url "${COINSWAP_COMMIT_URL}" \
+            --arg triggering_actor "${TRIGGERING_ACTOR}" \
+            '{
+              event_type: $event_type,
+              client_payload: {
+                coinswap_sha: $coinswap_sha,
+                coinswap_ref: $coinswap_ref,
+                coinswap_repository: $coinswap_repository,
+                coinswap_commit_url: $coinswap_commit_url,
+                triggering_actor: $triggering_actor
+              }
+            }' > "${payload_file}"
+
+          gh api \
+            --method POST \
+            repos/citadel-tech/coinswap-ffi/dispatches \
+            --input "${payload_file}"


### PR DESCRIPTION
Triggers a `coinswap-ffi` compatibility build whenever a commit lands on `master`. Passes the exact Coinswap commit SHA through a cross-repository dispatch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated notifications to the external integration whenever changes are pushed to the master branch.
  * Added support for manually triggering these notifications on demand.
  * Notifications include commit and repository details to support upstream validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->