### PR TITLE
fix(maker): release timed-out unfunded swap reservations

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -892,9 +892,8 @@ impl MakerServer {
         Ok(())
     }
 
-    /// Atomically find and remove stale entries from `ongoing_swaps`.
-    /// Returns swap data for each idle swap.
-    /// Only drains entries where `outgoing_swapcoins` is non-empty (otherwise nothing to recover).
+    /// Atomically release stale unfunded reservations and drain swaps requiring recovery.
+    /// Returns swap data only for entries with on-chain recovery material.
     pub fn drain_idle_swaps(&self, timeout: Duration) -> Result<Vec<IdleSwapData>, MakerError> {
         // Read before the lock: a chain round trip while holding `ongoing_swaps`
         // would stall every handler. A failure here must not kill the recovery
@@ -916,6 +915,30 @@ impl MakerServer {
             .lock()
             .map_err(|_| MakerError::MutexPossion)?;
         let mut idle = Vec::new();
+
+        // An accepted swap with no funding material only reserves liquidity;
+        // there is nothing on-chain to recover, so it is dropped without recovery.
+        let released_ids: Vec<String> = swaps
+            .iter()
+            .filter(|(_, state)| {
+                state.phase == SwapPhase::AwaitingContractData
+                    && state.incoming_swapcoins.is_empty()
+                    && state.outgoing_swapcoins.is_empty()
+                    && state.pending_funding_txes.is_empty()
+                    && !state.funding_broadcast
+                    && state.last_activity.elapsed() > timeout
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in released_ids {
+            swaps.remove(&id);
+            log::info!(
+                "[{}] Released idle unfunded reservation for swap {}",
+                self.config.network_port,
+                id
+            );
+        }
 
         // Carries why each swap was drained: an operator reading "dropped connection"
         // for a taker that never dropped would go looking for the wrong fault.

--- a/tests/integration/taproot_taker_abort1.rs
+++ b/tests/integration/taproot_taker_abort1.rs
@@ -19,7 +19,7 @@ use coinswap::{
 use super::test_framework::*;
 
 use log::{info, warn};
-use std::{sync::atomic::Ordering::Relaxed, thread};
+use std::{sync::atomic::Ordering::Relaxed, thread, time::Duration};
 
 /// Test: Taker aborts at AckSwapDetails response (Taproot).
 ///
@@ -97,7 +97,7 @@ fn test_taproot_taker_abort1() {
 
     // Prepare should fail at AckResponse — the taker closes the connection
     // right after receiving AckSwapDetails, before any funding is broadcast.
-    let prepare_result = taker.prepare_coinswap(swap_params);
+    let prepare_result = taker.prepare_coinswap(swap_params.clone());
     assert!(
         prepare_result.is_err(),
         "Prepare should fail due to CloseAtAckResponse behavior"
@@ -107,6 +107,47 @@ fn test_taproot_taker_abort1() {
         prepare_result.err().unwrap()
     );
     taker.log_tracker_state();
+
+    // The accepted-but-unfunded reservation must expire without requiring a restart.
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    wait_for_log(
+        &log_path,
+        "Released idle unfunded reservation",
+        Duration::from_secs(60),
+    );
+    let release_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while makers
+        .iter()
+        .any(|maker| maker.has_ongoing_swaps().unwrap())
+    {
+        assert!(
+            std::time::Instant::now() < release_deadline,
+            "Early-abort reservations should be released after the idle timeout"
+        );
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    // With the stale reservation gone, the makers must be back at full capacity:
+    // a fresh swap request has to be accepted again. The maker only sends
+    // AckSwapDetails after storing a new reservation, and the taker only emits
+    // the CloseAtAckResponse test error after receiving that ack — so hitting
+    // that exact error proves the makers accepted the retry.
+    let retry_result = taker.prepare_coinswap(swap_params);
+    let retry_err = format!(
+        "{:?}",
+        retry_result.expect_err("Retry should still abort at AckSwapDetails")
+    );
+    assert!(
+        retry_err.contains("closing at ack response"),
+        "Retry should have been accepted up to AckSwapDetails, got: {}",
+        retry_err
+    );
+    assert!(
+        makers
+            .iter()
+            .any(|maker| maker.has_ongoing_swaps().unwrap()),
+        "Accepted retry should hold a fresh reservation on a maker"
+    );
 
     // Sync taker wallet and verify balance
     taker


### PR DESCRIPTION
# Pull Request

## Description
# Pull Request

## Description

Makers keep accepted pre-contract swaps in `ongoing_swaps`, reserving liquidity before any funding exists.  
If the taker disconnects after `AckSwapDetails`, the idle cleanup skips the swap because it has no outgoing swapcoins.  
This leaves the liquidity reserved until `makerd` restarts and can prevent new swaps from being accepted.  
This PR removes timed-out, unfunded reservations while preserving normal recovery for funded swaps.

<img width="1100" height="568" alt="image" src="https://github.com/user-attachments/assets/40c49093-6c09-4786-9e24-084c77530e6f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale swaps awaiting contract data now release reserved liquidity when they have no funding or swap materials.
  * Unfunded Taproot aborts now complete cleanup reliably before shutdown.
* **Tests**
  * Expanded coverage to verify reservation release and complete maker swap cleanup during early abort scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->