### PR TITLE
keep every maker alive when Taker wait's for funding txn confirmation

### DIFF
--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1,7 +1,7 @@
 //! Legacy (ECDSA) specific swap methods for the Taker.
 
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     time::{Duration, Instant},
 };
 
@@ -345,15 +345,11 @@ impl Taker {
                     .filter_map(|sc| sc.funding_tx.as_ref().map(|tx| tx.compute_txid()))
                     .collect();
                 let required_confirms = self.swap_state()?.params.required_confirms;
-                prev_confirm_height = {
-                    let wallet = self.read_wallet()?;
-                    wallet.wait_for_tx_confirmation(
-                        &funding_txids,
-                        required_confirms,
-                        None,
-                        None,
-                    )?
-                };
+                prev_confirm_height = self.wait_for_legacy_funding_with_keepalive(
+                    &funding_txids,
+                    required_confirms,
+                    &swap_id,
+                )?;
                 _taker_funding_confirmed = true;
                 self.swap_state_mut()?.makers[maker_idx]
                     .legacy_exchange_mut()?
@@ -658,61 +654,11 @@ impl Taker {
                 .collect();
 
             let required_confirms = self.swap_state()?.params.required_confirms;
-            // Legacy may wait longer than the maker's idle timeout for funding
-            // confirmations. Keep this swap alive so the maker does not mistake
-            // it for a dropped taker and start contract recovery.
-            let mut keepalive_stream = self.net_connect(&maker_address)?;
-            self.net_handshake(&mut keepalive_stream)?;
-            let keepalive_stream = std::cell::RefCell::new(keepalive_stream);
-            let last_keepalive = Cell::new(Instant::now());
-            let keepalive_failed = Cell::new(false);
-            let abort_check = || {
-                if keepalive_failed.get() {
-                    return true;
-                }
-
-                let breached = self
-                    .breach_detector
-                    .as_ref()
-                    .is_some_and(|d| d.is_breached());
-                if !breached && last_keepalive.get().elapsed() >= FUNDING_KEEPALIVE_INTERVAL {
-                    if let Err(error) = send_message(
-                        &mut keepalive_stream.borrow_mut(),
-                        &TakerToMakerMessage::WaitingFundingConfirmation(swap_id.clone()),
-                    ) {
-                        log::error!(
-                            "Maker closed keepalive connection during funding wait: {:?}",
-                            error
-                        );
-                        // Do not mask a confirmation that may already be visible
-                        // in this polling iteration; interrupt on the next check.
-                        keepalive_failed.set(true);
-                        return false;
-                    }
-                    last_keepalive.set(Instant::now());
-                }
-                breached
-            };
-            let maker_confirm_height = {
-                let wallet = self.read_wallet()?;
-                match wallet.wait_for_tx_confirmation(
-                    &maker_funding_txids,
-                    required_confirms,
-                    None,
-                    Some(&abort_check),
-                ) {
-                    Ok(h) => h,
-                    Err(crate::wallet::WalletError::Interrupted(_)) if keepalive_failed.get() => {
-                        return Err(TakerError::General(
-                            "Maker closed keepalive connection during funding wait".to_string(),
-                        ));
-                    }
-                    Err(crate::wallet::WalletError::Interrupted(_)) => {
-                        return Err(TakerError::ContractsBroadcasted(vec![]));
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            };
+            let maker_confirm_height = self.wait_for_legacy_funding_with_keepalive(
+                &maker_funding_txids,
+                required_confirms,
+                &swap_id,
+            )?;
 
             // Verify that the maker's funding confirmed within a few blocks of the
             // previous hop. For legacy (CSV relative locktime), a large gap between
@@ -876,6 +822,95 @@ impl Taker {
 
         log::info!("Multi-hop Legacy swap contract exchange completed");
         Ok(())
+    }
+
+    /// Wait for Legacy funding while keeping every maker session in the route alive.
+    fn wait_for_legacy_funding_with_keepalive(
+        &self,
+        funding_txids: &[Txid],
+        required_confirms: u32,
+        swap_id: &str,
+    ) -> Result<u32, TakerError> {
+        let maker_addresses: Vec<String> = self
+            .swap_state()?
+            .makers
+            .iter()
+            .map(|maker| maker.address.to_string())
+            .collect();
+        let mut streams = Vec::with_capacity(maker_addresses.len());
+        for (maker_index, maker_address) in maker_addresses.into_iter().enumerate() {
+            let mut stream = self.net_connect(&maker_address)?;
+            self.net_handshake(&mut stream).map_err(|error| {
+                TakerError::General(format!(
+                    "Handshake failed with maker {} ({}): {:?}",
+                    maker_index, maker_address, error
+                ))
+            })?;
+            streams.push((maker_index, stream));
+        }
+
+        let streams = RefCell::new(streams);
+        let last_keepalive = Cell::new(Instant::now());
+        let failed_maker = Cell::new(None);
+        // Missing funding must still trigger maker idle-timeout recovery.
+        let funding_observed = Cell::new(false);
+        let wallet = self.read_wallet()?;
+        let abort_check = || {
+            if failed_maker.get().is_some() {
+                return true;
+            }
+
+            let breached = self
+                .breach_detector
+                .as_ref()
+                .is_some_and(|detector| detector.is_breached());
+            if !funding_observed.get() {
+                funding_observed.set(
+                    funding_txids
+                        .iter()
+                        .all(|txid| wallet.rpc.get_raw_transaction_info(txid, None).is_ok()),
+                );
+            }
+            if !breached
+                && funding_observed.get()
+                && last_keepalive.get().elapsed() >= FUNDING_KEEPALIVE_INTERVAL
+            {
+                let keepalive =
+                    TakerToMakerMessage::WaitingFundingConfirmation(swap_id.to_string());
+                for (maker_index, stream) in streams.borrow_mut().iter_mut() {
+                    if let Err(error) = send_message(stream, &keepalive) {
+                        log::error!(
+                            "Maker {} closed keepalive connection during funding wait: {:?}",
+                            maker_index,
+                            error
+                        );
+                        // Allow the current confirmation poll to complete before
+                        // interrupting so a visible confirmation is not masked.
+                        failed_maker.set(Some(*maker_index));
+                        return false;
+                    }
+                }
+                last_keepalive.set(Instant::now());
+            }
+            breached
+        };
+
+        match wallet.wait_for_tx_confirmation(
+            funding_txids,
+            required_confirms,
+            None,
+            Some(&abort_check),
+        ) {
+            Ok(height) => Ok(height),
+            Err(WalletError::Interrupted(_)) if failed_maker.get().is_some() => {
+                Err(TakerError::General(format!(
+                    "Maker {} closed keepalive connection during funding wait",
+                    failed_maker.get().unwrap_or_default()
+                )))
+            }
+            Err(WalletError::Interrupted(_)) => Err(TakerError::ContractsBroadcasted(vec![])),
+            Err(error) => Err(error.into()),
+        }
     }
 
     /// Request contract signatures for sender from a maker.

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1,9 +1,6 @@
 //! Legacy (ECDSA) specific swap methods for the Taker.
 
-use std::{
-    cell::{Cell, RefCell},
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
@@ -831,6 +828,10 @@ impl Taker {
         required_confirms: u32,
         swap_id: &str,
     ) -> Result<u32, TakerError> {
+        if required_confirms == 0 || funding_txids.is_empty() {
+            return Ok(0);
+        }
+
         let maker_addresses: Vec<String> = self
             .swap_state()?
             .makers
@@ -849,67 +850,112 @@ impl Taker {
             streams.push((maker_index, stream));
         }
 
-        let streams = RefCell::new(streams);
-        let last_keepalive = Cell::new(Instant::now());
-        let failed_maker = Cell::new(None);
+        let mut last_keepalive = Instant::now();
         // Missing funding must still trigger maker idle-timeout recovery.
-        let funding_observed = Cell::new(false);
-        let wallet = self.read_wallet()?;
-        let abort_check = || {
-            if failed_maker.get().is_some() {
-                return true;
-            }
+        let mut funding_observed = false;
+        let mut attempt = 0_u64;
 
-            let breached = self
+        log::info!(
+            "Waiting for {} confirmation(s) on {} transaction(s)...",
+            required_confirms,
+            funding_txids.len()
+        );
+
+        loop {
+            if self
                 .breach_detector
                 .as_ref()
-                .is_some_and(|detector| detector.is_breached());
-            if !funding_observed.get() {
-                funding_observed.set(
-                    funding_txids
-                        .iter()
-                        .all(|txid| wallet.rpc.get_raw_transaction_info(txid, None).is_ok()),
-                );
-            }
-            if !breached
-                && funding_observed.get()
-                && last_keepalive.get().elapsed() >= FUNDING_KEEPALIVE_INTERVAL
+                .is_some_and(|detector| detector.is_breached())
             {
-                let keepalive =
-                    TakerToMakerMessage::WaitingFundingConfirmation(swap_id.to_string());
-                for (maker_index, stream) in streams.borrow_mut().iter_mut() {
-                    if let Err(error) = send_message(stream, &keepalive) {
-                        log::error!(
-                            "Maker {} closed keepalive connection during funding wait: {:?}",
-                            maker_index,
-                            error
-                        );
-                        // Allow the current confirmation poll to complete before
-                        // interrupting so a visible confirmation is not masked.
-                        failed_maker.set(Some(*maker_index));
-                        return false;
+                return Err(TakerError::ContractsBroadcasted(vec![]));
+            }
+
+            attempt = attempt.saturating_add(1);
+            let (all_observed, all_confirmed, max_confirm_height) = {
+                // Keep the wallet read lock only for this RPC polling pass so
+                // recovery and sync writers can run while this loop sleeps.
+                let wallet = self.read_wallet()?;
+                let mut all_observed = true;
+                let mut all_confirmed = true;
+                let mut max_confirm_height = 0_u32;
+
+                for txid in funding_txids {
+                    match wallet.rpc.get_raw_transaction_info(txid, None) {
+                        Ok(tx_info) => {
+                            let confirmations = tx_info.confirmations.unwrap_or(0);
+                            if confirmations < required_confirms {
+                                all_confirmed = false;
+                            } else {
+                                let block_hash = tx_info.blockhash.ok_or_else(|| {
+                                    WalletError::General(format!(
+                                        "Confirmed transaction {txid} has no block hash"
+                                    ))
+                                })?;
+                                let confirmation_height = wallet
+                                    .rpc
+                                    .get_block_header_info(&block_hash)
+                                    .map_err(WalletError::Rpc)?
+                                    .height
+                                    as u32;
+                                max_confirm_height = max_confirm_height.max(confirmation_height);
+                            }
+                        }
+                        Err(error) => {
+                            log::debug!("Error getting tx info for {}: {:?}", txid, error);
+                            all_observed = false;
+                            all_confirmed = false;
+                        }
                     }
                 }
-                last_keepalive.set(Instant::now());
-            }
-            breached
-        };
+                (all_observed, all_confirmed, max_confirm_height)
+            };
 
-        match wallet.wait_for_tx_confirmation(
-            funding_txids,
-            required_confirms,
-            None,
-            Some(&abort_check),
-        ) {
-            Ok(height) => Ok(height),
-            Err(WalletError::Interrupted(_)) if failed_maker.get().is_some() => {
-                Err(TakerError::General(format!(
-                    "Maker {} closed keepalive connection during funding wait",
-                    failed_maker.get().unwrap_or_default()
-                )))
+            funding_observed |= all_observed;
+            if all_confirmed {
+                log::info!(
+                    "All transactions confirmed (latest at height {})",
+                    max_confirm_height
+                );
+                return Ok(max_confirm_height);
             }
-            Err(WalletError::Interrupted(_)) => Err(TakerError::ContractsBroadcasted(vec![])),
-            Err(error) => Err(error.into()),
+
+            let total_sleep = 10_u64.saturating_mul(attempt).min(600);
+            log::info!("Next sync in {} secs", total_sleep);
+
+            // Sleep in one-second increments to preserve prompt breach checks
+            // and keepalive delivery without retaining the wallet read guard.
+            for _ in 0..total_sleep {
+                if self
+                    .breach_detector
+                    .as_ref()
+                    .is_some_and(|detector| detector.is_breached())
+                {
+                    return Err(TakerError::ContractsBroadcasted(vec![]));
+                }
+
+                if !funding_observed {
+                    let wallet = self.read_wallet()?;
+                    funding_observed = funding_txids
+                        .iter()
+                        .all(|txid| wallet.rpc.get_raw_transaction_info(txid, None).is_ok());
+                }
+
+                if funding_observed && last_keepalive.elapsed() >= FUNDING_KEEPALIVE_INTERVAL {
+                    let keepalive =
+                        TakerToMakerMessage::WaitingFundingConfirmation(swap_id.to_string());
+                    for (maker_index, stream) in &mut streams {
+                        if let Err(error) = send_message(stream, &keepalive) {
+                            return Err(TakerError::General(format!(
+                                "Maker {} closed keepalive connection during funding wait: {:?}",
+                                maker_index, error
+                            )));
+                        }
+                    }
+                    last_keepalive = Instant::now();
+                }
+
+                std::thread::sleep(Duration::from_secs(1));
+            }
         }
     }
 

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -211,8 +211,8 @@ impl Taker {
         self.swap_state_mut()?.phase = SwapPhase::FundsBroadcast;
         self.persist_swap(SwapPhase::FundsBroadcast)?;
         // funding_broadcast opens maker 0's connection before the
-        // confirmation wait and keeps it warm with keepalives, returning the
-        // live stream so the contract exchange reuses it (no cold reconnect).
+        // confirmation wait and keeps the whole route warm with keepalives,
+        // returning the live maker 0 stream for the contract exchange.
         let maker0_stream = self.funding_broadcast()?;
 
         // Phase 2: Exchange contract data with makers.
@@ -496,9 +496,10 @@ impl Taker {
                         maker_funding_txids.len()
                     );
                     let swap_id = self.swap_state()?.id.clone();
-                    // Keep the session alive so the maker's idle checker does not start recovery.
+                    // Keep every active maker alive while any route funding is confirming.
                     self.wait_for_funding_with_keepalive(
                         &mut stream,
+                        i,
                         &maker_funding_txids,
                         required_confirms,
                         &swap_id,
@@ -653,12 +654,9 @@ impl Taker {
 
     /// Broadcast contract transactions (Taproot) and wait for them to confirm.
     ///
-    /// Opens the first maker's connection *before* the confirmation wait and
-    /// keeps it alive with `WaitingFundingConfirmation` keepalives, returning
-    /// the live stream so the contract exchange can reuse it. This prevents the
-    /// maker's swap session from going stale during the wait, which previously
-    /// caused a cold reconnect onto a dead session and surfaced as an
-    /// `UnexpectedEof` ("failed to fill whole buffer") on the contract exchange.
+    /// Opens maker 0's connection *before* the confirmation wait and keeps the
+    /// route alive with `WaitingFundingConfirmation` keepalives, returning the
+    /// live maker 0 stream so the contract exchange can reuse it.
     fn funding_broadcast(&mut self) -> Result<std::net::TcpStream, TakerError> {
         log::info!("Broadcasting contract transactions...");
 
@@ -692,8 +690,8 @@ impl Taker {
             .collect();
         let required_confirms = self.swap_state()?.params.required_confirms;
 
-        // Open and handshake maker 0's connection up front so we can keep it
-        // warm while waiting for our funding tx to confirm.
+        // Open and handshake maker 0 up front so its operational connection can
+        // stay warm and be reused after the taker's funding confirms.
         let swap_id = self.swap_state()?.id.clone();
         let maker0_address = self.swap_state()?.makers[0].address.to_string();
         let mut stream = self.net_connect(&maker0_address)?;
@@ -701,6 +699,7 @@ impl Taker {
 
         self.wait_for_funding_with_keepalive(
             &mut stream,
+            0,
             &contract_txids,
             required_confirms,
             &swap_id,
@@ -717,12 +716,13 @@ impl Taker {
         Ok(stream)
     }
 
-    /// Wait for the taker's outgoing contract (funding) txs to reach
-    /// `required_confirms`, sending periodic `WaitingFundingConfirmation`
-    /// keepalives to maker 0 so its swap session stays alive across the wait.
+    /// Wait for contract (funding) txs to reach `required_confirms`, sending
+    /// periodic `WaitingFundingConfirmation` keepalives to every maker so no
+    /// route session expires while another hop is confirming.
     fn wait_for_funding_with_keepalive(
         &self,
         stream: &mut std::net::TcpStream,
+        current_maker_index: usize,
         contract_txids: &[bitcoin::Txid],
         required_confirms: u32,
         swap_id: &str,
@@ -731,10 +731,34 @@ impl Taker {
             return Ok(());
         }
 
+        // Preserve the current maker's operational stream lifecycle. Use
+        // dedicated connections only to keep the other route makers alive.
+        let maker_addresses: Vec<String> = self
+            .swap_state()?
+            .makers
+            .iter()
+            .map(|maker| maker.address.to_string())
+            .collect();
+        let mut other_maker_streams = Vec::with_capacity(maker_addresses.len().saturating_sub(1));
+        for (maker_index, maker_address) in maker_addresses.into_iter().enumerate() {
+            if maker_index == current_maker_index {
+                continue;
+            }
+            let mut keepalive_stream = self.net_connect(&maker_address)?;
+            self.net_handshake(&mut keepalive_stream).map_err(|error| {
+                TakerError::General(format!(
+                    "Handshake failed with maker {} ({}): {:?}",
+                    maker_index, maker_address, error
+                ))
+            })?;
+            other_maker_streams.push((maker_index, keepalive_stream));
+        }
+
         log::info!(
-            "Waiting for {} confirmation(s) on {} contract tx(s), keeping maker warm...",
+            "Waiting for {} confirmation(s) on {} contract tx(s), keeping {} makers warm...",
             required_confirms,
-            contract_txids.len()
+            contract_txids.len(),
+            other_maker_streams.len() + 1
         );
 
         loop {
@@ -746,34 +770,43 @@ impl Taker {
                 return Err(TakerError::ContractsBroadcasted(vec![]));
             }
 
-            let all_confirmed = {
+            let funding_info = {
                 let wallet = self.read_wallet()?;
-                contract_txids.iter().all(|txid| {
-                    wallet
-                        .rpc
-                        .get_raw_transaction_info(txid, None)
-                        .ok()
-                        .and_then(|info| info.confirmations)
-                        .is_some_and(|c| c >= required_confirms)
-                })
+                contract_txids
+                    .iter()
+                    .map(|txid| wallet.rpc.get_raw_transaction_info(txid, None))
+                    .collect::<Vec<_>>()
             };
 
-            if all_confirmed {
+            if funding_info.iter().all(|info| {
+                info.as_ref()
+                    .ok()
+                    .and_then(|info| info.confirmations)
+                    .is_some_and(|confirms| confirms >= required_confirms)
+            }) {
                 return Ok(());
             }
 
-            // Ping the maker so it doesn't treat the swap session as idle.
-            if let Err(e) = send_message(
-                stream,
-                &TakerToMakerMessage::WaitingFundingConfirmation(swap_id.to_string()),
-            ) {
-                // The maker dropped the connection — fail fast with a clear
-                // error instead of waiting out the full confirmation and then
-                // hitting EOF on the contract exchange.
+            // Missing funding must still trigger maker idle-timeout recovery.
+            if funding_info.iter().any(Result::is_err) {
+                std::thread::sleep(FUNDING_KEEPALIVE_INTERVAL);
+                continue;
+            }
+
+            let keepalive = TakerToMakerMessage::WaitingFundingConfirmation(swap_id.to_string());
+            if let Err(e) = send_message(stream, &keepalive) {
                 return Err(TakerError::General(format!(
-                    "Maker closed connection during funding wait: {:?}",
-                    e
+                    "Maker {} closed connection during funding wait: {:?}",
+                    current_maker_index, e
                 )));
+            }
+            for (maker_index, keepalive_stream) in &mut other_maker_streams {
+                if let Err(e) = send_message(keepalive_stream, &keepalive) {
+                    return Err(TakerError::General(format!(
+                        "Maker {} closed connection during funding wait: {:?}",
+                        maker_index, e
+                    )));
+                }
             }
 
             std::thread::sleep(FUNDING_KEEPALIVE_INTERVAL);


### PR DESCRIPTION
# Pull Request

## Description
So currently when a taker waits for funding confirmation, it only sends keep alive message to only that particular hop maker, and other makers don't get any message. So if the funding confirmation takes more than `IDLE_CONNECTION_TIMEOUT` that is 900 secs, the other makers abort the swap and recovers via timelock.

During funding wait a taker should send keepalive to every maker in that particular swap to avoid this issue.

This pr addresses this thing and adds the behaviour to send keep-alive message to every maker involved in that swap.

## Related Issue(s)
<img width="1102" height="585" alt="Screenshot 2026-08-01 at 20 50 00" src="https://github.com/user-attachments/assets/35dc081d-dbea-4174-a1af-8ebccd9fc1c2" />
<img width="1097" height="585" alt="image" src="https://github.com/user-attachments/assets/389ea146-813e-4e57-8b4c-71abebc6676e" />
<img width="1499" height="929" alt="image" src="https://github.com/user-attachments/assets/98a92c29-e843-44d6-9276-cbfe9caa5f59" />



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):


## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)


## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funding confirmation reliability by keeping connections active with all makers during swaps, including Taproot swaps.
  * Reduced failures caused by temporary connection interruptions while waiting for funding confirmations.
  * Added clearer reporting when a maker disconnects or funding confirmation cannot complete.
  * Preserved breach-handling behavior when connection issues occur.
  * Improved handling of incomplete transaction data so valid swap flows can continue when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->