### PR TITLE
seed phrase

### DIFF
--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -2,7 +2,7 @@ use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
 use coinswap::{
     maker::{bind_port_retry, start_server, MakerError, MakerServer, MakerServerConfig},
-    utill::{parse_proxy_auth, setup_maker_logger},
+    utill::{parse_proxy_auth, print_new_wallet_seed, setup_maker_logger},
     wallet::RPCConfig,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -106,10 +106,14 @@ fn main() -> Result<(), MakerError> {
 
     let maker = Arc::new(MakerServer::init(config)?);
 
+    // Display and consume the mnemonic phrase. On failure, create a new wallet to get a new phrase.
     if let Some(mnemonic) = maker.wallet.write().unwrap().take_new_mnemonic() {
-        println!("\n========== New Wallet Seed Phrase ==========");
-        println!("{}", mnemonic.words());
-        println!("\nWrite these words down and store them offline. They will not be shown again.");
+        print_new_wallet_seed(&mnemonic).inspect_err(|e| {
+            log::error!(
+                "Failed to display new wallet seed phrase: {e}. \
+                 Delete the wallet and re-create it to get a new phrase."
+            );
+        })?;
     }
 
     start_server(maker)?;

--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -105,6 +105,13 @@ fn main() -> Result<(), MakerError> {
     config.write_to_file(&config_path)?;
 
     let maker = Arc::new(MakerServer::init(config)?);
+
+    if let Some(mnemonic) = maker.wallet.write().unwrap().take_new_mnemonic() {
+        println!("\n========== New Wallet Seed Phrase ==========");
+        println!("{}", mnemonic.words());
+        println!("\nWrite these words down and store them offline. They will not be shown again.");
+    }
+
     start_server(maker)?;
 
     Ok(())

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -7,7 +7,7 @@ use coinswap::{
         error::TakerError, format_state, MakerOfferCandidate, MakerState, SwapParams, Taker,
         TakerInitConfig,
     },
-    utill::{parse_proxy_auth, setup_taker_logger, UTXO},
+    utill::{parse_proxy_auth, print_new_wallet_seed, setup_taker_logger, UTXO},
     wallet::{AddressType, RPCConfig, Wallet},
 };
 use log::LevelFilter;
@@ -330,10 +330,14 @@ fn main() -> Result<(), TakerError> {
 
     let mut taker = Taker::init(config)?;
 
+    // Display and consume the mnemonic phrase. On failure, create a new wallet to get a new phrase.
     if let Some(mnemonic) = taker.get_wallet().write().unwrap().take_new_mnemonic() {
-        println!("\n========== New Wallet Seed Phrase ==========");
-        println!("{}", mnemonic.words());
-        println!("\nWrite these words down and store them offline. They will not be shown again.");
+        print_new_wallet_seed(&mnemonic).inspect_err(|e| {
+            log::error!(
+                "Failed to display new wallet seed phrase: {e}. \
+                 Delete the wallet and re-create it to get a new phrase."
+            );
+        })?;
     }
 
     // Sync wallet after initialization

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -330,6 +330,12 @@ fn main() -> Result<(), TakerError> {
 
     let mut taker = Taker::init(config)?;
 
+    if let Some(mnemonic) = taker.get_wallet().write().unwrap().take_new_mnemonic() {
+        println!("\n========== New Wallet Seed Phrase ==========");
+        println!("{}", mnemonic.words());
+        println!("\nWrite these words down and store them offline. They will not be shown again.");
+    }
+
     // Sync wallet after initialization
     taker.get_wallet().write().unwrap().sync_and_save()?;
 

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -42,7 +42,7 @@ static LOGGER: OnceLock<()> = OnceLock::new();
 use crate::{
     error::NetError,
     protocol::{contract::derive_maker_pubkey_and_nonce, error::ProtocolError},
-    wallet::{UTXOSpendInfo, WalletError},
+    wallet::{SecretMnemonic, UTXOSpendInfo, WalletError},
 };
 
 const INPUT_CHARSET: &str =
@@ -637,6 +637,19 @@ pub fn prompt_password(message: String) -> io::Result<String> {
 
     println!(); // move to next line after input
     Ok(password.trim_end().to_string())
+}
+
+/// Writes a new wallet's seed phrase to stdout, shown once at wallet creation.
+/// Returns write errors instead of panicking like `println!`.
+pub fn print_new_wallet_seed(mnemonic: &SecretMnemonic) -> io::Result<()> {
+    let mut out = io::stdout().lock();
+    writeln!(out, "\n========== New Wallet Seed Phrase ==========")?;
+    writeln!(out, "{}", mnemonic.words())?;
+    writeln!(
+        out,
+        "\nWrite these words down and store them offline. They will not be shown again."
+    )?;
+    out.flush()
 }
 
 #[cfg(not(feature = "integration-test"))]

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -20,7 +20,8 @@ use bitcoin::{
     secp256k1,
     secp256k1::{Keypair, Secp256k1, SecretKey},
     sighash::{EcdsaSighashType, Prevouts, SighashCache, TapSighashType},
-    Address, Amount, OutPoint, PublicKey, Script, ScriptBuf, Transaction, TxOut, Txid, Weight,
+    Address, Amount, Network, OutPoint, PublicKey, Script, ScriptBuf, Transaction, TxOut, Txid,
+    Weight,
 };
 use bitcoind::bitcoincore_rpc::{bitcoincore_rpc_json::ListUnspentResultEntry, Client, RpcApi};
 use serde::{Deserialize, Serialize};
@@ -61,8 +62,18 @@ const LEGACY_TIMELOCK_VSIZE: u64 = 142;
 /// ≈138 + 2 (growing block-height)
 const TAPROOT_TIMELOCK_VSIZE: u64 = 140;
 
+/// A BIP39 seed phrase for one-time display.No `Debug`/`Display`;
+/// [`SecretMnemonic::words`] is the only reader.
+pub struct SecretMnemonic(Mnemonic);
+
+impl SecretMnemonic {
+    /// Callers must not log or persist the result.
+    pub fn words(&self) -> String {
+        self.0.to_string()
+    }
+}
+
 /// Represents a Bitcoin wallet with associated functionality and data.
-#[derive(Debug)]
 pub struct Wallet {
     pub(crate) rpc: Client,
     pub(crate) wallet_file_path: PathBuf,
@@ -71,7 +82,11 @@ pub struct Wallet {
     /// If present, wallet data will be encrypted/decrypted using AES-GCM.
     /// The original passphrase is never stored—only the derived key is kept in memory.
     pub(crate) store_enc_material: Option<KeyMaterial>,
+    /// Transient: seed phrase of a wallet created by
+    /// [`Wallet::init`]. Read once via [`Wallet::take_new_mnemonic`].
+    pub(super) new_mnemonic: Option<SecretMnemonic>,
 }
+
 /// Compares two wallets for cryptographic equivalence.
 ///
 /// This comparison checks fields relevant to the cryptographic and functional
@@ -317,11 +332,8 @@ impl Wallet {
         let network = rpc.get_blockchain_info()?.chain;
 
         // Generate Master key
-        let master_key = {
-            let mnemonic = Mnemonic::generate(12)?;
-            let seed = mnemonic.to_entropy();
-            Xpriv::new_master(network, &seed)?
-        };
+        let mnemonic = Mnemonic::generate(12)?;
+        let master_key = Self::master_key_from_mnemonic(&mnemonic, network)?;
 
         // Initialise wallet
         let file_name = path
@@ -356,7 +368,21 @@ impl Wallet {
             wallet_file_path: path.to_path_buf(),
             store,
             store_enc_material,
+            new_mnemonic: Some(SecretMnemonic(mnemonic)),
         })
+    }
+
+    /// BIP39 seed to BIP32 master key, without the optional BIP39 passphrase
+    pub(super) fn master_key_from_mnemonic(
+        mnemonic: &Mnemonic,
+        network: Network,
+    ) -> Result<Xpriv, WalletError> {
+        Ok(Xpriv::new_master(network, &mnemonic.to_seed(""))?)
+    }
+
+    /// `Some` at most once; always `None` for loaded or restored wallets.
+    pub fn take_new_mnemonic(&mut self) -> Option<SecretMnemonic> {
+        self.new_mnemonic.take()
     }
     /// Get the wallet name
     pub fn get_name(&self) -> &str {
@@ -420,6 +446,7 @@ impl Wallet {
             wallet_file_path: path.to_path_buf(),
             store,
             store_enc_material,
+            new_mnemonic: None,
         })
     }
 
@@ -2812,7 +2839,27 @@ mod prevout_contract_tests {
             wallet_file_path: path.to_path_buf(),
             store,
             store_enc_material: None,
+            new_mnemonic: None,
         }
+    }
+
+    #[test]
+    fn new_mnemonic_is_yielded_once_then_dropped() {
+        const TEST_PHRASE: &str = "abandon abandon abandon abandon abandon abandon \
+                                   abandon abandon abandon abandon abandon about";
+
+        let temp_dir = tempdir().unwrap();
+        let mut wallet = test_wallet(&temp_dir.path().join("wallet.cbor"));
+        wallet.new_mnemonic = Some(SecretMnemonic(Mnemonic::parse(TEST_PHRASE).unwrap()));
+
+        assert_eq!(
+            wallet.take_new_mnemonic().map(|m| m.words()).as_deref(),
+            Some(TEST_PHRASE)
+        );
+        assert!(
+            wallet.take_new_mnemonic().is_none(),
+            "the phrase must be dropped from the wallet after the first take"
+        );
     }
 
     #[test]

--- a/src/wallet/backup.rs
+++ b/src/wallet/backup.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 
 use super::{rpc::RPCConfig, storage::WalletStore};
+use bip39::Mnemonic;
 use bitcoin::{bip32::Xpriv, Network};
-use bitcoind::bitcoincore_rpc::Client;
+use bitcoind::bitcoincore_rpc::{Client, RpcApi};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -98,6 +99,12 @@ impl Wallet {
         rpc_config: &RPCConfig,
         restored_enc_material: Option<KeyMaterial>,
     ) -> Result<Wallet, WalletError> {
+        if wallet_path.exists() {
+            return Err(WalletError::General(format!(
+                "a wallet already exists at {wallet_path:?}; refusing to overwrite it"
+            )));
+        }
+
         let wallet_file_name = wallet_path
             .file_name()
             .unwrap_or(OsStr::new(&wallet_backup.file_name)) // If no name filename for the restored one is provided use the previous one
@@ -125,10 +132,47 @@ impl Wallet {
             wallet_file_path: wallet_path.to_path_buf(),
             store,
             store_enc_material: restored_enc_material,
+            new_mnemonic: None,
         };
         tmp_wallet.sync_and_save()?;
 
         Ok(tmp_wallet)
+    }
+
+    /// Restores a `Wallet` from its BIP39 seed phrase, via [`Wallet::restore`].
+    ///
+    /// `wallet_birthday` is a floor on the Bitcoin Core rescan — `None` scans from
+    /// genesis, and the effective start may be up to 2h of blocks later. Electrum
+    /// ignores it and never rescans.
+    ///
+    /// Recovers exactly what a [`WalletBackup`] file does: HD funds, including
+    /// already-swept swap coins — though those lose the label that keeps them out of
+    /// the regular coin pool. Live swap keys are per-swap `OsRng` and unrecoverable
+    /// from any seed.
+    pub fn restore_from_mnemonic(
+        phrase: &str,
+        wallet_path: &Path,
+        rpc_config: &RPCConfig,
+        wallet_birthday: Option<u64>,
+        restored_enc_material: Option<KeyMaterial>,
+    ) -> Result<Wallet, WalletError> {
+        let network = Client::try_from(rpc_config)?.get_blockchain_info()?.chain;
+
+        let file_name = wallet_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let mnemonic = Mnemonic::parse(phrase)?;
+        let backup = WalletBackup {
+            network,
+            master_key: Wallet::master_key_from_mnemonic(&mnemonic, network)?,
+            wallet_birthday,
+            file_name,
+        };
+
+        Wallet::restore(&backup, wallet_path, rpc_config, restored_enc_material)
     }
 
     /// Interactively restores a wallet from a backup file.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -15,7 +15,7 @@ mod storage;
 pub(crate) mod swapcoin;
 
 pub(crate) use api::{contract_and_timelock_vsize, infer_address_type, SpendKind};
-pub use api::{Balances, RecoveryOutcome, UTXOSpendInfo, Wallet};
+pub use api::{Balances, RecoveryOutcome, SecretMnemonic, UTXOSpendInfo, Wallet};
 pub use backup::WalletBackup;
 pub use deniability::{verify_deniability, DeniabilityProof, DeniabilityProofData};
 pub use error::WalletError;

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -99,9 +99,9 @@ impl WalletStore {
         };
 
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
-        // write: overwrites existing file.
-        // create: creates new file if doesn't exist.
-        File::create(path)?;
+        // Exclusive create: fails with `AlreadyExists` instead of truncating a
+        // wallet that appeared since the caller checked the path.
+        File::create_new(path)?;
 
         store.write_to_disk(path, store_enc_material)?;
 

--- a/tests/integration/taker_cli.rs
+++ b/tests/integration/taker_cli.rs
@@ -109,10 +109,13 @@ fn test_taker_cli() {
     info!("Funding taker with 3 UTXOs of 1 BTC each");
     // Fund the taker with 3 utxos of 1 BTC each.
     for _ in 0..3 {
-        let taker_address = taker_cli.execute(&["get-new-address"]);
+        // The command that creates the wallet prints the seed phrase before its
+        // result, so the address is the last line.
+        let output = taker_cli.execute(&["get-new-address"]);
+        let taker_address = output.lines().last().unwrap();
 
         let taker_address: Address<NetworkChecked> =
-            Address::from_str(&taker_address).unwrap().assume_checked();
+            Address::from_str(taker_address).unwrap().assume_checked();
 
         send_to_address(bitcoind, &taker_address, Amount::ONE_BTC);
     }

--- a/tests/integration/wallet_backup.rs
+++ b/tests/integration/wallet_backup.rs
@@ -107,7 +107,10 @@ fn plainwallet_plainbackup_plainrestore() {
     let restored_wallet =
         Wallet::restore(&backup, &restored_wallet_file, &rpc_config, None).unwrap();
 
-    assert_eq!(wallet, restored_wallet); // only compares .store!
+    assert!(
+        wallet == restored_wallet, // only compares .store!
+        "restored wallet does not match the original"
+    );
 
     cleanup(&mut bitcoind, &root_dir);
 
@@ -149,7 +152,10 @@ fn encwallet_encbackup_encrestore() {
     let restored_wallet =
         Wallet::restore(&backup, &restored_wallet_file, &rpc_config, km.clone()).unwrap();
 
-    assert_eq!(wallet, restored_wallet); // only compares .store!
+    assert!(
+        wallet == restored_wallet, // only compares .store!
+        "restored wallet does not match the original"
+    );
 
     cleanup(&mut bitcoind, &root_dir);
 }


### PR DESCRIPTION
## Description
- Derive from `to_seed("")` instead of `to_entropy()`, so the phrase works in
  other BIP39 wallets. Existing wallets unaffected: `master_key` is persisted,
  never re-derived.
- New wallets yield the phrase once via `take_new_mnemonic()`. `SecretMnemonic`
  has no `Debug`/`Display`, Both binaries print it at creation.
- `restore_from_mnemonic` restores from the phrase alone. No CLI path yet.
- `Wallet::restore` now errors instead of overwriting an existing wallet file,
  which destroyed in-flight swapcoins.

## Related Issue(s)
Closes #951 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [x] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly created wallets now display a one-time recovery seed phrase with backup instructions.
  * Added wallet restoration from a recovery seed phrase.
* **Bug Fixes**
  * Existing wallet files can no longer be accidentally overwritten during restoration or initialization.
  * Recovery phrases are displayed only once and then securely discarded.
* **Tests**
  * Updated integration coverage for seed phrase output and wallet backup/restore comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->