### PR TITLE
test(utill): add unit test for parse_field

### DIFF
--- a/src/utill.rs
+++ b/src/utill.rs
@@ -1372,10 +1372,13 @@ mod tests {
         // to error-on-malformed is a conscious, reviewed decision.
         assert_eq!(parse_field::<u32>(Some(&malformed), 7), 7);
 
-        // The same silent fallback holds for other FromStr types.
+        // The same silent fallback holds for other FromStr types. The malformed
+        // and missing cases use `true` - a non-default for `bool` - so the
+        // assertions pin "returns the caller's default" specifically: a
+        // regression to `unwrap_or_default()` would yield `false` and fail here.
         let not_a_bool = "yes".to_string();
-        assert!(parse_field::<bool>(Some(&"true".to_string()), false));
-        assert!(!parse_field::<bool>(Some(&not_a_bool), false));
-        assert!(parse_field::<bool>(None, true));
+        assert!(!parse_field::<bool>(Some(&"false".to_string()), true)); // valid parse wins over the default
+        assert!(parse_field::<bool>(Some(&not_a_bool), true)); // malformed -> caller default, not type default
+        assert!(parse_field::<bool>(None, true)); // missing -> caller default
     }
 }

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -1353,4 +1353,29 @@ mod tests {
             assert!(msg.contains("Details"));
         }
     }
+
+    #[test]
+    fn test_parse_field() {
+        let present = "42".to_string();
+        let malformed = "not-a-number".to_string();
+
+        // A present, well-formed value parses to itself.
+        assert_eq!(parse_field::<u32>(Some(&present), 7), 42);
+
+        // A missing value falls back to the default.
+        assert_eq!(parse_field::<u32>(None, 7), 7);
+
+        // A present but unparseable value falls back to the default *silently* -
+        // there is no error. This is the behavior the maker config relies on in
+        // `maker/api.rs` (network_port, base_fee, etc.), so a typo'd config entry
+        // quietly uses the default rather than failing. Pin it so a future change
+        // to error-on-malformed is a conscious, reviewed decision.
+        assert_eq!(parse_field::<u32>(Some(&malformed), 7), 7);
+
+        // The same silent fallback holds for other FromStr types.
+        let not_a_bool = "yes".to_string();
+        assert!(parse_field::<bool>(Some(&"true".to_string()), false));
+        assert!(!parse_field::<bool>(Some(&not_a_bool), false));
+        assert!(parse_field::<bool>(None, true));
+    }
 }


### PR DESCRIPTION
`parse_field` returns the default whenever the value is missing *or* present but unparseable, since it does `value.and_then(|v| v.parse().ok()).unwrap_or(default)`. The maker config path in `maker/api.rs` (`network_port`, `rpc_port`, `base_fee`, and the fee/amount fields) relies on that silent fallback, so a typo'd config entry quietly uses the default instead of erroring.

This adds a unit test covering the three paths: present-and-valid parses to the value, missing falls back to the default, and present-but-unparseable also falls back to the default. It exercises two `FromStr` types (`u32`, `bool`) since the fallback is generic. No production change; it pins the current behavior so a future move to error-on-malformed is a conscious, reviewed decision.

Verified locally: `cargo test --lib parse_field` passes; `cargo +nightly fmt --all` and `cargo +stable clippy --all-features --lib --tests -- -D warnings` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for field parsing, including valid values, missing-value defaults, malformed numeric inputs, and boolean fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->