### PR TITLE
feat: transaction splitting per hop

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -147,8 +147,14 @@ enum Commands {
         /// Sets the swap amount in sats.
         #[clap(long, short = 'a', default_value = "20000")]
         amount: u64,
+        /// Uniform number of transaction splits per hop (Taproot only). Ignored if
+        /// `--tx-counts` is given.
         #[clap(long = "tx-count", default_value = "1")]
         tx_count: u32,
+        /// Per-hop split counts, e.g. `1,3,1` (Taproot only). Needs `makers + 1` entries
+        /// (index 0 = taker funding, rest = each maker's outgoing). Overrides `--tx-count`.
+        #[clap(long = "tx-counts", value_delimiter = ',')]
+        tx_counts: Option<Vec<u32>>,
         /// Protocol version to use: "legacy" or "taproot"
         #[clap(long, default_value = "legacy")]
         protocol: String,
@@ -545,6 +551,7 @@ fn main() -> Result<(), TakerError> {
             makers,
             amount,
             tx_count,
+            tx_counts,
             protocol,
             maker_addresses,
             auto_select,
@@ -552,6 +559,47 @@ fn main() -> Result<(), TakerError> {
             yes,
         } => {
             let protocol_version = parse_protocol(protocol)?;
+
+            // Resolve counts up front (length `makers + 1`) so bad input fails early.
+            let resolved_tx_counts: Vec<u32> = match tx_counts {
+                Some(counts) => {
+                    if counts.len() != *makers + 1 {
+                        return Err(TakerError::General(format!(
+                            "--tx-counts must have exactly {} entries (makers + 1), got {}",
+                            *makers + 1,
+                            counts.len()
+                        )));
+                    }
+                    if counts.contains(&0) {
+                        return Err(TakerError::General(
+                            "--tx-counts entries must all be >= 1".to_string(),
+                        ));
+                    }
+                    if let Some(&c) = counts
+                        .iter()
+                        .find(|&&c| c as usize > openswap::wallet::MAX_SPLITS)
+                    {
+                        return Err(TakerError::General(format!(
+                            "--tx-counts entry {} exceeds the maximum of {} splits",
+                            c,
+                            openswap::wallet::MAX_SPLITS
+                        )));
+                    }
+                    counts.clone()
+                }
+                None => {
+                    if *tx_count == 0 {
+                        return Err(TakerError::General("--tx-count must be >= 1".to_string()));
+                    }
+                    if *tx_count as usize > openswap::wallet::MAX_SPLITS {
+                        return Err(TakerError::General(format!(
+                            "--tx-count exceeds the maximum of {} splits",
+                            openswap::wallet::MAX_SPLITS
+                        )));
+                    }
+                    vec![*tx_count; *makers + 1]
+                }
+            };
 
             #[cfg(not(feature = "integration-test"))]
             let manually_selected_outpoints = if !auto_select {
@@ -577,7 +625,7 @@ fn main() -> Result<(), TakerError> {
 
             let mut swap_params =
                 SwapParams::new(protocol_version, Amount::from_sat(*amount), *makers);
-            swap_params.tx_count = *tx_count;
+            swap_params.tx_counts = resolved_tx_counts.clone();
             swap_params.manually_selected_outpoints = manually_selected_outpoints;
             if !maker_addresses.is_empty() {
                 swap_params.preferred_makers = Some(maker_addresses.clone());
@@ -608,6 +656,8 @@ fn main() -> Result<(), TakerError> {
                 );
             }
             println!();
+            println!("Tx splits per hop:   {resolved_tx_counts:?}");
+            println!("Total mining fee:    {}", summary.total_mining_fee);
             println!("Total estimated fee: {}", summary.total_estimated_fee);
             if let Some(payment) = &summary.payment {
                 println!("Estimated receive:   0 (settled to the payment receiver)");

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -85,6 +85,9 @@ struct SwapState {
     /// from it, and it cannot be derived later once the swap has moved on.
     /// `None` until that confirmation is observed.
     funding_confirmation_height: Option<u32>,
+    /// Requested outgoing contract count for this hop (Taproot per-hop splitting),
+    /// persisted across connections. `None` mirrors the incoming count (legacy).
+    outgoing_tx_count: Option<u32>,
 }
 
 impl Default for SwapState {
@@ -106,6 +109,7 @@ impl Default for SwapState {
             swap_start_time: Instant::now(),
             refund_locktime_offset: 0,
             funding_confirmation_height: None,
+            outgoing_tx_count: None,
         }
     }
 }
@@ -1167,6 +1171,19 @@ impl MakerTrait for MakerServer {
             }
         }
 
+        // Reject over-cap outgoing splits at connect time. Advisory only (doesn't check
+        // available UTXOs), so the taker still needs its mid-swap abort path.
+        if let Some(requested) = details.outgoing_tx_count {
+            if requested == 0 {
+                return Err(MakerError::General("Requested outgoing_tx_count is zero"));
+            }
+            if requested as usize > crate::wallet::MAX_SPLITS {
+                return Err(MakerError::General(
+                    "Requested outgoing_tx_count exceeds maximum splits",
+                ));
+            }
+        }
+
         // Check timelock bounds and work out how long the funds stay locked.
         let locked_blocks = if details.protocol_version == ProtocolVersion::Legacy {
             if details.timelock < MIN_CONTRACT_REACTION_TIME as u32 {
@@ -1523,6 +1540,7 @@ impl MakerTrait for MakerServer {
         swap_state.last_activity = Instant::now();
         swap_state.swap_start_time = state.swap_start_time;
         swap_state.refund_locktime_offset = state.refund_locktime_offset;
+        swap_state.outgoing_tx_count = state.outgoing_tx_count;
         log::debug!(
             "[{}] Stored connection state for {}: amount={}, timelock={}, protocol={:?}, outgoing_count={}",
             self.config.network_port,
@@ -1555,6 +1573,7 @@ impl MakerTrait for MakerServer {
             state.swap_start_time = s.swap_start_time;
             state.refund_locktime_offset = s.refund_locktime_offset;
             state.last_activity = s.last_activity;
+            state.outgoing_tx_count = s.outgoing_tx_count;
             state
         }))
     }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -64,6 +64,12 @@ pub enum MakerBehavior {
     UnderfundTaprootContract,
     /// Deduct one extra satoshi beyond the advertised fee.
     FeeSkimming,
+    /// Build one more outgoing Taproot contract than requested (over-split test).
+    OverSplitTaprootContract,
+    /// Build one fewer outgoing Taproot contract than requested (under-split test).
+    UnderSplitTaprootContract,
+    /// Advertise `max_tx_splits: None` to emulate a pre-feature maker (downgrade test).
+    AdvertiseNoSplitSupport,
 }
 
 /// Minimum time required to react to contract broadcasts (in blocks).
@@ -128,6 +134,13 @@ pub struct ConnectionState {
     pub timelock: u32,
     /// Relative locktime offset for deterministic fee calculation.
     pub refund_locktime_offset: u16,
+    /// Number of outgoing contracts to build for this hop (Taproot per-hop splitting).
+    ///
+    /// `None` means the taker did not request a specific outgoing count, so the maker
+    /// mirrors its incoming contract count (legacy behavior). Carried from
+    /// [`SwapDetails::outgoing_tx_count`] so `process_taproot_contract` can decouple its
+    /// outgoing count from the incoming one.
+    pub outgoing_tx_count: Option<u32>,
     /// Incoming swap coins (we receive).
     pub incoming_swapcoins: Vec<IncomingSwapCoin>,
     /// Outgoing swap coins (we send).
@@ -177,6 +190,7 @@ impl Default for ConnectionState {
             tx_count: 0,
             timelock: 0,
             refund_locktime_offset: 0,
+            outgoing_tx_count: None,
             incoming_swapcoins: Vec::new(),
             outgoing_swapcoins: Vec::new(),
             pending_funding_txes: Vec::new(),
@@ -557,6 +571,16 @@ fn handle_get_offer<M: Maker>(
         tweakable_point,
         fidelity,
         tweak_chain_code,
+        // `Some` tells the taker this maker reads `outgoing_tx_count`, up to the ceiling.
+        #[cfg(not(feature = "integration-test"))]
+        max_tx_splits: Some(crate::wallet::MAX_SPLITS as u32),
+        // One test behavior suppresses this to emulate a pre-feature maker.
+        #[cfg(feature = "integration-test")]
+        max_tx_splits: if maker.behavior() == MakerBehavior::AdvertiseNoSplitSupport {
+            None
+        } else {
+            Some(crate::wallet::MAX_SPLITS as u32)
+        },
     };
 
     log::info!(
@@ -605,6 +629,7 @@ fn handle_swap_details<M: Maker>(
     state.tx_count = details.tx_count;
     state.timelock = details.timelock;
     state.refund_locktime_offset = refund_locktime_offset;
+    state.outgoing_tx_count = details.outgoing_tx_count;
     state.protocol = details.protocol_version;
     state.swap_start_time = Instant::now();
     let swap_fee = maker.calculate_swap_fee(details.amount, state.refund_locktime_offset as u32);
@@ -691,6 +716,7 @@ fn restore_state_if_needed<M: Maker>(
             state.service_fee_sats = stored.service_fee_sats;
             state.swap_start_time = stored.swap_start_time;
             state.refund_locktime_offset = stored.refund_locktime_offset;
+            state.outgoing_tx_count = stored.outgoing_tx_count;
         }
     }
     Ok(())

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -27,9 +27,13 @@ use crate::{
     utill::estimate_funding_tx_fee_sats,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
-        MakerReport, WalletError,
+        vary_amounts, MakerReport, WalletError,
     },
 };
+
+/// Minimum size (sats) for an outgoing contract output; smaller splits are rejected as
+/// dust. Above P2TR dust (~330) with margin for the next hop's spend fee.
+const MIN_OUTGOING_CHUNK: u64 = 1_000;
 
 /// Handle a Taproot protocol message.
 pub fn handle_taproot_message<M: Maker>(
@@ -204,6 +208,34 @@ fn process_taproot_contract<M: Maker>(
         incoming_swapcoins.push(incoming_swapcoin);
     }
 
+    // Outgoing count is `outgoing_tx_count` if set, else mirror the incoming count.
+    // Re-check bounds here (also checked at SwapDetails time) since this is what we build.
+    let n_out = match state.outgoing_tx_count {
+        Some(c) => c as usize,
+        None => n,
+    };
+    if n_out == 0 {
+        return Err(MakerError::General("Outgoing tx count is zero"));
+    }
+    if n_out > crate::wallet::MAX_SPLITS {
+        return Err(MakerError::General(
+            "Outgoing tx count exceeds maximum splits",
+        ));
+    }
+
+    // QA: return a wrong outgoing count to exercise the taker's per-hop count assertion.
+    #[cfg(feature = "integration-test")]
+    let n_out = {
+        use super::handlers::MakerBehavior;
+        match maker.behavior() {
+            MakerBehavior::OverSplitTaprootContract if n_out < crate::wallet::MAX_SPLITS => {
+                n_out + 1
+            }
+            MakerBehavior::UnderSplitTaprootContract if n_out > 1 => n_out - 1,
+            _ => n_out,
+        }
+    };
+
     // The fee is priced on the negotiated offset, so it is fixed at negotiation
     // and matches the taker's mirror. The offset is not bound to the real lock
     // duration; assess the CSV transition (binding it in the script) later.
@@ -212,37 +244,43 @@ fn process_taproot_contract<M: Maker>(
     // amount; overwrite with the fee on the actual incoming amount so
     // success reports match what was really earned.
     state.service_fee_sats = swap_fee.to_sat();
-    let mining_fee = Amount::from_sat(estimate_funding_tx_fee_sats() * n as u64);
+    // Mining fee scales with the outgoing count, which the taker ultimately covers.
+    let mining_fee = Amount::from_sat(estimate_funding_tx_fee_sats() * n_out as u64);
     let fee = swap_fee + mining_fee;
     let outgoing_total = total_incoming
         .checked_sub(fee)
         .ok_or(MakerError::General("Fee exceeds incoming amount"))?;
-    let total_sat = total_incoming.to_sat() as u128;
-    let mut outgoing_amounts = data
-        .amounts
-        .iter()
-        .map(|amt| {
-            let share = (fee.to_sat() as u128 * amt.to_sat() as u128 / total_sat) as u64;
-            Amount::from_sat(amt.to_sat() - share)
-        })
+
+    // Split into n_out organic-looking chunks (summing to outgoing_total) so per-output
+    // sizes don't correlate across hops. n_out is already bounded to 1..=MAX_SPLITS.
+    let outgoing_amounts = vary_amounts(outgoing_total.to_sat(), n_out)
+        .into_iter()
+        .map(Amount::from_sat)
         .collect::<Vec<Amount>>();
-    // Flooring leaves the outgoing sum a few sats above total fee; deduct that remainder from the largest output so the totals stay exact and deterministic.
-    let remainder =
-        outgoing_amounts.iter().map(|amt| amt.to_sat()).sum::<u64>() - outgoing_total.to_sat();
-    if remainder > 0 {
-        let max_idx = outgoing_amounts
-            .iter()
-            .enumerate()
-            .max_by_key(|(_, amt)| amt.to_sat())
-            .map(|(idx, _)| idx)
-            .unwrap_or(0);
-        outgoing_amounts[max_idx] -= Amount::from_sat(remainder);
+
+    // Reject splits that would produce dust-tier outgoing contracts.
+    if let Some(dust) = outgoing_amounts
+        .iter()
+        .find(|amt| amt.to_sat() < MIN_OUTGOING_CHUNK)
+    {
+        log::warn!(
+            "[{}] Rejecting split into {} outputs: chunk {} below dust floor {}",
+            maker.network_port(),
+            n_out,
+            dust,
+            MIN_OUTGOING_CHUNK
+        );
+        return Err(MakerError::General(
+            "Requested split would produce dust-sized outgoing contracts",
+        ));
     }
 
     log::info!(
-        "[{}] Fee calculation: incoming_total={}, swap_fee={}, mining_fee={}, outgoing_total={}",
+        "[{}] Fee calculation: incoming_total={}, incoming_txs={}, outgoing_txs={}, swap_fee={}, mining_fee={}, outgoing_total={}",
         maker.network_port(),
         total_incoming,
+        n,
+        n_out,
         swap_fee,
         mining_fee,
         outgoing_total
@@ -262,15 +300,15 @@ fn process_taproot_contract<M: Maker>(
     let next_hop_xonly = bitcoin::key::XOnlyPublicKey::from(next_hop_hashlock_pubkey.inner);
     let hashlock_script = create_hashlock_script(&hash, &next_hop_xonly);
 
-    // Build one outgoing contract (with its own keys/scripts/address) per contract.
-    let mut outgoing_swapcoins = Vec::with_capacity(n);
-    let mut response_pubkeys = Vec::with_capacity(n);
-    let mut response_internal_keys = Vec::with_capacity(n);
-    let mut response_tap_tweaks = Vec::with_capacity(n);
-    let mut response_timelock_scripts = Vec::with_capacity(n);
-    let mut response_contract_txs = Vec::with_capacity(n);
-    let mut response_amounts = Vec::with_capacity(n);
-    let mut reserved = Vec::with_capacity(n);
+    // Build one outgoing contract (with its own keys/scripts/address) per outgoing chunk.
+    let mut outgoing_swapcoins = Vec::with_capacity(n_out);
+    let mut response_pubkeys = Vec::with_capacity(n_out);
+    let mut response_internal_keys = Vec::with_capacity(n_out);
+    let mut response_tap_tweaks = Vec::with_capacity(n_out);
+    let mut response_timelock_scripts = Vec::with_capacity(n_out);
+    let mut response_contract_txs = Vec::with_capacity(n_out);
+    let mut response_amounts = Vec::with_capacity(n_out);
+    let mut reserved = Vec::with_capacity(n_out);
     let mut spent_inputs: Vec<OutPoint> = Vec::new();
 
     let base_excluded = maker.collect_excluded_utxos(&data.id)?;
@@ -410,9 +448,10 @@ fn process_taproot_contract<M: Maker>(
     state.outgoing_swapcoins = outgoing_swapcoins.clone();
     #[cfg(debug_assertions)]
     log::debug!(
-        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | Contracts: {} | IncomingTotal: {} | ReservedUtxos: {}",
+        "[CONTRACT_STATE] Role: Maker | Protocol: Taproot | SwapID: {} | IncomingContracts: {} | OutgoingContracts: {} | IncomingTotal: {} | ReservedUtxos: {}",
         data.id,
         n,
+        n_out,
         total_incoming.to_sat(),
         state.reserve_utxo.len()
     );

--- a/src/maker/taproot_verification.rs
+++ b/src/maker/taproot_verification.rs
@@ -31,6 +31,19 @@ pub(crate) fn verify_taproot_contract_data(
         ));
     }
 
+    // Bound the incoming count: each contract consumes a distinct confirmed UTXO, so an
+    // unbounded count could force the maker to fan out beyond the split ceiling.
+    if data.contract_txs.len() > crate::wallet::MAX_SPLITS {
+        return Err(MakerError::General(
+            format!(
+                "Taproot incoming contract count ({}) exceeds maximum splits ({})",
+                data.contract_txs.len(),
+                crate::wallet::MAX_SPLITS
+            )
+            .leak(),
+        ));
+    }
+
     // contract_txs and amounts must have matching lengths
     if data.contract_txs.len() != data.amounts.len() {
         return Err(MakerError::General(

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -79,6 +79,11 @@ pub struct Offer {
     pub fidelity: FidelityProof,
     /// Chain code for deterministic derivation of swap addresses from the tweakable point.
     pub tweak_chain_code: ChainCode,
+    /// Max outgoing contract splits this maker will build per hop (Taproot).
+    /// `None` = maker predates the feature; the taker must not send it an
+    /// `outgoing_tx_count` differing from the incoming count.
+    #[serde(default)]
+    pub max_tx_splits: Option<u32>,
 }
 
 /// Swap details from Taker to Maker.
@@ -90,8 +95,13 @@ pub struct SwapDetails {
     pub protocol_version: ProtocolVersion,
     /// Amount to swap in satoshis.
     pub amount: Amount,
-    /// Number of contract transactions.
+    /// Contracts the taker funds *into this maker* (this hop's incoming count).
     pub tx_count: u32,
+    /// Outgoing contracts to build for this hop (Taproot per-hop splitting).
+    /// `None` (wire default) = mirror the incoming count. Old peers ignore/omit it,
+    /// so its presence activates the feature without a protocol version bump.
+    #[serde(default)]
+    pub outgoing_tx_count: Option<u32>,
     /// Timelock value.
     /// - Legacy: relative block count (CSV).
     /// - Taproot: absolute block height (CLTV).

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -216,10 +216,11 @@ pub struct SwapParams {
     pub send_amount: Amount,
     /// Number of makers (hops) to use.
     pub maker_count: usize,
-    /// Number of funding transactions per hop. Each funding transaction creates
-    /// one contract transaction, so this also determines the number of contracts
-    /// per hop. Used by both Legacy and Taproot protocols; defaults to 1.
-    pub tx_count: u32,
+    /// Per-hop split counts (Taproot only), one per funding hop (`maker_count + 1`).
+    /// Index 0 is the taker's own funding; index `i` is maker `i-1`'s outgoing count
+    /// (= maker `i`'s incoming), enabling routes like `[1, 3, 1]`. Empty = uniform 1.
+    /// Read via [`SwapParams::resolved_tx_counts`] rather than indexing directly.
+    pub tx_counts: Vec<u32>,
     /// Required confirmations for funding transactions.
     pub required_confirms: u32,
     /// User-selected UTXOs (optional).
@@ -240,7 +241,7 @@ impl SwapParams {
             protocol,
             send_amount,
             maker_count,
-            tx_count: 1,
+            tx_counts: Vec::new(),
             required_confirms: 1,
             manually_selected_outpoints: None,
             preferred_makers: None,
@@ -248,10 +249,28 @@ impl SwapParams {
         }
     }
 
-    /// Set the number of funding transactions per hop.
+    /// Set a uniform split count across every hop (fills `maker_count + 1` entries, so
+    /// call after `maker_count` is set). Use `with_tx_counts` for per-hop counts.
     pub fn with_tx_count(mut self, tx_count: u32) -> Self {
-        self.tx_count = tx_count;
+        self.tx_counts = vec![tx_count; self.maker_count + 1];
         self
+    }
+
+    /// Set explicit per-hop split counts. The vector must have exactly
+    /// `maker_count + 1` entries (validated when the swap starts, not here).
+    pub fn with_tx_counts(mut self, tx_counts: Vec<u32>) -> Self {
+        self.tx_counts = tx_counts;
+        self
+    }
+
+    /// Effective per-hop counts: `tx_counts` if it has the expected length
+    /// (`maker_count + 1`), else a uniform 1 per hop (so unset/malformed degrades safely).
+    pub fn resolved_tx_counts(&self) -> Vec<u32> {
+        if self.tx_counts.len() == self.maker_count + 1 {
+            self.tx_counts.clone()
+        } else {
+            vec![1; self.maker_count + 1]
+        }
     }
 
     /// Set the required confirmations.
@@ -313,7 +332,10 @@ pub struct SwapSummary {
     pub send_amount: Amount,
     /// Per-maker fee breakdown (one entry per hop, in route order).
     pub makers: Vec<MakerFeeInfo>,
-    /// Total estimated fees across all hops.
+    /// Total estimated mining fee across every funding hop (incl. the taker's own),
+    /// scaling with the per-hop split counts.
+    pub total_mining_fee: Amount,
+    /// Total estimated fees across all hops (maker service fees + total mining fee).
     pub total_estimated_fee: Amount,
     /// Estimated amount the taker will receive after all fees.
     pub estimated_receive_amount: Amount,
@@ -418,9 +440,11 @@ impl Taker {
         let swap = self.swap_state().ok()?;
         let send_amount = swap.params.send_amount;
         let maker_count = swap.makers.len();
+        // Maker `i` builds tx_counts[i + 1] outgoing contracts (per-hop mining fee).
+        let tx_counts = swap.params.resolved_tx_counts();
 
         // TODO : Have the makers derive the fee & a smart messaging layer to send the estimated target to the taker sequentially.
-        let per_hop_mining_fee = estimate_funding_tx_fee_sats() * swap.params.tx_count as u64;
+        let mining_fee_per_split = estimate_funding_tx_fee_sats();
 
         // Replay each hop's deduction exactly as the maker computes it. Any
         // slack here is room for a cheating maker to underpay the next hop;
@@ -436,6 +460,8 @@ impl Taker {
                         as u32
                 }
             };
+            // Mining fee this hop pays scales with its own outgoing split count.
+            let per_hop_mining_fee = mining_fee_per_split * tx_counts[i + 1] as u64;
             amount_sats = hop_net_sats(
                 &HopFeeTerms::from_offer(offer, locktime),
                 per_hop_mining_fee,
@@ -860,6 +886,29 @@ impl Taker {
             params.protocol
         );
 
+        // Validate per-hop counts before any network activity. Empty = uniform-1 default;
+        // otherwise require `maker_count + 1` entries, each in `1..=MAX_SPLITS`.
+        if !params.tx_counts.is_empty() {
+            if params.tx_counts.len() != params.maker_count + 1 {
+                return Err(TakerError::General(format!(
+                    "tx_counts must have exactly {} entries (maker_count + 1), got {}",
+                    params.maker_count + 1,
+                    params.tx_counts.len()
+                )));
+            }
+            if let Some(&bad) = params
+                .tx_counts
+                .iter()
+                .find(|&&c| c == 0 || c as usize > crate::wallet::MAX_SPLITS)
+            {
+                return Err(TakerError::General(format!(
+                    "tx_counts entry {} is out of range (must be 1..={})",
+                    bad,
+                    crate::wallet::MAX_SPLITS
+                )));
+            }
+        }
+
         let available = self.read_wallet()?.get_balances()?.spendable;
         let required = params.send_amount + FUNDING_FEE_BUFFER;
         if available < required {
@@ -986,7 +1035,12 @@ impl Taker {
             amount_sats = (amount_sats - fee).max(0.0);
         }
 
-        let total_fee_sats: u64 = maker_fees.iter().map(|m| m.estimated_fee_sats).sum();
+        let service_fee_sats: u64 = maker_fees.iter().map(|m| m.estimated_fee_sats).sum();
+        // Total splits the taker pays mining fee for: its own funding plus every hop.
+        let tx_counts = swap.params.resolved_tx_counts();
+        let total_splits: u64 = tx_counts.iter().map(|&c| c as u64).sum();
+        let total_mining_fee_sats = estimate_funding_tx_fee_sats() * total_splits;
+        let total_fee_sats = service_fee_sats + total_mining_fee_sats;
         let estimated_receive = send_amount
             .checked_sub(Amount::from_sat(total_fee_sats))
             .unwrap_or(Amount::ZERO);
@@ -996,6 +1050,7 @@ impl Taker {
             protocol,
             send_amount,
             makers: maker_fees,
+            total_mining_fee: Amount::from_sat(total_mining_fee_sats),
             total_estimated_fee: Amount::from_sat(total_fee_sats),
             estimated_receive_amount: estimated_receive,
             payment: swap.payment.clone(),
@@ -1451,7 +1506,8 @@ impl Taker {
         let maker_count = swap.params.maker_count;
         let swap_id = swap.id.clone();
         let send_amount = swap.params.send_amount;
-        let tx_count = swap.params.tx_count;
+        // Maker `i` receives tx_counts[i] contracts and builds tx_counts[i+1].
+        let tx_counts = swap.params.resolved_tx_counts();
         let protocol = swap.params.protocol;
 
         // Get reference height once for consistent absolute timelocks (Taproot).
@@ -1471,7 +1527,8 @@ impl Taker {
                 i,
                 &swap_id,
                 send_amount,
-                tx_count,
+                tx_counts[i],
+                tx_counts[i + 1],
                 maker_count,
                 reference_height,
             );
@@ -1526,23 +1583,25 @@ impl Taker {
 
         #[cfg(debug_assertions)]
         log::debug!(
-            "[SWAP_ROUTE] Source: taker::api::negotiate_swap_details | SwapID: {} | NegotiatedMakers: {} | Protocol: {:?} | ReferenceHeight: {} | TxCount: {}",
+            "[SWAP_ROUTE] Source: taker::api::negotiate_swap_details | SwapID: {} | NegotiatedMakers: {} | Protocol: {:?} | ReferenceHeight: {} | TxCounts: {:?}",
             swap_id,
             maker_count,
             protocol,
             reference_height,
-            tx_count
+            tx_counts
         );
         Ok(())
     }
 
     /// Negotiate swap details with a single maker at the given route index.
+    #[allow(clippy::too_many_arguments)]
     fn negotiate_with_maker(
         &mut self,
         maker_idx: usize,
         swap_id: &str,
         send_amount: Amount,
-        tx_count: u32,
+        incoming_tx_count: u32,
+        outgoing_tx_count: u32,
         maker_count: usize,
         reference_height: u32,
     ) -> Result<(), TakerError> {
@@ -1559,14 +1618,15 @@ impl Taker {
         send_message(&mut stream, &TakerToMakerMessage::GetOffer(GetOffer))?;
         let offer_bytes = read_message(&mut stream)?;
         let offer_msg: MakerToTakerMessage = serde_cbor::from_slice(&offer_bytes)?;
-        match offer_msg {
+        let maker_max_tx_splits: Option<u32> = match offer_msg {
             MakerToTakerMessage::Offer(offer) => {
                 log::info!(
-                    "Received offer from maker {}: base_fee={}, amt_pct={}, time_pct={}",
+                    "Received offer from maker {}: base_fee={}, amt_pct={}, time_pct={}, max_tx_splits={:?}",
                     maker_idx,
                     offer.base_fee,
                     offer.amount_relative_fee_pct,
-                    offer.time_relative_fee_pct
+                    offer.time_relative_fee_pct,
+                    offer.max_tx_splits
                 );
                 Self::validate_offer(&offer, maker_idx, send_amount)?;
                 // A repricing since the payment quote would silently move the
@@ -1588,7 +1648,9 @@ impl Taker {
                         )));
                     }
                 }
+                let max_tx_splits = offer.max_tx_splits;
                 self.swap_state_mut()?.makers[maker_idx].offer = Some(*offer);
+                max_tx_splits
             }
             other => {
                 return Err(TakerError::General(format!(
@@ -1596,7 +1658,32 @@ impl Taker {
                     maker_idx, other
                 )));
             }
-        }
+        };
+
+        // Only uneven hops send `outgoing_tx_count`; uniform hops send `None` (wire stays
+        // identical to an old taker). An uneven hop on an unsupporting maker aborts here,
+        // before funding, so `negotiate_swap_details` can substitute a spare.
+        let outgoing_tx_count_field = if negotiated_protocol == ProtocolVersion::Taproot
+            && outgoing_tx_count != incoming_tx_count
+        {
+            match maker_max_tx_splits {
+                Some(cap) if (1..=cap).contains(&outgoing_tx_count) => Some(outgoing_tx_count),
+                Some(cap) => {
+                    return Err(TakerError::General(format!(
+                        "Maker {} advertised max_tx_splits {} but this hop needs an outgoing split of {}",
+                        maker_idx, cap, outgoing_tx_count
+                    )));
+                }
+                None => {
+                    return Err(TakerError::General(format!(
+                        "Maker {} predates per-hop splitting (no max_tx_splits) but this hop needs an uneven outgoing split of {} (incoming {})",
+                        maker_idx, outgoing_tx_count, incoming_tx_count
+                    )));
+                }
+            }
+        } else {
+            None
+        };
 
         let refund_locktime_offset =
             REFUND_LOCKTIME_BASE + REFUND_LOCKTIME_STEP * (maker_count - maker_idx - 1) as u16;
@@ -1612,7 +1699,8 @@ impl Taker {
             id: swap_id.to_string(),
             protocol_version: negotiated_protocol,
             amount: send_amount,
-            tx_count,
+            tx_count: incoming_tx_count,
+            outgoing_tx_count: outgoing_tx_count_field,
             timelock,
             refund_locktime_offset,
         };
@@ -1815,7 +1903,7 @@ impl Taker {
         // Negotiate with the spare maker.
         let swap_id = self.swap_state()?.id.clone();
         let send_amount = self.swap_state()?.params.send_amount;
-        let tx_count = self.swap_state()?.params.tx_count;
+        let tx_counts = self.swap_state()?.params.resolved_tx_counts();
         let maker_count = self.swap_state()?.params.maker_count;
         let reference_height =
             {
@@ -1829,7 +1917,8 @@ impl Taker {
             target_idx,
             &swap_id,
             send_amount,
-            tx_count,
+            tx_counts[target_idx],
+            tx_counts[target_idx + 1],
             maker_count,
             reference_height,
         )?;
@@ -1900,7 +1989,9 @@ impl Taker {
         let preimage = swap.preimage;
         let send_amount = swap.params.send_amount;
         let swap_id = swap.id.clone();
-        let swap_tx_count = swap.params.tx_count as usize;
+        // Index 0 is the taker's own funding count (also correct for uniform Legacy).
+        let taker_tx_count = swap.params.resolved_tx_counts()[0];
+        let swap_tx_count = taker_tx_count as usize;
         let manually_selected_outpoints = swap.params.manually_selected_outpoints.clone();
         let reference_height = swap.reference_height;
 
@@ -1908,7 +1999,7 @@ impl Taker {
             generate_maker_keys(
                 &tweakable_point,
                 if protocol == ProtocolVersion::Legacy {
-                    swap.params.tx_count
+                    taker_tx_count
                 } else {
                     1
                 },

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -139,7 +139,8 @@ impl Taker {
         let swap = self.swap_state()?;
         let swap_id = swap.id.clone();
         let maker_count = swap.makers.len();
-        let tx_count = swap.params.tx_count;
+        // Legacy uses a uniform split count; every entry is equal, so read index 0.
+        let tx_count = swap.params.resolved_tx_counts()[0];
 
         // Ping every maker for the life of the march: while we negotiate one
         // hop, the others must not read our silence as a dropped swap.

--- a/src/taker/legacy_verification.rs
+++ b/src/taker/legacy_verification.rs
@@ -185,7 +185,8 @@ impl Taker {
         refund_locktime: u16,
         expected_amount: Option<Amount>,
     ) -> Result<(), TakerError> {
-        let expected_count = self.swap_state()?.params.tx_count as usize;
+        // Uniform Legacy count: index 0 applies to every hop.
+        let expected_count = self.swap_state()?.params.resolved_tx_counts()[0] as usize;
         if senders_info.len() != expected_count {
             return Err(TakerError::General(format!(
                 "Wrong number of maker sender contracts: expected {}, got {}",

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -1256,6 +1256,7 @@ impl MakerAddress {
                 cert_sig: router_offer.fidelity.cert_sig,
             },
             tweak_chain_code: router_offer.tweak_chain_code,
+            max_tx_splits: router_offer.max_tx_splits,
         };
 
         log::info!(
@@ -1331,6 +1332,7 @@ mod tests {
                 cert_sig,
             },
             tweak_chain_code: bitcoin::bip32::ChainCode::from([0u8; 32]),
+            max_tx_splits: Some(crate::wallet::MAX_SPLITS as u32),
         }
     }
 

--- a/src/taker/payment.rs
+++ b/src/taker/payment.rs
@@ -158,9 +158,12 @@ impl Taker {
             ))
         })?;
 
-        // The receiver amount is split across `tx_count` settlement outputs;
-        // each must clear the dust floor.
-        let tx_count = params.tx_count as u64;
+        // Settlement outputs are the final hop's count (last entry); each must clear dust.
+        let tx_counts = params.resolved_tx_counts();
+        let tx_count = *tx_counts
+            .last()
+            .expect("resolved_tx_counts always yields maker_count + 1 entries")
+            as u64;
         if tx_count == 0 {
             return Err(TakerError::General(
                 "A payment swap needs at least one transaction split".into(),
@@ -183,15 +186,26 @@ impl Taker {
     /// rewrite `params.send_amount` from the receiver's exact amount to the
     /// solved gross route amount. `address` is the validated receiver.
     pub(crate) fn payment_prepare_route(&mut self, address: Address) -> Result<(), TakerError> {
-        let (receiver_amount, tx_count, protocol, maker_count) = {
+        let (receiver_amount, tx_counts, protocol, maker_count) = {
             let swap = self.swap_state()?;
             (
                 swap.params.send_amount,
-                swap.params.tx_count as u64,
+                swap.params.resolved_tx_counts(),
                 swap.params.protocol,
                 swap.makers.len(),
             )
         };
+
+        // `solve_route_gross_sats` prices one uniform per-hop mining fee, so an uneven
+        // route has no exact solution — refuse rather than silently misprice a hop.
+        if tx_counts.iter().any(|&c| c != tx_counts[0]) {
+            return Err(TakerError::General(format!(
+                "A payment swap needs a uniform per-hop split count, got {tx_counts:?}; \
+                 use a single count for every hop"
+            )));
+        }
+        // Uniform per above, so any entry is the settlement (final-hop) count.
+        let tx_count = tx_counts[0] as u64;
 
         // Discovery fills these from the offerbook synced moments earlier; a
         // preferred-maker route has none, so poll those makers directly (which

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -390,6 +390,20 @@ impl Taker {
                         ));
                     }
 
+                    // Maker's contract count must equal the agreed outgoing split
+                    // (tx_counts[i + 1]); reject before signing. Since maker i's outgoing
+                    // is maker i+1's incoming, this also chain-checks consecutive hops.
+                    let expected_outgoing =
+                        self.swap_state()?.params.resolved_tx_counts()[i + 1] as usize;
+                    if maker_contract.contract_txs.len() != expected_outgoing {
+                        return Err(TakerError::General(format!(
+                            "Maker {} returned {} contract txs but the agreed outgoing split for this hop is {}",
+                            i,
+                            maker_contract.contract_txs.len(),
+                            expected_outgoing
+                        )));
+                    }
+
                     // Verify contract data before creating swapcoins
                     let expected_locktime = self.swap_state()?.makers[i].negotiated_timelock;
                     let expected_amount = self.expected_amount_for_hop(i);

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -10,6 +10,7 @@ mod fidelity;
 mod funding;
 mod report;
 mod spend;
+mod split_utxos;
 mod storage;
 pub(crate) mod swapcoin;
 
@@ -33,4 +34,6 @@ pub use report::{
     MakerFeeInfo, MakerReport, PaymentResult, RecoveryReport, SwapRole, SwapStatus, TakerReport,
 };
 pub use spend::Destination;
+pub(crate) use split_utxos::vary_amounts;
+pub use split_utxos::MAX_SPLITS;
 pub use storage::AddressType;

--- a/src/wallet/split_utxos.rs
+++ b/src/wallet/split_utxos.rs
@@ -1,0 +1,104 @@
+//! Amount-splitting helpers for per-hop coinswap transaction splitting.
+
+use bip39::rand::{thread_rng, Rng};
+
+/// Global ceiling on transaction splits per hop, bounding `outgoing_tx_count`.
+pub const MAX_SPLITS: usize = 5;
+
+/// Splits `total` into `num_chunks` organic-looking amounts with an exact sum, so chunk
+/// sizes don't look like proportional copies of some upstream amount.
+///
+/// reference :- (ε, δ)-indistinguishable Mixing for Cryptocurrencies
+/// <https://eprint.iacr.org/2021/1197.pdf>
+///
+/// Never errors: returns `vec![total]` (with a warning) if `num_chunks > MAX_SPLITS`,
+/// so callers must reject oversized counts themselves.
+pub(crate) fn vary_amounts(total: u64, num_chunks: usize) -> Vec<u64> {
+    let mut rng = thread_rng();
+
+    match num_chunks {
+        0 => vec![],
+        1 => vec![total],
+        2..=MAX_SPLITS => {
+            let ratios = match num_chunks {
+                2 => vec![1.05, 0.95],
+                3 => vec![1.0, 1.05, 0.95],
+                4 => vec![1.1, 0.9, 1.05, 0.95],
+                5 => vec![1.0, 1.1, 0.9, 1.05, 0.95],
+                _ => unreachable!(), // This line is safe because of the match guard
+            };
+
+            // Apply randomness (±5% of each ratio)
+            let randomized: Vec<f64> = ratios
+                .iter()
+                .map(|&r| r * rng.gen_range(0.95..1.05))
+                .collect();
+
+            // Normalize to maintain total
+            let sum: f64 = randomized.iter().sum();
+            let normalized: Vec<u64> = randomized
+                .iter()
+                .map(|&r| (total as f64 * r / sum).round() as u64)
+                .collect();
+
+            // Fix rounding errors
+            let mut sum_check: i64 = normalized.iter().sum::<u64>() as i64;
+            let mut adjusted = normalized.clone();
+
+            while sum_check != total as i64 {
+                let idx = rng.gen_range(0..adjusted.len());
+                let delta = if sum_check < total as i64 { 1 } else { -1 };
+                adjusted[idx] = (adjusted[idx] as i64 + delta) as u64;
+                sum_check += delta;
+            }
+
+            // Random output ordering
+            for i in 0..adjusted.len() {
+                let swap_with = rng.gen_range(0..adjusted.len());
+                adjusted.swap(i, swap_with);
+            }
+
+            adjusted
+        }
+        _ => {
+            log::warn!(
+                "vary_amounts: num_chunks={num_chunks} exceeds maximum of {MAX_SPLITS}, returning single chunk",
+            );
+            vec![total]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{vary_amounts, MAX_SPLITS};
+
+    #[test]
+    fn vary_amounts_preserves_total_for_all_valid_counts() {
+        let total = 1_234_567u64;
+        for n in 1..=MAX_SPLITS {
+            let chunks = vary_amounts(total, n);
+            assert_eq!(chunks.len(), n, "expected {n} chunks");
+            assert_eq!(
+                chunks.iter().sum::<u64>(),
+                total,
+                "chunks for n={n} must sum exactly to the total"
+            );
+            assert!(chunks.iter().all(|&c| c > 0), "no chunk should be zero");
+        }
+    }
+
+    #[test]
+    fn vary_amounts_edge_counts() {
+        assert!(vary_amounts(100, 0).is_empty());
+        assert_eq!(vary_amounts(100, 1), vec![100]);
+    }
+
+    #[test]
+    fn vary_amounts_over_max_collapses_to_single_chunk() {
+        // Above the ceiling the helper never errors; it returns a single chunk. Callers
+        // are responsible for rejecting oversized counts before calling.
+        let chunks = vary_amounts(500, MAX_SPLITS + 1);
+        assert_eq!(chunks, vec![500]);
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -35,6 +35,7 @@ mod taproot_maker_abort3;
 mod taproot_maker_malice;
 mod taproot_multi_maker;
 mod taproot_multi_taker;
+mod taproot_per_hop_splits;
 mod taproot_swap;
 mod taproot_taker_abort1;
 mod taproot_taker_abort2;

--- a/tests/integration/taproot_per_hop_splits.rs
+++ b/tests/integration/taproot_per_hop_splits.rs
@@ -1,0 +1,351 @@
+//! Integration tests for flexible per-hop transaction splitting (Taproot).
+//!
+//! A taker can ask each hop to fan out to a different number of outgoing contracts via
+//! `SwapParams::tx_counts`. These tests cover:
+//!
+//! - the happy path for an uneven `[1, 3, 1]` route across 2 makers (a passing swap is
+//!   itself the per-hop count assertion: the taker aborts unless each maker returns
+//!   exactly the agreed count),
+//! - a maker that over- or under-splits being rejected before the taker signs, and
+//! - the backward-compatibility path where a maker predating the feature (advertising
+//!   `max_tx_splits: None`) forces a clean pre-funding abort rather than a mid-swap one.
+
+use bitcoin::Amount;
+use openswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{error::TakerError, SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use log::{info, warn};
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+/// Happy path: a `[1, 3, 1]` route through 2 makers. The taker funds a single contract,
+/// the first maker fans out to 3, and the second collapses back to 1.
+#[test]
+fn test_taproot_per_hop_splits_1_3_1() {
+    warn!("Running Test: Taproot per-hop splitting with an uneven [1, 3, 1] route");
+
+    let makers_config_map = vec![(7920, Some(20920)), (17920, Some(20921))];
+    let taker_behavior = vec![TakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(makers_config_map, taker_behavior, vec![]);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    let taker_original_balance = fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    // Each maker needs enough confirmed UTXOs to build its outgoing contracts (the first
+    // maker fans out to 3), plus its fidelity bond.
+    fund_makers(
+        &makers,
+        bitcoind,
+        5,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker
+            .wallet
+            .write()
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+            .unwrap();
+    }
+    // Capture pre-swap spendable directly (the shared helper hardcodes a 4-UTXO golden).
+    let maker_spendable_balance: Vec<Amount> = makers
+        .iter()
+        .map(|m| m.wallet.read().unwrap().get_balances().unwrap().spendable)
+        .collect();
+
+    // Uneven per-hop counts: index 0 is the taker's own funding, then each maker's
+    // outgoing split. Length is maker_count + 1.
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
+        .with_tx_counts(vec![1, 3, 1])
+        .with_required_confirms(1);
+
+    generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare [1,3,1] Taproot coinswap");
+    info!("Swap summary: {summary:?}");
+    // The mining-fee estimate must scale with the total number of splits (1 + 3 + 1 = 5).
+    assert!(
+        summary.total_mining_fee > Amount::ZERO,
+        "expected a non-zero mining fee estimate for an uneven split route"
+    );
+
+    // Completion is the per-hop count check: the taker aborts unless each hop returns the
+    // agreed count, so success proves 1 -> 3 -> 1 held on-chain.
+    taker
+        .start_swap(&summary.swap_id)
+        .expect("[1,3,1] Taproot coinswap should complete");
+
+    // Keep makers running so their post-swap sweep can finish (it aborts on shutdown),
+    // then mine a block and sync before checking balances. Shut down at the very end.
+    taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+    generate_blocks(bitcoind, 1);
+    for maker in makers.iter() {
+        maker
+            .wallet
+            .write()
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+            .unwrap();
+    }
+
+    let taker_after = taker.get_wallet().read().unwrap().get_balances().unwrap();
+    info!(
+        "Taker after [1,3,1] swap - spendable: {}, contract: {}, swap: {}",
+        taker_after.spendable, taker_after.contract, taker_after.swap
+    );
+
+    // Structural checks only (randomized chunking rules out golden sats): contracts
+    // resolved and the taker paid a fee.
+    assert_eq!(
+        taker_after.contract.to_sat(),
+        0,
+        "taker contract balance must be swept to zero"
+    );
+    assert!(
+        taker_after.spendable < taker_original_balance,
+        "taker should have paid fees: before={taker_original_balance}, after={}",
+        taker_after.spendable
+    );
+
+    for (i, (maker, original_spendable)) in makers.iter().zip(maker_spendable_balance).enumerate() {
+        let balances = maker.wallet.read().unwrap().get_balances().unwrap();
+        // Zero contract balance proves the hop settled cleanly.
+        assert_eq!(
+            balances.contract.to_sat(),
+            0,
+            "maker {i} contract balance must be zero after swap"
+        );
+        // No per-maker profit assertion: a collapse hop (3 -> 1) can net slightly negative
+        // (mining fee is per outgoing, sweep cost per incoming). The taker's exact
+        // `expected_amount_for_hop` replay already guarantees amounts reconcile.
+        info!(
+            "Maker {i} spendable {} -> {}",
+            original_spendable, balances.spendable
+        );
+    }
+
+    info!("[1,3,1] per-hop split swap completed successfully");
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+/// A maker that builds MORE outgoing contracts than requested must be rejected by the
+/// taker before it signs anything.
+#[test]
+fn test_taproot_maker_over_split_rejected() {
+    warn!("Running Test: taker rejects a maker that over-splits its outgoing contracts");
+    run_misbehaving_split_maker(MakerBehavior::OverSplitTaprootContract);
+}
+
+/// A maker that builds FEWER outgoing contracts than requested must be rejected too.
+#[test]
+fn test_taproot_maker_under_split_rejected() {
+    warn!("Running Test: taker rejects a maker that under-splits its outgoing contracts");
+    run_misbehaving_split_maker(MakerBehavior::UnderSplitTaprootContract);
+}
+
+/// Shared driver for the over/under-split rejection tests. Uses a single maker (so route
+/// order is irrelevant) with a uniform `tx_count` of 3; the maker then returns 4 or 2
+/// contracts respectively and the taker must abort at contract verification.
+fn run_misbehaving_split_maker(behavior: MakerBehavior) {
+    let makers_config_map = vec![(7930, Some(20930))];
+    let taker_behavior = vec![TakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(makers_config_map, taker_behavior, vec![behavior]);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    // Headroom: over-splitting turns a requested 3-way fan-out into 4 distinct funding
+    // txs, each needing its own confirmed UTXO on top of the fidelity bond.
+    fund_makers(
+        &makers,
+        bitcoind,
+        7,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    generate_blocks(bitcoind, 1);
+
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 1)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+    let summary = taker
+        .prepare_swap(swap_params)
+        .expect("failed to prepare Taproot coinswap");
+
+    let error = taker
+        .start_swap(&summary.swap_id)
+        .expect_err("taker must reject a maker that returns the wrong outgoing split count");
+    match error {
+        TakerError::General(message) => {
+            assert!(
+                message.contains("agreed outgoing split for this hop"),
+                "unexpected taker error: {}",
+                message
+            );
+        }
+        other => panic!("unexpected taker error: {:?}", other),
+    }
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+/// Backward compatibility: when every maker predates per-hop splitting (advertises
+/// `max_tx_splits: None`) but the taker asks for an uneven `[1, 3, 1]` route, the taker
+/// must abort during negotiation — before any funds are committed — rather than discover
+/// the mismatch mid-swap.
+#[test]
+fn test_taproot_uneven_split_old_maker_aborts_before_funding() {
+    warn!("Running Test: uneven split against pre-feature makers aborts before funding");
+
+    let makers_config_map = vec![(7940, Some(20940)), (17940, Some(20941))];
+    let taker_behavior = vec![TakerBehavior::Normal];
+    // Both makers emulate old software with no per-hop-split support.
+    let maker_behaviors = vec![
+        MakerBehavior::AdvertiseNoSplitSupport,
+        MakerBehavior::AdvertiseNoSplitSupport,
+    ];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    let taker_original_balance = fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_makers_setup(&makers, 120);
+    generate_blocks(bitcoind, 1);
+
+    // Both hops of [1, 3, 1] are uneven (1->3, 3->1), so with no supporting maker and no
+    // spare, preparation aborts regardless of route order.
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
+        .with_tx_counts(vec![1, 3, 1])
+        .with_required_confirms(1);
+
+    let result = taker.prepare_swap(swap_params);
+    match result {
+        Err(TakerError::General(message)) => {
+            assert!(
+                message.contains("predates per-hop splitting"),
+                "unexpected taker error: {}",
+                message
+            );
+        }
+        Err(other) => panic!("unexpected taker error: {:?}", other),
+        Ok(summary) => panic!(
+            "preparation should have aborted, got summary: {:?}",
+            summary
+        ),
+    }
+
+    // No funding should have been broadcast: the taker's balance is untouched.
+    taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+    let taker_after = taker.get_wallet().read().unwrap().get_balances().unwrap();
+    assert_eq!(
+        taker_after.spendable, taker_original_balance,
+        "no funds should be committed when preparation aborts"
+    );
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}


### PR DESCRIPTION
# Pull Request

## Description

Implement flexible transaction splitting per hop instead of the fixed splitting number

## Related Issue(s)

Closes #948

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [x] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [x] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [x] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable per-hop transaction split counts for Taproot swaps.
  - Added CLI support for specifying uneven split counts and displaying resolved counts and total mining fees.
  - Added negotiation of maker split capabilities with compatibility for older peers.
  - Added organic amount splitting across outgoing contracts, with dust and maximum-split safeguards.

- **Bug Fixes**
  - Rejects invalid, excessive, or mismatched contract split counts before funding or settlement.

- **Tests**
  - Added coverage for successful uneven splits, unsupported makers, and incorrect contract counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->