### PR TITLE
Audit fixes wave 2: cap swap admissions, persist incoming swapcoins, bound backend waits

### DIFF
--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -1,6 +1,7 @@
 use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
 use coinswap::{
+    lock_debug,
     maker::{bind_port_retry, start_server, MakerError, MakerServer, MakerServerConfig},
     utill::{parse_proxy_auth, print_new_wallet_seed, setup_maker_logger},
     wallet::{BackendConfig, CoreRpcConfig, ElectrumConfig},
@@ -134,7 +135,10 @@ fn main() -> Result<(), MakerError> {
     let maker = Arc::new(MakerServer::init(config)?);
 
     // Display and consume the mnemonic phrase. On failure, create a new wallet to get a new phrase.
-    if let Some(mnemonic) = maker.wallet.write().unwrap().take_new_mnemonic() {
+    if let Some(mnemonic) = lock_debug!(maker.wallet.write())
+        .unwrap()
+        .take_new_mnemonic()
+    {
         print_new_wallet_seed(&mnemonic).inspect_err(|e| {
             log::error!(
                 "Failed to display new wallet seed phrase: {e}. \

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -2,6 +2,7 @@ use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
 use coinswap::{
+    lock_debug,
     protocol::ProtocolVersion,
     taker::{
         error::TakerError, format_state, MakerOfferCandidate, MakerState, SwapParams, Taker,
@@ -384,7 +385,10 @@ fn main() -> Result<(), TakerError> {
     let mut taker = Taker::init(config)?;
 
     // Display and consume the mnemonic phrase. On failure, create a new wallet to get a new phrase.
-    if let Some(mnemonic) = taker.get_wallet().write().unwrap().take_new_mnemonic() {
+    if let Some(mnemonic) = lock_debug!(taker.get_wallet().write())
+        .unwrap()
+        .take_new_mnemonic()
+    {
         print_new_wallet_seed(&mnemonic).inspect_err(|e| {
             log::error!(
                 "Failed to display new wallet seed phrase: {e}. \
@@ -394,15 +398,13 @@ fn main() -> Result<(), TakerError> {
     }
 
     // Sync wallet after initialization
-    taker
-        .get_wallet()
-        .write()
+    lock_debug!(taker.get_wallet().write())
         .unwrap()
         .sync_and_save(&coinswap::utill::NO_SHUTDOWN)?;
 
     match &args.command {
         Commands::ListUtxo => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let utxos = wallet.list_all_utxo_spend_info();
             for utxo in utxos {
                 let utxo = UTXO::from_utxo_data(utxo);
@@ -410,7 +412,7 @@ fn main() -> Result<(), TakerError> {
             }
         }
         Commands::ListUtxoRegular => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let utxos = wallet.list_descriptor_utxo_spend_info();
             for utxo in utxos {
                 let utxo = UTXO::from_utxo_data(utxo);
@@ -418,7 +420,7 @@ fn main() -> Result<(), TakerError> {
             }
         }
         Commands::ListUtxoSwap => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let utxos = wallet.list_incoming_swap_coin_utxo_spend_info();
             for utxo in utxos {
                 let utxo = UTXO::from_utxo_data(utxo);
@@ -426,7 +428,7 @@ fn main() -> Result<(), TakerError> {
             }
         }
         Commands::ListUtxoContract => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let utxos = wallet.list_live_timelock_contract_spend_info();
             for utxo in utxos {
                 let utxo = UTXO::from_utxo_data(utxo);
@@ -434,7 +436,7 @@ fn main() -> Result<(), TakerError> {
             }
         }
         Commands::GetBalances => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let balances = wallet.get_balances()?;
             println!(
                 "{}",
@@ -448,7 +450,7 @@ fn main() -> Result<(), TakerError> {
             );
         }
         Commands::GetNewAddress => {
-            let mut wallet = taker.get_wallet().write().unwrap();
+            let mut wallet = lock_debug!(taker.get_wallet().write()).unwrap();
             let address = wallet.get_next_external_address(AddressType::P2TR)?;
             println!("{address:?}");
         }
@@ -461,7 +463,7 @@ fn main() -> Result<(), TakerError> {
 
             #[cfg(not(feature = "integration-test"))]
             let manually_selected_outpoints = {
-                let wallet = taker.get_wallet().read().unwrap();
+                let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
                 Some(
                     coinswap::utill::interactive_select(wallet.list_all_utxo_spend_info(), amount)?
                         .iter()
@@ -472,7 +474,7 @@ fn main() -> Result<(), TakerError> {
             #[cfg(feature = "integration-test")]
             let manually_selected_outpoints = None;
 
-            let mut wallet = taker.get_wallet().write().unwrap();
+            let mut wallet = lock_debug!(taker.get_wallet().write()).unwrap();
             let txid = wallet.send_to_address(
                 amount.to_sat(),
                 address.clone(),
@@ -502,7 +504,7 @@ fn main() -> Result<(), TakerError> {
 
             println!("\nDiscovered {} makers\n", makers.len());
 
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             display_makers_with_summary(&wallet, &makers)?;
         }
         Commands::ListOffers => {
@@ -518,12 +520,12 @@ fn main() -> Result<(), TakerError> {
 
             println!("\n{} makers in local offerbook\n", makers.len());
 
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             display_makers_with_summary(&wallet, &makers)?;
         }
         Commands::PollMaker { address } => {
             let result = taker.poll_maker(address.clone())?;
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             let (tip_height, tip_time) = wallet.chain_tip()?;
             println!("{}", display_offer(&wallet, &result, tip_height, tip_time)?);
         }
@@ -549,7 +551,7 @@ fn main() -> Result<(), TakerError> {
             #[cfg(not(feature = "integration-test"))]
             let manually_selected_outpoints = if !auto_select {
                 let target_amount = Amount::from_sat(*amount);
-                let wallet = taker.get_wallet().read().unwrap();
+                let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
                 Some(
                     coinswap::utill::interactive_select(
                         wallet.list_all_utxo_spend_info(),
@@ -625,7 +627,7 @@ fn main() -> Result<(), TakerError> {
             taker.recover_active_swap()?;
         }
         Commands::Backup { encrypt } => {
-            let wallet = taker.get_wallet().read().unwrap();
+            let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
             Wallet::backup_interactive(&wallet, *encrypt);
         }
         Commands::Restore { .. } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,28 @@ pub mod taker;
 pub mod utill;
 pub mod wallet;
 pub mod watch_tower;
+
+/// Logs before and after a blocking lock acquisition.
+#[macro_export]
+macro_rules! lock_debug {
+    ($acquire:expr) => {{
+        log::debug!(
+            target: "lock",
+            "WAIT {:?} {}:{} {}",
+            std::thread::current().id(),
+            file!(),
+            line!(),
+            stringify!($acquire)
+        );
+        let guard = $acquire;
+        log::debug!(
+            target: "lock",
+            "GOT  {:?} {}:{} {}",
+            std::thread::current().id(),
+            file!(),
+            line!(),
+            stringify!($acquire)
+        );
+        guard
+    }};
+}

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -17,6 +17,7 @@ use std::{
 use bitcoin::{bip32::ChainCode, Amount, Network, OutPoint, PublicKey, Transaction};
 
 use crate::{
+    lock_debug,
     nostr_coinswap::NOSTR_RELAYS,
     protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
     taker::api::REFUND_LOCKTIME_STEP,
@@ -380,9 +381,7 @@ impl ThreadPool {
         stream: Option<Weak<TcpStream>>,
     ) -> Result<(), MakerError> {
         let finished = {
-            let mut threads = self
-                .threads
-                .lock()
+            let mut threads = lock_debug!(self.threads.lock())
                 .map_err(|_| MakerError::General("thread pool lock poisoned"))?;
             let (finished, mut running): (Vec<_>, Vec<_>) = std::mem::take(&mut *threads)
                 .into_iter()
@@ -401,9 +400,7 @@ impl ThreadPool {
     pub fn join_all_threads(&self) -> Result<(), MakerError> {
         loop {
             let mut threads = {
-                let mut owned = self
-                    .threads
-                    .lock()
+                let mut owned = lock_debug!(self.threads.lock())
                     .map_err(|_| MakerError::General("Failed to lock threads"))?;
                 std::mem::take(&mut *owned)
             };
@@ -638,23 +635,17 @@ impl MakerServer {
     pub fn setup_fidelity_bond(&self, maker_address: &str) -> Result<FidelityProof, MakerError> {
         use bitcoin::absolute::LockTime;
 
-        let highest_index = self
-            .wallet
-            .read()
+        let highest_index = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .get_highest_fidelity_index()
             .map_err(MakerError::Wallet)?;
 
-        let mut proof = self
-            .highest_fidelity_proof
-            .write()
+        let mut proof = lock_debug!(self.highest_fidelity_proof.write())
             .map_err(|_| MakerError::General("Failed to lock fidelity proof"))?;
 
         if let Some(i) = highest_index {
             // Existing fidelity bond found
-            let wallet_read = self
-                .wallet
-                .read()
+            let wallet_read = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?;
             let bond = wallet_read
                 .store
@@ -669,9 +660,7 @@ impl MakerServer {
                 .to_sat();
             drop(wallet_read);
 
-            let highest_proof = self
-                .wallet
-                .read()
+            let highest_proof = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .generate_fidelity_proof(i, maker_address)
                 .map_err(MakerError::Wallet)?;
@@ -695,9 +684,7 @@ impl MakerServer {
             let amount = Amount::from_sat(self.config.fidelity_amount);
             log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
 
-            let current_height = self
-                .wallet
-                .read()
+            let current_height = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .blockchain
                 .get_block_count()
@@ -743,15 +730,12 @@ impl MakerServer {
                 sleep_multiplier += 1;
 
                 log::info!("Sync at:----setup_fidelity_bond----");
-                self.wallet
-                    .write()
+                lock_debug!(self.wallet.write())
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?
                     .sync_and_save(&self.shutdown)
                     .map_err(MakerError::Wallet)?;
 
-                let fidelity_result = self
-                    .wallet
-                    .write()
+                let fidelity_result = lock_debug!(self.wallet.write())
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?
                     .create_fidelity(
                         amount,
@@ -770,9 +754,7 @@ impl MakerServer {
                         {
                             log::warn!("Insufficient funds to create fidelity bond.");
                             let needed = required - available;
-                            let addr = self
-                                .wallet
-                                .write()
+                            let addr = lock_debug!(self.wallet.write())
                                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                                 .get_next_external_address(AddressType::P2TR)
                                 .map_err(MakerError::Wallet)?;
@@ -804,16 +786,13 @@ impl MakerServer {
                             self.config.network_port,
                             txid
                         );
-                        let conf_height = self
-                            .wallet
-                            .read()
+                        let conf_height = lock_debug!(self.wallet.read())
                             .map_err(|_| MakerError::General("Failed to lock wallet"))?
                             .wait_for_tx_confirmation(&[txid], 1, Some(&self.shutdown), None)
                             .map_err(MakerError::Wallet)?;
 
                         // Re-acquire write lock briefly to finalize
-                        self.wallet
-                            .write()
+                        lock_debug!(self.wallet.write())
                             .map_err(|_| MakerError::General("Failed to lock wallet"))?
                             .update_fidelity_bond_conf_details(index, conf_height)
                             .map_err(MakerError::Wallet)?;
@@ -822,9 +801,7 @@ impl MakerServer {
                             "[{}] Successfully created fidelity bond",
                             self.config.network_port
                         );
-                        let highest_proof = self
-                            .wallet
-                            .read()
+                        let highest_proof = lock_debug!(self.wallet.read())
                             .map_err(|_| MakerError::General("Failed to lock wallet"))?
                             .generate_fidelity_proof(index, maker_address)
                             .map_err(MakerError::Wallet)?;
@@ -832,8 +809,7 @@ impl MakerServer {
                         *proof = Some(highest_proof);
 
                         log::info!("Sync at end:----setup_fidelity_bond----");
-                        self.wallet
-                            .write()
+                        lock_debug!(self.wallet.write())
                             .map_err(|_| MakerError::General("Failed to lock wallet"))?
                             .sync_and_save(&self.shutdown)
                             .map_err(MakerError::Wallet)?;
@@ -853,24 +829,19 @@ impl MakerServer {
         let sleep_increment = 10u64;
         let mut sleep_duration = 0u64;
 
-        let addr = self
-            .wallet
-            .write()
+        let addr = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .get_next_external_address(AddressType::P2TR)
             .map_err(MakerError::Wallet)?;
 
         while !self.shutdown.load(Ordering::Relaxed) {
             log::info!("Sync at:----check_swap_liquidity----");
-            self.wallet
-                .write()
+            lock_debug!(self.wallet.write())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .sync_and_save(&self.shutdown)
                 .map_err(MakerError::Wallet)?;
 
-            let offer_max_size = self
-                .wallet
-                .read()
+            let offer_max_size = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .store
                 .offer_maxsize;
@@ -916,10 +887,8 @@ impl MakerServer {
             }
         };
 
-        let mut swaps = self
-            .ongoing_swaps
-            .lock()
-            .map_err(|_| MakerError::MutexPossion)?;
+        let mut swaps =
+            lock_debug!(self.ongoing_swaps.lock()).map_err(|_| MakerError::MutexPossion)?;
         let mut idle = Vec::new();
 
         // An accepted swap with no funding material only reserves liquidity;
@@ -992,27 +961,22 @@ impl MakerServer {
 
     /// Remove a completed swap's entry from `ongoing_swaps`.
     pub fn remove_swap_state(&self, swap_id: &str) -> Result<(), MakerError> {
-        let mut swaps = self
-            .ongoing_swaps
-            .lock()
-            .map_err(|_| MakerError::MutexPossion)?;
+        let mut swaps =
+            lock_debug!(self.ongoing_swaps.lock()).map_err(|_| MakerError::MutexPossion)?;
         swaps.remove(swap_id);
         Ok(())
     }
 
     /// Check if any swaps are currently in progress.
     pub fn has_ongoing_swaps(&self) -> Result<bool, MakerError> {
-        Ok(!self
-            .ongoing_swaps
-            .lock()
+        Ok(!lock_debug!(self.ongoing_swaps.lock())
             .map_err(|_| MakerError::MutexPossion)?
             .is_empty())
     }
 
     /// Verify the deniability proof for a specific swap.
     pub fn verify_deniability(&self, swap_id: &str) -> Result<bool, std::io::Error> {
-        self.wallet
-            .read()
+        lock_debug!(self.wallet.read())
             .map_err(|e| std::io::Error::other(format!("wallet lock poisoned: {e}")))?
             .verify_deniability(swap_id)
     }
@@ -1026,17 +990,13 @@ impl MakerTrait for MakerServer {
     fn get_tweakable_keypair(
         &self,
     ) -> Result<(bitcoin::secp256k1::SecretKey, PublicKey, ChainCode), MakerError> {
-        let wallet = self
-            .wallet
-            .read()
+        let wallet = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
         wallet.get_tweakable_keypair().map_err(MakerError::Wallet)
     }
 
     fn get_fidelity_proof(&self) -> Result<FidelityProof, MakerError> {
-        let proof = self
-            .highest_fidelity_proof
-            .read()
+        let proof = lock_debug!(self.highest_fidelity_proof.read())
             .map_err(|_| MakerError::General("Failed to lock fidelity proof"))?;
         proof
             .clone()
@@ -1049,9 +1009,7 @@ impl MakerTrait for MakerServer {
             amount_relative_fee_pct: self.config.amount_relative_fee_pct,
             time_relative_fee_pct: self.config.time_relative_fee_pct,
             min_swap_amount: self.config.min_swap_amount,
-            max_swap_amount: self
-                .wallet
-                .read()
+            max_swap_amount: lock_debug!(self.wallet.read())
                 .map(|w| w.store.offer_maxsize)
                 .unwrap_or(u64::MAX),
             required_confirms: self.config.required_confirms,
@@ -1083,7 +1041,7 @@ impl MakerTrait for MakerServer {
         }
 
         // Check maker has enough liquidity to fund the outgoing swap
-        if let Ok(wallet) = self.wallet.read() {
+        if let Ok(wallet) = lock_debug!(self.wallet.read()) {
             if let Ok(balances) = wallet.get_balances() {
                 let swap_liquidity = balances.regular + balances.swap;
                 if swap_liquidity < details.amount {
@@ -1163,9 +1121,7 @@ impl MakerTrait for MakerServer {
         address: bitcoin::Address,
         excluded_outpoints: Option<Vec<OutPoint>>,
     ) -> Result<(Transaction, u32), MakerError> {
-        let mut wallet = self
-            .wallet
-            .write()
+        let mut wallet = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
         let result = wallet
@@ -1194,9 +1150,7 @@ impl MakerTrait for MakerServer {
     }
 
     fn get_current_height(&self) -> Result<u32, MakerError> {
-        let wallet = self
-            .wallet
-            .read()
+        let wallet = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
         wallet
             .blockchain
@@ -1220,9 +1174,7 @@ impl MakerTrait for MakerServer {
             required_confirms,
             txid
         );
-        let chain = self
-            .wallet
-            .read()
+        let chain = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .blockchain
             .new_connection()
@@ -1240,17 +1192,14 @@ impl MakerTrait for MakerServer {
     }
 
     fn broadcast_transaction(&self, tx: &Transaction) -> Result<bitcoin::Txid, MakerError> {
-        let wallet = self
-            .wallet
-            .read()
+        let wallet = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
         wallet.send_tx(tx).map_err(MakerError::Wallet)
     }
 
     fn is_transaction_known(&self, txid: &bitcoin::Txid) -> bool {
-        self.wallet
-            .read()
+        lock_debug!(self.wallet.read())
             .map(|wallet| wallet.blockchain.get_raw_transaction(txid, None).is_ok())
             .unwrap_or(false)
     }
@@ -1259,9 +1208,7 @@ impl MakerTrait for MakerServer {
         &self,
         swapcoin: &crate::wallet::swapcoin::IncomingSwapCoin,
     ) -> Result<(), MakerError> {
-        let mut wallet = self
-            .wallet
-            .write()
+        let mut wallet = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
         wallet.add_incoming_swapcoin(swapcoin);
         wallet.save_to_disk().map_err(MakerError::Wallet)
@@ -1271,9 +1218,7 @@ impl MakerTrait for MakerServer {
         &self,
         swapcoin: &crate::wallet::swapcoin::OutgoingSwapCoin,
     ) -> Result<(), MakerError> {
-        let mut wallet = self
-            .wallet
-            .write()
+        let mut wallet = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
         wallet.add_outgoing_swapcoin(swapcoin);
         wallet.save_to_disk().map_err(MakerError::Wallet)
@@ -1299,8 +1244,7 @@ impl MakerTrait for MakerServer {
     }
 
     fn sync_and_save_wallet(&self) -> Result<(), MakerError> {
-        self.wallet
-            .write()
+        lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .sync_and_save(&self.shutdown)
             .map_err(MakerError::Wallet)
@@ -1314,9 +1258,7 @@ impl MakerTrait for MakerServer {
 
         // Sweep all completed incoming swapcoins. The sweep takes the lock itself and
         // drops it across its waits, so a stuck tx cannot wedge the wallet.
-        let chain = self
-            .wallet
-            .read()
+        let chain = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .blockchain
             .new_connection()
@@ -1338,8 +1280,7 @@ impl MakerTrait for MakerServer {
             "[{}] Sync at:----sweep_incoming_swapcoins----",
             self.config.network_port
         );
-        self.wallet
-            .write()
+        lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .sync_and_save(&self.shutdown)
             .map_err(MakerError::Wallet)?;
@@ -1356,9 +1297,7 @@ impl MakerTrait for MakerServer {
         // Fetch the balance before taking the swaps lock: reading the wallet
         // under it would stall every handler thread behind a mid-sync writer.
         let swap_liquidity = if admission {
-            let balances = self
-                .wallet
-                .read()
+            let balances = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .get_balances()
                 .map_err(MakerError::Wallet)?;
@@ -1367,7 +1306,7 @@ impl MakerTrait for MakerServer {
             None
         };
 
-        let mut swaps = self.ongoing_swaps.lock()?;
+        let mut swaps = lock_debug!(self.ongoing_swaps.lock())?;
         let is_new = !swaps.contains_key(swap_id);
         if let Some(swap_liquidity) = swap_liquidity.filter(|_| is_new) {
             let active_swaps = swaps
@@ -1479,10 +1418,7 @@ impl MakerTrait for MakerServer {
     }
 
     fn get_connection_state(&self, swap_id: &str) -> Result<Option<ConnectionState>, MakerError> {
-        let swaps = self
-            .ongoing_swaps
-            .lock()
-            .map_err(|_| MakerError::MutexPossion)?;
+        let swaps = lock_debug!(self.ongoing_swaps.lock()).map_err(|_| MakerError::MutexPossion)?;
         Ok(swaps.get(swap_id).map(|s| {
             let mut state = ConnectionState::new(s.protocol);
             state.swap_id = Some(swap_id.to_string());
@@ -1510,10 +1446,7 @@ impl MakerTrait for MakerServer {
 
     fn swap_past_refund_deadline(&self, swap_id: &str) -> Result<bool, MakerError> {
         let current_height = self.get_current_height()?;
-        let swaps = self
-            .ongoing_swaps
-            .lock()
-            .map_err(|_| MakerError::MutexPossion)?;
+        let swaps = lock_debug!(self.ongoing_swaps.lock()).map_err(|_| MakerError::MutexPossion)?;
         Ok(swaps.get(swap_id).is_some_and(|state| {
             past_refund_deadline(
                 state.protocol,
@@ -1533,10 +1466,7 @@ impl MakerTrait for MakerServer {
     }
 
     fn collect_excluded_utxos(&self, current_swap_id: &str) -> Result<Vec<OutPoint>, MakerError> {
-        let swaps = self
-            .ongoing_swaps
-            .lock()
-            .map_err(|_| MakerError::MutexPossion)?;
+        let swaps = lock_debug!(self.ongoing_swaps.lock()).map_err(|_| MakerError::MutexPossion)?;
         Ok(swaps
             .iter()
             .filter(|(id, _)| id.as_str() != current_swap_id)
@@ -1575,8 +1505,7 @@ impl MakerTrait for MakerServer {
                 )
             })
             .collect::<Vec<_>>();
-        self.wallet
-            .write()
+        lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .cache_prevout_to_contract(&bindings)?;
 
@@ -1681,9 +1610,7 @@ impl MakerTrait for MakerServer {
                 self.config.required_confirms.max(MIN_REQUIRED_CONFIRM),
             )?;
 
-            let wallet_read = self
-                .wallet
-                .read()
+            let wallet_read = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
             // A confirmed txid says nothing about its outputs. Without this the taker
@@ -1747,9 +1674,7 @@ impl MakerTrait for MakerServer {
         // Legacy's refund deadline is counted from this height and nothing later can
         // recover it, so record it while the proof is still in hand.
         if let Some(height) = funding_confirmed_at {
-            if let Some(state) = self
-                .ongoing_swaps
-                .lock()
+            if let Some(state) = lock_debug!(self.ongoing_swaps.lock())
                 .map_err(|_| MakerError::MutexPossion)?
                 .get_mut(&message.id)
             {
@@ -1783,9 +1708,7 @@ impl MakerTrait for MakerServer {
             next_multisig_pubkeys.len()
         );
 
-        let mut wallet = self
-            .wallet
-            .write()
+        let mut wallet = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
         let (coinswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = next_multisig_pubkeys
@@ -1867,7 +1790,7 @@ impl MakerTrait for MakerServer {
         multisig_redeemscript: &bitcoin::ScriptBuf,
     ) -> Option<OutgoingSwapCoin> {
         // Check the ongoing swap states for outgoing swapcoins
-        if let Ok(swaps) = self.ongoing_swaps.lock() {
+        if let Ok(swaps) = lock_debug!(self.ongoing_swaps.lock()) {
             for state in swaps.values() {
                 for outgoing in &state.outgoing_swapcoins {
                     if outgoing.protocol == crate::protocol::ProtocolVersion::Legacy {
@@ -1893,7 +1816,7 @@ impl MakerTrait for MakerServer {
         }
 
         // Check outgoing swapcoins in wallet
-        if let Ok(wallet) = self.wallet.read() {
+        if let Ok(wallet) = lock_debug!(self.wallet.read()) {
             if let Some(swapcoin) = wallet.find_outgoing_swapcoin_by_multisig(multisig_redeemscript)
             {
                 log::debug!(
@@ -1936,9 +1859,7 @@ impl MakerRpc for MakerServer {
 
     #[cfg(not(feature = "integration-test"))]
     fn get_tor_hostname(&self) -> Result<String, crate::utill::TorError> {
-        let tor_key_bytes = self
-            .wallet
-            .read()
+        let tor_key_bytes = lock_debug!(self.wallet.read())
             .map_err(|_| crate::utill::TorError::General("wallet lock poisoned".into()))?
             .derive_tor_key();
 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -577,10 +577,13 @@ impl MakerServer {
         // wallet. Without this a restart leaves them undefended.
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
+        // Contracts we cannot watch are contracts we cannot defend: a dead
+        // watcher at startup is fatal, not a warning.
         if !watches.is_empty() {
-            if let Err(e) = watch_service.rebuild_watches(watches) {
+            watch_service.rebuild_watches(watches).map_err(|e| {
                 log::error!("could not rebuild watches on startup: {e}");
-            }
+                MakerError::General("watch rebuild failed on startup")
+            })?;
         }
 
         let swap_tracker = MakerSwapTracker::load_or_create(&data_dir)?;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1353,17 +1353,15 @@ impl MakerTrait for MakerServer {
         state: &ConnectionState,
         admission: bool,
     ) -> Result<(), MakerError> {
-        let should_check_liquidity = {
-            let swaps = self.ongoing_swaps.lock()?;
-            !swaps.contains_key(swap_id)
-        };
-
-        let swap_liquidity = if should_check_liquidity {
-            let wallet = self
+        // Fetch the balance before taking the swaps lock: reading the wallet
+        // under it would stall every handler thread behind a mid-sync writer.
+        let swap_liquidity = if admission {
+            let balances = self
                 .wallet
                 .read()
-                .map_err(|_| MakerError::General("Failed to lock wallet"))?;
-            let balances = wallet.get_balances().map_err(MakerError::Wallet)?;
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .get_balances()
+                .map_err(MakerError::Wallet)?;
             Some(balances.regular + balances.swap)
         } else {
             None
@@ -1371,22 +1369,7 @@ impl MakerTrait for MakerServer {
 
         let mut swaps = self.ongoing_swaps.lock()?;
         let is_new = !swaps.contains_key(swap_id);
-        // The entry can vanish between the two locks (idle drainer, connection
-        // cleanup), making the first-lock classification stale. Re-read the
-        // balance here so admission checks are not skipped for a new swap.
-        let swap_liquidity = match swap_liquidity {
-            Some(liquidity) if is_new => Some(liquidity),
-            None if is_new => {
-                let wallet = self
-                    .wallet
-                    .read()
-                    .map_err(|_| MakerError::General("Failed to lock wallet"))?;
-                let balances = wallet.get_balances().map_err(MakerError::Wallet)?;
-                Some(balances.regular + balances.swap)
-            }
-            _ => None,
-        };
-        if let Some(swap_liquidity) = swap_liquidity {
+        if let Some(swap_liquidity) = swap_liquidity.filter(|_| is_new) {
             let active_swaps = swaps
                 .values()
                 .filter(|state| state.phase != SwapPhase::Completed)

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1369,7 +1369,23 @@ impl MakerTrait for MakerServer {
         };
 
         let mut swaps = self.ongoing_swaps.lock()?;
-        if let Some(swap_liquidity) = swap_liquidity.filter(|_| !swaps.contains_key(swap_id)) {
+        let is_new = !swaps.contains_key(swap_id);
+        // The entry can vanish between the two locks (idle drainer, connection
+        // cleanup), making the first-lock classification stale. Re-read the
+        // balance here so admission checks are not skipped for a new swap.
+        let swap_liquidity = match swap_liquidity {
+            Some(liquidity) if is_new => Some(liquidity),
+            None if is_new => {
+                let wallet = self
+                    .wallet
+                    .read()
+                    .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+                let balances = wallet.get_balances().map_err(MakerError::Wallet)?;
+                Some(balances.regular + balances.swap)
+            }
+            _ => None,
+        };
+        if let Some(swap_liquidity) = swap_liquidity {
             let active_swaps = swaps
                 .values()
                 .filter(|state| state.phase != SwapPhase::Completed)

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -36,6 +36,7 @@ use super::{
     error::MakerError,
     handlers::{
         past_refund_deadline, ConnectionState, Maker as MakerTrait, MakerConfig, SwapPhase,
+        MAX_CONCURRENT_SWAPS,
     },
     rpc::server::MakerRpc,
     swap_tracker::MakerSwapTracker,
@@ -1366,6 +1367,21 @@ impl MakerTrait for MakerServer {
 
         let mut swaps = self.ongoing_swaps.lock()?;
         if let Some(swap_liquidity) = swap_liquidity.filter(|_| !swaps.contains_key(swap_id)) {
+            let active_swaps = swaps
+                .values()
+                .filter(|state| state.phase != SwapPhase::Completed)
+                .count();
+            if active_swaps >= MAX_CONCURRENT_SWAPS {
+                log::warn!(
+                    "[{}] Rejecting swap {}: {} active swaps at the {} cap",
+                    self.config.network_port,
+                    swap_id,
+                    active_swaps,
+                    MAX_CONCURRENT_SWAPS
+                );
+                return Err(MakerError::TooManySwaps);
+            }
+
             let reserved_liquidity = swaps
                 .values()
                 .filter(|state| state.phase != SwapPhase::Completed)

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1351,6 +1351,7 @@ impl MakerTrait for MakerServer {
         &self,
         swap_id: &str,
         state: &ConnectionState,
+        admission: bool,
     ) -> Result<(), MakerError> {
         let should_check_liquidity = {
             let swaps = self.ongoing_swaps.lock()?;
@@ -1422,6 +1423,30 @@ impl MakerTrait for MakerServer {
                     requested: state.swap_amount,
                 });
             }
+        }
+
+        // A resent SwapDetails for a live swap is a reconnect after a dropped
+        // connection: identical parameters just refresh the idle timer, while
+        // different ones must never overwrite the stored swap.
+        if admission && !is_new {
+            let swap_state = swaps
+                .get_mut(swap_id)
+                .expect("entry exists under this lock when !is_new");
+            if swap_state.swap_amount != state.swap_amount
+                || swap_state.tx_count != state.tx_count
+                || swap_state.timelock != state.timelock
+                || swap_state.protocol != state.protocol
+                || swap_state.refund_locktime_offset != state.refund_locktime_offset
+            {
+                log::warn!(
+                    "[{}] Rejecting duplicate SwapDetails for {}: parameters differ from stored swap",
+                    self.config.network_port,
+                    swap_id,
+                );
+                return Err(MakerError::SwapParamMismatch);
+            }
+            swap_state.last_activity = Instant::now();
+            return Ok(());
         }
 
         let swap_state = swaps.entry(swap_id.to_string()).or_default();

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1310,8 +1310,15 @@ impl MakerTrait for MakerServer {
 
         // Sweep all completed incoming swapcoins. The sweep takes the lock itself and
         // drops it across its waits, so a stuck tx cannot wedge the wallet.
+        let chain = self
+            .wallet
+            .read()
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?
+            .blockchain
+            .new_connection()
+            .map_err(MakerError::Wallet)?;
         let sweep_outcome =
-            Wallet::sweep_incoming_swapcoins(&self.wallet, MIN_FEE_RATE, &self.shutdown)
+            Wallet::sweep_incoming_swapcoins(&self.wallet, &chain, MIN_FEE_RATE, &self.shutdown)
                 .map_err(MakerError::Wallet)?;
 
         if !sweep_outcome.is_empty() {

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -41,6 +41,8 @@ pub enum MakerError {
     },
     /// Represents a maker-side rejection because the concurrent swap cap is reached.
     TooManySwaps,
+    /// Represents a resent SwapDetails whose admission parameters differ from the stored swap.
+    SwapParamMismatch,
     /// Represents a mutex poisoning error.
     MutexPossion,
     /// Represents an error related to secp256k1 operations.

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -39,6 +39,8 @@ pub enum MakerError {
         /// Liquidity requested by the new swap.
         requested: Amount,
     },
+    /// Represents a maker-side rejection because the concurrent swap cap is reached.
+    TooManySwaps,
     /// Represents a mutex poisoning error.
     MutexPossion,
     /// Represents an error related to secp256k1 operations.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -65,6 +65,11 @@ pub enum MakerBehavior {
 /// Minimum time required to react to contract broadcasts (in blocks).
 pub const MIN_CONTRACT_REACTION_TIME: u16 = 10;
 
+/// Each admitted swap pins a connection thread and liquidity until it settles
+/// or times out. Past this cap, reject new SwapDetails instead of stacking
+/// unfunded admissions.
+pub(crate) const MAX_CONCURRENT_SWAPS: usize = 30;
+
 /// The taker's declared offset is also its claimed reaction window. Too small a
 /// value means neither side can act on the contract.
 pub(crate) fn offset_meets_reaction_time(refund_locktime_offset: u16) -> bool {
@@ -575,7 +580,16 @@ fn handle_swap_details<M: Maker>(
     state.service_fee_sats = swap_fee.to_sat();
     state.phase = SwapPhase::AwaitingContractData;
 
-    maker.store_connection_state(&details.id, state)?;
+    // A capacity rejection must reach the taker as a message, not a dropped
+    // connection, or it waits out a timeout before trying the next maker.
+    match maker.store_connection_state(&details.id, state) {
+        Err(MakerError::TooManySwaps) => {
+            return Ok(Some(MakerToTakerMessage::AckSwapDetails(
+                AckSwapDetails::reject(),
+            )));
+        }
+        result => result?,
+    }
 
     let (_, tweakable_point, _) = maker.get_tweakable_keypair()?;
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -303,10 +303,12 @@ pub trait Maker: Send + Sync {
     fn sweep_incoming_swapcoins(&self) -> Result<(), MakerError>;
 
     /// Store connection state for persistence across connections.
+    /// `admission` is set only when storing from a fresh SwapDetails message.
     fn store_connection_state(
         &self,
         swap_id: &str,
         state: &ConnectionState,
+        admission: bool,
     ) -> Result<(), MakerError>;
 
     /// Retrieve stored connection state.
@@ -472,7 +474,7 @@ pub fn handle_message<M: Maker>(
                 id
             );
             if let Some(stored_state) = maker.get_connection_state(id)? {
-                maker.store_connection_state(id, &stored_state)?;
+                maker.store_connection_state(id, &stored_state, false)?;
             }
             state.touch();
             Ok(None)
@@ -580,10 +582,12 @@ fn handle_swap_details<M: Maker>(
     state.service_fee_sats = swap_fee.to_sat();
     state.phase = SwapPhase::AwaitingContractData;
 
-    // A capacity rejection must reach the taker as a message, not a dropped
+    // An admission rejection must reach the taker as a message, not a dropped
     // connection, or it waits out a timeout before trying the next maker.
-    match maker.store_connection_state(&details.id, state) {
-        Err(MakerError::TooManySwaps) => {
+    match maker.store_connection_state(&details.id, state, true) {
+        // A param mismatch means the id already belongs to a live swap; both
+        // arms are terminal rejections and get the same reset.
+        Err(MakerError::TooManySwaps | MakerError::SwapParamMismatch) => {
             // A rejected admission must leave no live phase: with AwaitingContractData
             // still set, the taker could send ContractData and drive funding for a
             // swap we refused. Nothing was stored, so restore_state_if_needed stays a no-op.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -60,6 +60,8 @@ pub enum MakerBehavior {
     MalformedLegacyFundingOutput,
     /// Underfund the Taproot contract while claiming the expected amount.
     UnderfundTaprootContract,
+    /// Deduct one extra satoshi beyond the advertised fee.
+    FeeSkimming,
 }
 
 /// Minimum time required to react to contract broadcasts (in blocks).

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -584,6 +584,16 @@ fn handle_swap_details<M: Maker>(
     // connection, or it waits out a timeout before trying the next maker.
     match maker.store_connection_state(&details.id, state) {
         Err(MakerError::TooManySwaps) => {
+            // A rejected admission must leave no live phase: with AwaitingContractData
+            // still set, the taker could send ContractData and drive funding for a
+            // swap we refused. Nothing was stored, so restore_state_if_needed stays a no-op.
+            state.phase = SwapPhase::AwaitingSwapDetails;
+            state.swap_id = None;
+            state.swap_amount = Amount::ZERO;
+            state.tx_count = 0;
+            state.timelock = 0;
+            state.refund_locktime_offset = 0;
+            state.service_fee_sats = 0;
             return Ok(Some(MakerToTakerMessage::AckSwapDetails(
                 AckSwapDetails::reject(),
             )));

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -323,6 +323,14 @@ fn process_proof_of_funding<M: Maker>(
         .checked_sub(swap_fee)
         .and_then(|amt| amt.checked_sub(mining_fee))
         .ok_or(MakerError::General("Swap fee exceeds incoming amount"))?;
+    #[cfg(feature = "integration-test")]
+    let outgoing_amount = if maker.behavior() == super::handlers::MakerBehavior::FeeSkimming {
+        outgoing_amount
+            .checked_sub(Amount::from_sat(1))
+            .ok_or(MakerError::General("Test fee skim exceeds outgoing amount"))?
+    } else {
+        outgoing_amount
+    };
 
     log::info!(
         "[{}] Incoming: {}, Fee: {}, MiningFee: {}, Outgoing: {}",

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -118,7 +118,7 @@ fn process_req_contract_sigs_for_sender<M: Maker>(
     );
 
     // Store connection state for persistence
-    maker.store_connection_state(&req.id, state)?;
+    maker.store_connection_state(&req.id, state, false)?;
 
     let response = crate::protocol::legacy_messages::RespContractSigsForSender { id: req.id, sigs };
 
@@ -462,7 +462,7 @@ fn process_proof_of_funding<M: Maker>(
     }
 
     state.phase = SwapPhase::AwaitingSignaturesOrPreimage;
-    maker.store_connection_state(&pof.id, state)?;
+    maker.store_connection_state(&pof.id, state, false)?;
 
     log::info!(
         "[{}] Created {} outgoing swapcoins, requesting signatures",
@@ -565,7 +565,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
             for outgoing in &state.outgoing_swapcoins {
                 maker.save_outgoing_swapcoin(outgoing)?;
             }
-            maker.store_connection_state(&resp.id, state)?;
+            maker.store_connection_state(&resp.id, state, false)?;
             return Err(MakerError::General("Test: skipped funding broadcast"));
         }
     }
@@ -653,7 +653,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
     state.funding_broadcast = true;
     state.phase = SwapPhase::AwaitingPrivateKeyHandover;
 
-    maker.store_connection_state(&resp.id, state)?;
+    maker.store_connection_state(&resp.id, state, false)?;
 
     #[cfg(feature = "integration-test")]
     {

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -16,6 +16,7 @@ use super::messages::{AuthenticatedRpcRequest, RpcMsgReq};
 #[cfg(not(feature = "integration-test"))]
 use crate::utill::TorError;
 use crate::{
+    lock_debug,
     maker::{
         api::{MakerServerConfig, ShutdownSignal},
         error::MakerError,
@@ -96,9 +97,7 @@ fn handle_request<M: MakerRpc>(
     let resp = match rpc_request {
         RpcMsgReq::Ping => RpcMsgResp::Pong,
         RpcMsgReq::ContractUtxo => {
-            let utxos = maker
-                .wallet()
-                .read()?
+            let utxos = lock_debug!(maker.wallet().read())?
                 .list_live_timelock_contract_spend_info()
                 .into_iter()
                 .map(|(utxo, spend_info)| UTXO::from_utxo_data((utxo.clone(), spend_info.clone())))
@@ -106,9 +105,7 @@ fn handle_request<M: MakerRpc>(
             RpcMsgResp::ContractUtxoResp { utxos }
         }
         RpcMsgReq::FidelityUtxo => {
-            let utxos = maker
-                .wallet()
-                .read()?
+            let utxos = lock_debug!(maker.wallet().read())?
                 .list_fidelity_spend_info()
                 .into_iter()
                 .map(|(utxo, spend_info)| UTXO::from_utxo_data((utxo.clone(), spend_info.clone())))
@@ -116,9 +113,7 @@ fn handle_request<M: MakerRpc>(
             RpcMsgResp::FidelityUtxoResp { utxos }
         }
         RpcMsgReq::Utxo => {
-            let utxos = maker
-                .wallet()
-                .read()?
+            let utxos = lock_debug!(maker.wallet().read())?
                 .list_all_utxo_spend_info()
                 .into_iter()
                 .map(|(utxo, spend_info)| UTXO::from_utxo_data((utxo.clone(), spend_info.clone())))
@@ -126,9 +121,7 @@ fn handle_request<M: MakerRpc>(
             RpcMsgResp::UtxoResp { utxos }
         }
         RpcMsgReq::SwapUtxo => {
-            let utxos = maker
-                .wallet()
-                .read()?
+            let utxos = lock_debug!(maker.wallet().read())?
                 .list_incoming_swap_coin_utxo_spend_info()
                 .into_iter()
                 .map(|(utxo, spend_info)| UTXO::from_utxo_data((utxo.clone(), spend_info.clone())))
@@ -136,13 +129,11 @@ fn handle_request<M: MakerRpc>(
             RpcMsgResp::SwapUtxoResp { utxos }
         }
         RpcMsgReq::Balances => {
-            let balances = maker.wallet().read()?.get_balances()?;
+            let balances = lock_debug!(maker.wallet().read())?.get_balances()?;
             RpcMsgResp::TotalBalanceResp(balances)
         }
         RpcMsgReq::NewAddress => {
-            let new_address = maker
-                .wallet()
-                .write()?
+            let new_address = lock_debug!(maker.wallet().write())?
                 .get_next_external_address(AddressType::P2TR)?;
             RpcMsgResp::NewAddressResp(new_address.to_string())
         }
@@ -164,21 +155,23 @@ fn handle_request<M: MakerRpc>(
                 change_address_type: AddressType::P2TR,
             };
 
-            let coins_to_send =
-                maker
-                    .wallet()
-                    .read()?
-                    .coin_select(amount, feerate, address_type, None, None)?;
-            let tx =
-                maker
-                    .wallet()
-                    .write()?
-                    .spend_from_wallet(feerate, destination, &coins_to_send)?;
+            let coins_to_send = lock_debug!(maker.wallet().read())?.coin_select(
+                amount,
+                feerate,
+                address_type,
+                None,
+                None,
+            )?;
+            let tx = lock_debug!(maker.wallet().write())?.spend_from_wallet(
+                feerate,
+                destination,
+                &coins_to_send,
+            )?;
 
-            let txid = maker.wallet().read()?.send_tx(&tx)?;
+            let txid = lock_debug!(maker.wallet().read())?.send_tx(&tx)?;
 
             log::info!("Sync at:----handle_request----");
-            maker.wallet().write()?.sync_and_save(maker.shutdown())?;
+            lock_debug!(maker.wallet().write())?.sync_and_save(maker.shutdown())?;
 
             RpcMsgResp::SendToAddressResp(txid.to_string())
         }
@@ -200,12 +193,12 @@ fn handle_request<M: MakerRpc>(
         }
 
         RpcMsgReq::ListFidelity => {
-            let list = maker.wallet().read()?.display_fidelity_bonds()?;
+            let list = lock_debug!(maker.wallet().read())?.display_fidelity_bonds()?;
             RpcMsgResp::ListBonds(list)
         }
         RpcMsgReq::SyncWallet => {
             log::info!("Initializing wallet sync");
-            let mut wallet = maker.wallet().write()?;
+            let mut wallet = lock_debug!(maker.wallet().write())?;
             if let Err(e) = wallet.sync_and_save(maker.shutdown()) {
                 RpcMsgResp::ServerError(e.to_string())
             } else {
@@ -214,7 +207,7 @@ fn handle_request<M: MakerRpc>(
             }
         }
         RpcMsgReq::VerifyDeniability { swap_id } => {
-            match maker.wallet().read()?.verify_deniability(&swap_id) {
+            match lock_debug!(maker.wallet().read())?.verify_deniability(&swap_id) {
                 Ok(valid) => RpcMsgResp::VerifyDeniabilityResp(valid),
                 Err(e) => RpcMsgResp::ServerError(e.to_string()),
             }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -14,6 +14,7 @@ use std::{
 #[cfg(not(feature = "integration-test"))]
 use crate::maker::rpc::server::MakerRpc;
 use crate::{
+    lock_debug,
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
     utill::{HEART_BEAT_INTERVAL, MAX_RPC_MESSAGE_SIZE},
@@ -87,9 +88,7 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
 
     // Check for unfinished swapcoins from a previous run and start recovery.
     {
-        let (inc, out) = maker
-            .wallet
-            .read()
+        let (inc, out) = lock_debug!(maker.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .find_unfinished_swapcoins();
         if !inc.is_empty() || !out.is_empty() {
@@ -144,9 +143,7 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     }
 
     {
-        let wallet = maker
-            .wallet
-            .read()
+        let wallet = lock_debug!(maker.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
         log::info!(
             "[{}] Bitcoin Network: {}",
@@ -251,9 +248,7 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
         std::process::id(),
         maker.config.network_port
     );
-    let save_result = maker
-        .wallet
-        .write()
+    let save_result = lock_debug!(maker.wallet.write())
         .map_err(|_| MakerError::General("Failed to lock wallet"))
         .and_then(|wallet| wallet.save_to_disk().map_err(MakerError::Wallet));
     log::info!(
@@ -533,9 +528,7 @@ fn check_for_idle_states(maker: Arc<MakerServer>) -> Result<(), MakerError> {
                 updated_at: now,
             };
 
-            if let Err(e) = maker
-                .swap_tracker
-                .lock()
+            if let Err(e) = lock_debug!(maker.swap_tracker.lock())
                 .map_err(|_| MakerError::MutexPossion)?
                 .save_record(&record)
             {
@@ -608,9 +601,7 @@ fn fidelity_renewal_loop(maker: Arc<MakerServer>, maker_address: &str) -> Result
         );
 
         // Redeem any expired bonds
-        if let Err(e) = maker
-            .wallet
-            .write()
+        if let Err(e) = lock_debug!(maker.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .redeem_expired_fidelity_bonds(AddressType::P2TR)
         {
@@ -703,9 +694,7 @@ fn check_for_preimage_via_watchtower(
     );
 
     // Apply extracted preimages to incoming swapcoins in the wallet.
-    let mut wallet = maker
-        .wallet
-        .write()
+    let mut wallet = lock_debug!(maker.wallet.write())
         .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
     for incoming in incoming_swapcoins {
@@ -763,7 +752,7 @@ fn update_tracker(
     swap_id: &str,
     f: impl FnOnce(&mut super::swap_tracker::MakerSwapRecord),
 ) {
-    let mut tracker = match maker.swap_tracker.lock() {
+    let mut tracker = match lock_debug!(maker.swap_tracker.lock()) {
         Ok(tracker) => tracker,
         Err(_) => {
             log::error!("Swap tracker lock poisoned, skipping update for {swap_id}");
@@ -805,9 +794,7 @@ fn recover_from_swap(
         .and_then(|o| o.get_timelock())
         .ok_or(MakerError::General("missing timelock on outgoing swapcoin"))?;
 
-    let start_height = maker
-        .wallet
-        .read()
+    let start_height = lock_debug!(maker.wallet.read())
         .map_err(|_| MakerError::General("Failed to lock wallet"))?
         .blockchain
         .get_block_count()
@@ -823,9 +810,7 @@ fn recover_from_swap(
     );
 
     let all_swap_contracts_resolved = || -> Result<bool, MakerError> {
-        let wallet = maker
-            .wallet
-            .read()
+        let wallet = lock_debug!(maker.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
         let contract_txids = outgoing_swapcoins
@@ -850,9 +835,7 @@ fn recover_from_swap(
     // funding_broadcast=false is safe to discard; missing tracker state can
     // happen after a reboot and must not delete persisted recovery material.
     {
-        let funding_broadcast = maker
-            .swap_tracker
-            .lock()
+        let funding_broadcast = lock_debug!(maker.swap_tracker.lock())
             .map_err(|_| MakerError::MutexPossion)?
             .get_record(&swap_id)
             .map(|r| r.funding_broadcast);
@@ -865,9 +848,7 @@ fn recover_from_swap(
             );
 
             {
-                let mut wallet = maker
-                    .wallet
-                    .write()
+                let mut wallet = lock_debug!(maker.wallet.write())
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?;
                 for outgoing in &outgoing_swapcoins {
                     let key = outgoing.contract_tx.compute_txid().to_string();
@@ -903,9 +884,7 @@ fn recover_from_swap(
 
         // Check if all incoming swapcoins now have preimages
         let all_preimages_known = {
-            let wallet = maker
-                .wallet
-                .read()
+            let wallet = lock_debug!(maker.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?;
             incoming_swapcoins.iter().all(|incoming| {
                 // Wallet stores incoming swapcoins keyed by contract txid.
@@ -916,9 +895,7 @@ fn recover_from_swap(
             })
         };
 
-        let current_height = maker
-            .wallet
-            .read()
+        let current_height = lock_debug!(maker.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?
             .blockchain
             .get_block_count()
@@ -931,9 +908,7 @@ fn recover_from_swap(
             || current_height >= timelock_expiry
         {
             Some(
-                maker
-                    .wallet
-                    .read()
+                lock_debug!(maker.wallet.read())
                     .map_err(|_| MakerError::General("Failed to lock wallet"))?
                     .blockchain
                     .new_connection()
@@ -949,9 +924,7 @@ fn recover_from_swap(
                 maker.config.network_port
             );
 
-            maker
-                .wallet
-                .write()
+            lock_debug!(maker.wallet.write())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
                 .sync_and_save(&maker.shutdown)
                 .map_err(MakerError::Wallet)?;
@@ -984,9 +957,7 @@ fn recover_from_swap(
                 // someone else (hashlock), so they are no longer recoverable
                 // via timelock. Remove them from the wallet store.
                 {
-                    let mut wallet = maker
-                        .wallet
-                        .write()
+                    let mut wallet = lock_debug!(maker.wallet.write())
                         .map_err(|_| MakerError::General("Failed to lock wallet"))?;
                     for outgoing in &outgoing_swapcoins {
                         // Wallet stores outgoing swapcoins keyed by contract txid.
@@ -1003,9 +974,7 @@ fn recover_from_swap(
                 });
 
                 // Emit hashlock recovery reports
-                let network = maker
-                    .wallet
-                    .read()
+                let network = lock_debug!(maker.wallet.read())
                     .map(|w| w.store.network.to_string())
                     .unwrap_or_default();
                 let recovery_txids: Vec<String> = swept
@@ -1083,9 +1052,7 @@ fn recover_from_swap(
                     });
 
                     // Emit timelock recovery reports
-                    let network = maker
-                        .wallet
-                        .read()
+                    let network = lock_debug!(maker.wallet.read())
                         .map(|w| w.store.network.to_string())
                         .unwrap_or_default();
                     let recovery_txids: Vec<String> = timelock_recovery_txids

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -664,20 +664,17 @@ fn check_for_preimage_via_watchtower(
             };
             // Blocking on purpose: we need this pass's fresh answer before
             // choosing timelock over hashlock — a stale miss refunds while a
-            // preimage spend already exists.
-            let reply = match maker.watch_service.watch_request(outpoint) {
-                Ok(reply) => reply,
-                // If something is wrong at watchtower, log the error, don't suppress fully.
-                Err(e) => {
-                    log::error!("watch request for {outpoint} failed (watcher gone): {e}");
-                    continue;
-                }
-            };
+            // preimage spend already exists. A query that fails after retries
+            // is fatal: abort the pass rather than refund blind.
+            let reply = maker.watch_service.watch_request(outpoint).map_err(|e| {
+                log::error!("watch request for {outpoint} failed (watcher gone): {e}");
+                MakerError::General("watchtower query failed, aborting recovery pass")
+            })?;
 
-            if let Some(crate::watch_tower::watcher::WatcherEvent::UtxoSpent {
+            if let crate::watch_tower::watcher::WatcherEvent::UtxoSpent {
                 spending_tx: Some(spending_tx),
                 ..
-            }) = reply
+            } = reply
             {
                 // Extract preimages from the spending transaction's witnesses.
                 for input in &spending_tx.input {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -932,8 +932,17 @@ fn recover_from_swap(
                 .sync_and_save(&maker.shutdown)
                 .map_err(MakerError::Wallet)?;
 
+            let chain = maker
+                .wallet
+                .read()
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .blockchain
+                .new_connection()
+                .map_err(MakerError::Wallet)?;
+
             let swept = Wallet::sweep_incoming_swapcoins(
                 &maker.wallet,
+                &chain,
                 crate::utill::MIN_FEE_RATE,
                 &maker.shutdown,
             )
@@ -1022,8 +1031,17 @@ fn recover_from_swap(
                 r.recovery.phase = MakerRecoveryPhase::TimelockWaiting;
             });
 
+            let chain = maker
+                .wallet
+                .read()
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .blockchain
+                .new_connection()
+                .map_err(MakerError::Wallet)?;
+
             let recovered = Wallet::recover_timelocked_swapcoins(
                 &maker.wallet,
+                &chain,
                 crate::utill::MIN_FEE_RATE,
                 &maker.shutdown,
             )

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -916,6 +916,33 @@ fn recover_from_swap(
             })
         };
 
+        let current_height = maker
+            .wallet
+            .read()
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?
+            .blockchain
+            .get_block_count()
+            .map_err(MakerError::Wallet)? as u32;
+
+        // One connection per pass, shared by both recovery paths below: on Tor
+        // Electrum each fresh connection costs a circuit handshake. Idle passes
+        // that only poll the watchtower pay for none.
+        let chain = if (all_preimages_known && !incoming_swapcoins.is_empty())
+            || current_height >= timelock_expiry
+        {
+            Some(
+                maker
+                    .wallet
+                    .read()
+                    .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                    .blockchain
+                    .new_connection()
+                    .map_err(MakerError::Wallet)?,
+            )
+        } else {
+            None
+        };
+
         if all_preimages_known && !incoming_swapcoins.is_empty() {
             log::info!(
                 "[{}] All preimages known, recovering via hashlock path",
@@ -929,17 +956,11 @@ fn recover_from_swap(
                 .sync_and_save(&maker.shutdown)
                 .map_err(MakerError::Wallet)?;
 
-            let chain = maker
-                .wallet
-                .read()
-                .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .blockchain
-                .new_connection()
-                .map_err(MakerError::Wallet)?;
+            let chain = chain.as_ref().expect("connection created for this branch");
 
             let swept = Wallet::sweep_incoming_swapcoins(
                 &maker.wallet,
-                &chain,
+                chain,
                 crate::utill::MIN_FEE_RATE,
                 &maker.shutdown,
             )
@@ -1007,14 +1028,6 @@ fn recover_from_swap(
         }
 
         // --- Timelock path: reclaim outgoing after timelock expires ---
-        let current_height = maker
-            .wallet
-            .read()
-            .map_err(|_| MakerError::General("Failed to lock wallet"))?
-            .blockchain
-            .get_block_count()
-            .map_err(MakerError::Wallet)? as u32;
-
         if current_height >= timelock_expiry {
             log::info!(
                 "[{}] Timelock expired at {} (expiry={}), recovering via timelock path",
@@ -1028,17 +1041,11 @@ fn recover_from_swap(
                 r.recovery.phase = MakerRecoveryPhase::TimelockWaiting;
             });
 
-            let chain = maker
-                .wallet
-                .read()
-                .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .blockchain
-                .new_connection()
-                .map_err(MakerError::Wallet)?;
+            let chain = chain.as_ref().expect("connection created for this branch");
 
             let recovered = Wallet::recover_timelocked_swapcoins(
                 &maker.wallet,
-                &chain,
+                chain,
                 crate::utill::MIN_FEE_RATE,
                 &maker.shutdown,
             )

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -421,7 +421,7 @@ fn process_taproot_contract<M: Maker>(
             for outgoing in &outgoing_swapcoins {
                 maker.save_outgoing_swapcoin(outgoing)?;
             }
-            maker.store_connection_state(&data.id, state)?;
+            maker.store_connection_state(&data.id, state, false)?;
             return Err(MakerError::General("Test: skipped funding broadcast"));
         }
     }
@@ -498,7 +498,7 @@ fn process_taproot_contract<M: Maker>(
     state.funding_broadcast = true;
     state.phase = SwapPhase::AwaitingPrivateKeyHandover;
 
-    maker.store_connection_state(&data.id, state)?;
+    maker.store_connection_state(&data.id, state, false)?;
 
     #[cfg(feature = "integration-test")]
     {

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use bitcoin::{Amount, OutPoint, PublicKey};
 use bitcoind::bitcoincore_rpc::{jsonrpc::error::Error as JsonRpcError, Error as BitcoinRpcError};
 
+#[cfg(feature = "integration-test")]
+use super::handlers::MakerBehavior;
 use super::{
     error::MakerError,
     handlers::{
@@ -273,7 +275,17 @@ fn process_taproot_contract<M: Maker>(
 
     let base_excluded = maker.collect_excluded_utxos(&data.id)?;
 
-    for &outgoing_amount in &outgoing_amounts {
+    for &expected_outgoing_amount in &outgoing_amounts {
+        #[cfg(feature = "integration-test")]
+        let outgoing_amount = if maker.behavior() == MakerBehavior::FeeSkimming {
+            expected_outgoing_amount
+                .checked_sub(Amount::from_sat(1))
+                .ok_or(MakerError::General("Test fee skim exceeds outgoing amount"))?
+        } else {
+            expected_outgoing_amount
+        };
+        #[cfg(not(feature = "integration-test"))]
+        let outgoing_amount = expected_outgoing_amount;
         let outgoing_nonce =
             bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
         let outgoing_privkey = tweakable_privkey

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -24,6 +24,7 @@ use nostr::{
 use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
+    lock_debug,
     nostr_coinswap::{coinswap_kind, connect_nostr_websocket, EXPIRATION_SECS},
     wallet::{AnyBlockchain, Blockchain},
     watch_tower::{
@@ -392,7 +393,7 @@ fn handle_relay_message(
 
             // Claim the txid before any RPC work, so duplicate events and
             // concurrent relay sessions don't repeat the fetch and validation.
-            if !seen_txid.lock()?.claim(txid) {
+            if !lock_debug!(seen_txid.lock())?.claim(txid) {
                 log::info!("Skipping already-seen txid {txid} via {relay_url}");
                 registry.save_nostr_cursor(relay_url, cursor)?;
                 return Ok(false);
@@ -403,14 +404,14 @@ fn handle_relay_message(
                 Err(e) => {
                     log::warn!("Failed to fetch raw tx {txid:?} via {relay_url}: {e}");
                     // A transient fetch failure leaves the txid eligible for retry.
-                    seen_txid.lock()?.release(&txid);
+                    lock_debug!(seen_txid.lock())?.release(&txid);
                     return Ok(false);
                 }
             };
 
             // The txid is marked seen once fetched (regardless of validation outcome) so a relay
             // replaying an invalid txid can't force re-validation every time;
-            seen_txid.lock()?.insert(txid);
+            lock_debug!(seen_txid.lock())?.insert(txid);
             log::info!("Added txid to Nostr discovery cache: {txid}");
 
             match process_fidelity(&tx) {

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -118,6 +118,13 @@ impl AckSwapDetails {
             tweakable_point: Some(tweakable_point),
         }
     }
+
+    /// Create a rejection response.
+    pub fn reject() -> Self {
+        AckSwapDetails {
+            tweakable_point: None,
+        }
+    }
 }
 
 /// A private key exchanged during swap completion.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -624,29 +624,56 @@ impl Taker {
     fn init_recover_wallet(&mut self) {
         log::info!("Checking wallet for unresolved swap contracts...");
 
-        // The sweep takes the lock itself and drops it across its waits, so a stuck
-        // counterparty tx cannot wedge taker startup.
-        match Wallet::sweep_incoming_swapcoins(&self.wallet, 2.0, &crate::utill::NO_SHUTDOWN) {
-            Ok(ref swept) if !swept.is_empty() => {
-                log::info!(
-                    "Startup recovery: swept {} incoming swapcoins",
-                    swept.resolved.len()
-                );
+        // One connection serves both startup recovery passes; the sweep and
+        // timelock recovery each take the lock themselves and drop it across
+        // their waits, so a stuck counterparty tx cannot wedge taker startup.
+        let chain = match self.read_wallet() {
+            Ok(w) => match w.blockchain.new_connection() {
+                Ok(chain) => Some(chain),
+                Err(e) => {
+                    log::warn!("Startup recovery: no backend connection: {:?}", e);
+                    None
+                }
+            },
+            Err(e) => {
+                log::warn!("Startup recovery: failed to lock wallet: {:?}", e);
+                None
             }
-            Ok(_) => {}
-            Err(e) => log::warn!("Startup incoming sweep failed: {:?}", e),
-        }
+        };
 
-        // Wallet-driven recovery: recover timelocked. Also takes the lock itself.
-        match Wallet::recover_timelocked_swapcoins(&self.wallet, 2.0, &crate::utill::NO_SHUTDOWN) {
-            Ok(ref recovered) if !recovered.is_empty() => {
-                log::info!(
-                    "Startup recovery: recovered {} timelocked outgoing swapcoins",
-                    recovered.len()
-                );
+        if let Some(chain) = &chain {
+            match Wallet::sweep_incoming_swapcoins(
+                &self.wallet,
+                chain,
+                2.0,
+                &crate::utill::NO_SHUTDOWN,
+            ) {
+                Ok(ref swept) if !swept.is_empty() => {
+                    log::info!(
+                        "Startup recovery: swept {} incoming swapcoins",
+                        swept.resolved.len()
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("Startup incoming sweep failed: {:?}", e),
             }
-            Ok(_) => {}
-            Err(e) => log::warn!("Startup timelock recovery failed: {:?}", e),
+
+            // Wallet-driven recovery: recover timelocked. Also takes the lock itself.
+            match Wallet::recover_timelocked_swapcoins(
+                &self.wallet,
+                chain,
+                2.0,
+                &crate::utill::NO_SHUTDOWN,
+            ) {
+                Ok(ref recovered) if !recovered.is_empty() => {
+                    log::info!(
+                        "Startup recovery: recovered {} timelocked outgoing swapcoins",
+                        recovered.len()
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("Startup timelock recovery failed: {:?}", e),
+            }
         }
 
         let has_remaining = match self.write_wallet() {
@@ -1133,8 +1160,12 @@ impl Taker {
         // Success path: sweep + report (shared by both protocols)
         let swap_id_owned = swap_id.to_string();
         let expected_incoming_swapcoins = self.swap_state()?.incoming_swapcoins.len();
-        let swept =
-            Wallet::sweep_incoming_swapcoins(&self.wallet, 2.0, &crate::utill::NO_SHUTDOWN)?;
+        let swept = Wallet::sweep_incoming_swapcoins(
+            &self.wallet,
+            &self.read_wallet()?.blockchain.new_connection()?,
+            2.0,
+            &crate::utill::NO_SHUTDOWN,
+        )?;
         log::info!("Swept {} incoming swapcoins", swept.resolved.len());
         self.write_wallet()?
             .sync_and_save(&crate::utill::NO_SHUTDOWN)?;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -29,6 +29,7 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 
 use crate::{
+    lock_debug,
     nostr_coinswap::NOSTR_RELAYS,
     protocol::{
         common_messages::{
@@ -456,7 +457,8 @@ impl Drop for Taker {
             if let Ok(record) = self.persist_build_record(swap) {
                 // Drop can't propagate; a poisoned tracker must not abort the
                 // process while we're already unwinding.
-                let mut tracker = self.swap_tracker.lock().unwrap_or_else(|e| e.into_inner());
+                let mut tracker =
+                    lock_debug!(self.swap_tracker.lock()).unwrap_or_else(|e| e.into_inner());
                 if let Err(e) = tracker.save_record(&record) {
                     log::error!("Failed to flush swap tracker on shutdown: {:?}", e);
                 }
@@ -485,7 +487,7 @@ impl Drop for Taker {
             log::error!("Failed to persist offerbook: {:?}", e);
             save_ok = false;
         }
-        if let Ok(wallet) = self.wallet.write() {
+        if let Ok(wallet) = lock_debug!(self.wallet.write()) {
             if let Err(e) = wallet.save_to_disk() {
                 log::error!("Failed to save wallet: {:?}", e);
                 save_ok = false;
@@ -509,15 +511,13 @@ impl Role for Taker {
 impl Taker {
     /// Acquire a read lock on the wallet.
     pub(crate) fn read_wallet(&self) -> Result<RwLockReadGuard<'_, Wallet>, TakerError> {
-        self.wallet
-            .read()
+        lock_debug!(self.wallet.read())
             .map_err(|_| TakerError::General("Failed to lock wallet".to_string()))
     }
 
     /// Acquire a write lock on the wallet.
     pub(crate) fn write_wallet(&self) -> Result<RwLockWriteGuard<'_, Wallet>, TakerError> {
-        self.wallet
-            .write()
+        lock_debug!(self.wallet.write())
             .map_err(|_| TakerError::General("Failed to lock wallet".to_string()))
     }
 
@@ -594,8 +594,7 @@ impl Taker {
             shutdown.clone(),
         )?;
         let swap_tracker = Arc::new(Mutex::new(SwapTracker::load_or_create(&data_dir)?));
-        swap_tracker
-            .lock()
+        lock_debug!(swap_tracker.lock())
             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?
             .cleanup_incomplete();
 
@@ -814,7 +813,7 @@ impl Taker {
     /// Log the current swap tracker state at INFO level.
     pub fn log_tracker_state(&self) {
         // Info-only path; a poisoned tracker should not kill the caller.
-        let Ok(tracker) = self.swap_tracker.lock() else {
+        let Ok(tracker) = lock_debug!(self.swap_tracker.lock()) else {
             log::error!("swap tracker lock poisoned; skipping tracker state log");
             return;
         };
@@ -1047,9 +1046,7 @@ impl Taker {
                             }
                         } else {
                             log::info!("No funds on-chain — safe to abort");
-                            let _ = self
-                                .swap_tracker
-                                .lock()
+                            let _ = lock_debug!(self.swap_tracker.lock())
                                 .map_err(|_| {
                                     TakerError::General("swap tracker lock poisoned".into())
                                 })?
@@ -1079,9 +1076,7 @@ impl Taker {
                         }
                     } else {
                         log::info!("No funds on-chain — safe to abort");
-                        let _ = self
-                            .swap_tracker
-                            .lock()
+                        let _ = lock_debug!(self.swap_tracker.lock())
                             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?
                             .remove_record(
                                 &self.swap_state().map(|s| s.id.clone()).unwrap_or_default(),
@@ -2220,9 +2215,7 @@ impl Taker {
 
         // Snapshot preserved fields from any existing record.
         let swap_id = self.swap_state()?.id.clone();
-        let tracker_guard = self
-            .swap_tracker
-            .lock()
+        let tracker_guard = lock_debug!(self.swap_tracker.lock())
             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?;
         let existing = tracker_guard.get_record(&swap_id);
         let created_at = existing.map(|r| r.created_at);
@@ -2249,8 +2242,7 @@ impl Taker {
             record.failure_reason = Some(reason);
         }
 
-        self.swap_tracker
-            .lock()
+        lock_debug!(self.swap_tracker.lock())
             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?
             .save_record(&record)
     }
@@ -2272,7 +2264,7 @@ impl Taker {
                 record.updated_at = now_secs();
                 // The failure was already reported to the caller; a poisoned
                 // tracker here is no reason to panic.
-                let Ok(mut tracker) = self.swap_tracker.lock() else {
+                let Ok(mut tracker) = lock_debug!(self.swap_tracker.lock()) else {
                     log::error!("swap tracker lock poisoned; skipping failure persist");
                     return;
                 };
@@ -2600,8 +2592,7 @@ impl Taker {
                 })?
         };
 
-        self.swap_tracker
-            .lock()
+        lock_debug!(self.swap_tracker.lock())
             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?
             .update_and_save(&swap_id, |record| {
                 record.phase = SwapPhase::Failed;
@@ -2672,8 +2663,7 @@ impl Taker {
             }
         }
 
-        self.swap_tracker
-            .lock()
+        lock_debug!(self.swap_tracker.lock())
             .map_err(|_| TakerError::General("swap tracker lock poisoned".into()))?
             .update_and_save(swap_id, |r| {
                 r.recovery.incoming = incoming_outcomes;
@@ -2686,8 +2676,7 @@ impl Taker {
 
     /// Verify the deniability proof for a specific swap.
     pub fn verify_deniability(&self, swap_id: &str) -> Result<bool, std::io::Error> {
-        self.wallet
-            .read()
+        lock_debug!(self.wallet.read())
             .map_err(|e| std::io::Error::other(format!("wallet lock poisoned: {e}")))?
             .verify_deniability(swap_id)
     }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1124,7 +1124,15 @@ impl Taker {
             return Err(err);
         }
 
-        self.finalize_persist_incoming()?;
+        // Die with the contracts accepted but nothing settled and no recovery
+        // run — the window where incoming coins would exist only in memory.
+        #[cfg(feature = "integration-test")]
+        if self.behavior == TakerBehavior::CrashAfterContractExchange {
+            log::warn!("Test behavior: crashing after contract exchange");
+            let err = TakerError::General("Test: crashed after contract exchange".to_string());
+            self.persist_failure(SwapPhase::ContractsExchanged, &err);
+            return Err(err);
+        }
 
         // SP7: Finalization starts.
         self.persist_swap(SwapPhase::Finalizing)?;
@@ -1946,7 +1954,7 @@ impl Taker {
 
         self.persist_swap(SwapPhase::PrivkeysForwarded)?;
 
-        self.finalize_persist_incoming()?;
+        self.persist_incoming_swapcoins()?;
 
         log::info!("Swap finalized successfully");
         Ok(())
@@ -2101,9 +2109,10 @@ impl Taker {
         Ok(())
     }
 
-    /// Persist the taker's incoming swapcoins to the wallet.
-    /// Preimage is already stamped at swapcoin creation time.
-    fn finalize_persist_incoming(&mut self) -> Result<(), TakerError> {
+    /// Persist incoming swapcoins, keyed by contract txid so repeats overwrite.
+    /// Called when contracts are accepted — a crash before finalization must not
+    /// lose what the taker is owed — and again after the privkey handover.
+    pub(crate) fn persist_incoming_swapcoins(&mut self) -> Result<(), TakerError> {
         let incoming = self.swap_state()?.incoming_swapcoins.clone();
         let mut wallet = self.write_wallet()?;
         for swapcoin in &incoming {
@@ -2113,7 +2122,7 @@ impl Taker {
         wallet.save_to_disk()?;
         #[cfg(debug_assertions)]
         log::debug!(
-            "[WALLET_STATE] Action: persist_final_incoming | Added: {} | IncomingStored: {}",
+            "[WALLET_STATE] Action: persist_incoming | Added: {} | IncomingStored: {}",
             incoming.len(),
             wallet.get_incoming_swapcoins_count()
         );
@@ -2784,4 +2793,8 @@ pub enum TakerBehavior {
     /// no key handed over and no recovery run. Leaves every party's contract
     /// unclaimed so only a restart can settle them (restart_rebuilds_watches).
     CrashBeforeRecovery,
+    /// Die right after the contract exchange, before finalization and with no
+    /// recovery run — the window where incoming coins would otherwise exist only
+    /// in memory (crash_after_contract_exchange).
+    CrashAfterContractExchange,
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1170,9 +1170,12 @@ impl Taker {
         // Success path: sweep + report (shared by both protocols)
         let swap_id_owned = swap_id.to_string();
         let expected_incoming_swapcoins = self.swap_state()?.incoming_swapcoins.len();
+        // Hoist connection creation so the read guard drops before sweep
+        // takes the write lock on the same wallet.
+        let chain = self.read_wallet()?.blockchain.new_connection()?;
         let swept = Wallet::sweep_incoming_swapcoins(
             &self.wallet,
-            &self.read_wallet()?.blockchain.new_connection()?,
+            &chain,
             2.0,
             &crate::utill::NO_SHUTDOWN,
         )?;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -570,10 +570,12 @@ impl Taker {
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
         watches.extend(wallet.watchonly_contract_outpoints());
+        // Contracts we cannot watch are contracts we cannot defend: a dead
+        // watcher at startup is fatal, not a warning.
         if !watches.is_empty() {
-            if let Err(e) = watch_service.rebuild_watches(watches) {
-                log::error!("could not rebuild watches on startup: {e}");
-            }
+            watch_service.rebuild_watches(watches).map_err(|e| {
+                TakerError::General(format!("could not rebuild watches on startup: {e}"))
+            })?;
         }
 
         Self::init_taker_config(&config, &data_dir)?;

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -62,41 +62,66 @@ impl RecoveryLoop {
             .spawn(move || {
                 log::info!("Recovery loop started");
                 while !shutdown_clone.load(Relaxed) {
+                    // One connection per pass, shared by all three steps below:
+                    // on Tor Electrum each fresh connection costs a circuit handshake.
+                    let chain = match wallet.read() {
+                        Ok(w) => match w.blockchain.new_connection() {
+                            Ok(chain) => chain,
+                            Err(e) => {
+                                log::warn!("Recovery loop: no connection: {:?}", e);
+                                thread::park_timeout(RECOVERY_LOOP_INTERVAL);
+                                continue;
+                            }
+                        },
+                        Err(_) => {
+                            thread::park_timeout(RECOVERY_LOOP_INTERVAL);
+                            continue;
+                        }
+                    };
+
                     // Try hashlock sweep (incoming). It takes the lock itself and drops
                     // it across its waits, so a stuck tx cannot wedge the wallet.
-                    let incoming_result =
-                        match Wallet::sweep_incoming_swapcoins(&wallet, 2.0, &shutdown_clone) {
-                            Ok(ref swept) if !swept.is_empty() => {
-                                log::info!(
-                                    "Recovery loop: swept {} incoming swapcoins",
-                                    swept.resolved.len()
-                                );
-                                Some(swept.clone())
-                            }
-                            Err(e) => {
-                                log::debug!("Recovery loop: incoming sweep: {:?}", e);
-                                None
-                            }
-                            _ => None,
-                        };
+                    let incoming_result = match Wallet::sweep_incoming_swapcoins(
+                        &wallet,
+                        &chain,
+                        2.0,
+                        &shutdown_clone,
+                    ) {
+                        Ok(ref swept) if !swept.is_empty() => {
+                            log::info!(
+                                "Recovery loop: swept {} incoming swapcoins",
+                                swept.resolved.len()
+                            );
+                            Some(swept.clone())
+                        }
+                        Err(e) => {
+                            log::debug!("Recovery loop: incoming sweep: {:?}", e);
+                            None
+                        }
+                        _ => None,
+                    };
 
                     // Try timelock recovery (outgoing). Same deal — it manages the
                     // lock itself and never holds it across a confirmation wait.
-                    let outgoing_result =
-                        match Wallet::recover_timelocked_swapcoins(&wallet, 2.0, &shutdown_clone) {
-                            Ok(ref recovered) if !recovered.is_empty() => {
-                                log::info!(
-                                    "Recovery loop: recovered {} timelocked swapcoins",
-                                    recovered.len()
-                                );
-                                Some(recovered.clone())
-                            }
-                            Err(e) => {
-                                log::debug!("Recovery loop: timelock recovery: {:?}", e);
-                                None
-                            }
-                            _ => None,
-                        };
+                    let outgoing_result = match Wallet::recover_timelocked_swapcoins(
+                        &wallet,
+                        &chain,
+                        2.0,
+                        &shutdown_clone,
+                    ) {
+                        Ok(ref recovered) if !recovered.is_empty() => {
+                            log::info!(
+                                "Recovery loop: recovered {} timelocked swapcoins",
+                                recovered.len()
+                            );
+                            Some(recovered.clone())
+                        }
+                        Err(e) => {
+                            log::debug!("Recovery loop: timelock recovery: {:?}", e);
+                            None
+                        }
+                        _ => None,
+                    };
 
                     // Update tracker outcomes from recovery results
                     if incoming_result.is_some() || outgoing_result.is_some() {
@@ -109,26 +134,20 @@ impl RecoveryLoop {
                         }
                     }
 
-                    // Snapshot the outpoints and a connection, then drop the guard:
-                    // the checks below are backend calls and must not hold the wallet.
-                    let snapshot = match wallet.read() {
+                    // Snapshot the outpoints, then drop the guard: the checks below
+                    // are backend calls and must not hold the wallet.
+                    let outpoints = match wallet.read() {
                         Ok(w) => {
                             let mut outpoints = w.outgoing_contract_outpoints();
                             outpoints.extend(w.incoming_contract_outpoints());
-                            match w.blockchain.new_connection() {
-                                Ok(chain) => Some((outpoints, chain)),
-                                Err(e) => {
-                                    log::warn!("Recovery loop: no connection: {:?}", e);
-                                    None
-                                }
-                            }
+                            Some(outpoints)
                         }
                         Err(_) => None,
                     };
 
                     // Check if all contract outpoints are resolved
-                    let all_resolved = match snapshot {
-                        Some((outpoints, chain)) => outpoints.iter().all(|(op, spk)| {
+                    let all_resolved = match outpoints {
+                        Some(outpoints) => outpoints.iter().all(|(op, spk)| {
                             // Only a confirmed spend proves a contract resolved;
                             // a missing output also means evicted or unknown, and
                             // a failed lookup keeps us watching.

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -441,7 +441,8 @@ impl BreachDetector {
                     };
 
                     for (outpoint, expected_contract_txid) in &current_sentinels {
-                        // If a watch request fails, log the error, don't panic.
+                        // The poll loop is the retry here: a failed query is
+                        // logged and re-asked on the next pass.
                         let reply = match watch_service.watch_request(*outpoint) {
                             Ok(reply) => reply,
                             Err(e) => {
@@ -451,10 +452,10 @@ impl BreachDetector {
                                 continue;
                             }
                         };
-                        if let Some(WatcherEvent::UtxoSpent {
+                        if let WatcherEvent::UtxoSpent {
                             spending_tx: Some(ref tx),
                             ..
-                        }) = reply
+                        } = reply
                         {
                             let actual_txid = tx.compute_txid();
                             if actual_txid == *expected_contract_txid {

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -16,6 +16,7 @@ use std::{
 use bitcoin::{OutPoint, Txid};
 
 use crate::{
+    lock_debug,
     taker::error::TakerError,
     utill::HEART_BEAT_INTERVAL,
     wallet::{Blockchain, RecoveryReport, Wallet},
@@ -64,7 +65,7 @@ impl RecoveryLoop {
                 while !shutdown_clone.load(Relaxed) {
                     // One connection per pass, shared by all three steps below:
                     // on Tor Electrum each fresh connection costs a circuit handshake.
-                    let chain = match wallet.read() {
+                    let chain = match lock_debug!(wallet.read()) {
                         Ok(w) => match w.blockchain.new_connection() {
                             Ok(chain) => chain,
                             Err(e) => {
@@ -125,7 +126,7 @@ impl RecoveryLoop {
 
                     // Update tracker outcomes from recovery results
                     if incoming_result.is_some() || outgoing_result.is_some() {
-                        if let Ok(mut tracker) = swap_tracker.lock() {
+                        if let Ok(mut tracker) = lock_debug!(swap_tracker.lock()) {
                             Self::update_tracker_outcomes(
                                 &mut tracker,
                                 incoming_result.as_ref(),
@@ -136,7 +137,7 @@ impl RecoveryLoop {
 
                     // Snapshot the outpoints, then drop the guard: the checks below
                     // are backend calls and must not hold the wallet.
-                    let outpoints = match wallet.read() {
+                    let outpoints = match lock_debug!(wallet.read()) {
                         Ok(w) => {
                             let mut outpoints = w.outgoing_contract_outpoints();
                             outpoints.extend(w.incoming_contract_outpoints());
@@ -165,8 +166,7 @@ impl RecoveryLoop {
                     if all_resolved {
                         log::info!("Recovery loop: all contracts resolved");
                         // Clean up wallet entries and update tracker
-                        let swap_ids: Vec<String> = swap_tracker
-                            .lock()
+                        let swap_ids: Vec<String> = lock_debug!(swap_tracker.lock())
                             .ok()
                             .map(|t| {
                                 t.incomplete_swaps()
@@ -176,7 +176,7 @@ impl RecoveryLoop {
                             })
                             .unwrap_or_default();
 
-                        if let Ok(mut w) = wallet.write() {
+                        if let Ok(mut w) = lock_debug!(wallet.write()) {
                             for swap_id in &swap_ids {
                                 let keys = w.outgoing_keys_for_swap(swap_id);
                                 for key in &keys {
@@ -187,11 +187,10 @@ impl RecoveryLoop {
                             let _ = w.save_to_disk();
                         }
 
-                        if let Ok(mut tracker) = swap_tracker.lock() {
+                        if let Ok(mut tracker) = lock_debug!(swap_tracker.lock()) {
                             // Emit recovery reports before marking as cleaned up
                             for record in tracker.incomplete_swaps() {
-                                let network = wallet
-                                    .read()
+                                let network = lock_debug!(wallet.read())
                                     .map(|w| w.store.network.to_string())
                                     .unwrap_or_default();
                                 let all_outcomes = record
@@ -435,7 +434,7 @@ impl BreachDetector {
                         break;
                     }
 
-                    let current_sentinels = match sentinels_clone.lock() {
+                    let current_sentinels = match lock_debug!(sentinels_clone.lock()) {
                         Ok(guard) => guard.clone(),
                         Err(_) => continue,
                     };
@@ -510,7 +509,7 @@ impl BreachDetector {
                     ))
                 })?;
         }
-        if let Ok(mut guard) = self.sentinels.lock() {
+        if let Ok(mut guard) = lock_debug!(self.sentinels.lock()) {
             #[cfg(debug_assertions)]
             log::debug!(
                 "[WATCH_STATE] Source: taker::background_services::add_sentinels | Action: register_breach_sentinels | Added: {} | Total: {}",

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -837,6 +837,7 @@ impl Taker {
                 "Stored {} receiver contract signatures on incoming swapcoins",
                 receiver_sigs.len()
             );
+            self.persist_incoming_swapcoins()?;
         }
 
         // SP6-L: All makers responded, incoming swapcoins created.

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -23,6 +23,7 @@ use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    lock_debug,
     protocol::{
         common_messages::{
             FidelityProof, GetOffer as RouterGetOffer,
@@ -273,9 +274,7 @@ impl OfferBookHandle {
 
     /// Gets the current snapshot of whole offerbook
     pub fn snapshot(&self) -> Result<OfferBook, TakerError> {
-        Ok(self
-            .inner
-            .read()
+        Ok(lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .clone())
     }
@@ -283,8 +282,7 @@ impl OfferBookHandle {
     /// Tag a maker as bad
     pub fn add_bad_maker(&self, maker: &OfferAndAddress) -> Result<(), TakerError> {
         log::info!("Bad Maker added: {}", maker.address);
-        self.inner
-            .write()
+        lock_debug!(self.inner.write())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .mark_bad(&maker.address);
         Ok(())
@@ -295,18 +293,14 @@ impl OfferBookHandle {
         &self,
         protocol: &MakerProtocol,
     ) -> Result<Vec<OfferAndAddress>, TakerError> {
-        Ok(self
-            .inner
-            .read()
+        Ok(lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .active_makers(protocol))
     }
 
     /// Fetch all good makers
     pub fn good_makers(&self) -> Result<Vec<OfferAndAddress>, TakerError> {
-        Ok(self
-            .inner
-            .read()
+        Ok(lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .good_makers())
     }
@@ -316,27 +310,21 @@ impl OfferBookHandle {
         &self,
         protocol: &MakerProtocol,
     ) -> Result<Vec<OfferAndAddress>, TakerError> {
-        Ok(self
-            .inner
-            .read()
+        Ok(lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .get_bad_makers(protocol))
     }
 
     /// Fetch all makers good, bad, and unresponsive
     pub fn all_makers(&self) -> Result<Vec<MakerOfferCandidate>, TakerError> {
-        Ok(self
-            .inner
-            .read()
+        Ok(lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .all_makers())
     }
 
     /// Checks if an address is bad or not
     pub fn is_bad_maker(&self, offer_and_address: &OfferAndAddress) -> Result<bool, TakerError> {
-        let offerbook = self
-            .inner
-            .read()
+        let offerbook = lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?;
         let value = offerbook
             .makers
@@ -351,8 +339,7 @@ impl OfferBookHandle {
 
     /// Persist offerbook on disk
     pub fn persist(&self) -> Result<(), TakerError> {
-        self.inner
-            .read()
+        lock_debug!(self.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .write_to_disk(&self.path)
     }
@@ -360,9 +347,7 @@ impl OfferBookHandle {
     /// Remove a maker from the offerbook by address.
     /// Returns `true` if an entry was removed, `false` if no matching address was found.
     pub fn remove(&self, address: &MakerAddress) -> Result<bool, TakerError> {
-        let mut book = self
-            .inner
-            .write()
+        let mut book = lock_debug!(self.inner.write())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?;
         let before = book.makers.len();
         book.makers.retain(|m| &m.address != address);
@@ -578,10 +563,7 @@ impl OfferSyncService {
         };
         let fidelities = self.registry.list_fidelity(height)?;
         {
-            let mut book = self
-                .offerbook
-                .inner
-                .write()
+            let mut book = lock_debug!(self.offerbook.inner.write())
                 .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?;
             for fidelity in fidelities {
                 match MakerAddress::try_from(fidelity.onion_address) {
@@ -593,10 +575,7 @@ impl OfferSyncService {
             }
         }
 
-        let to_poll = self
-            .offerbook
-            .inner
-            .read()
+        let to_poll = lock_debug!(self.offerbook.inner.read())
             .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?
             .makers_to_poll(now);
 
@@ -650,7 +629,7 @@ impl OfferSyncService {
         });
         // Poison means a worker panicked mid-update; skip this maker instead
         // of panicking the whole worker pool.
-        let mut book = match offerbook.write() {
+        let mut book = match lock_debug!(offerbook.write()) {
             Ok(book) => book,
             Err(_) => {
                 log::error!("offerbook lock poisoned; skipping maker {addr}");
@@ -683,7 +662,7 @@ impl OfferSyncService {
 
         // Ensure the maker is present in the offerbook before polling.
         // Same poison policy as fetch_and_record_one: skip this poll.
-        match self.offerbook.inner.write() {
+        match lock_debug!(self.offerbook.inner.write()) {
             Ok(mut book) => book.upsert_address(address.clone(), None),
             Err(_) => {
                 log::error!("offerbook lock poisoned; skipping poll of {address}");
@@ -749,7 +728,9 @@ impl OfferSyncService {
                             break;
                         }
                         let addr = {
-                            let Ok(mut guard) = queue.lock() else { break };
+                            let Ok(mut guard) = lock_debug!(queue.lock()) else {
+                                break;
+                            };
                             guard.next()
                         };
                         let Some(addr) = addr else { break };

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -80,6 +80,8 @@ const DISCOVERY_WAIT_MAX: Duration = Duration::from_secs(150);
 #[cfg(feature = "integration-test")]
 const DISCOVERY_WAIT_MAX: Duration = Duration::from_secs(10);
 
+const OFFER_SYNC_WAIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
 /// Represents an offer along with the corresponding maker address.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OfferAndAddress {
@@ -448,12 +450,9 @@ pub struct OfferSyncClient {
 }
 
 impl OfferSyncClient {
-    /// Trigger an offerbook sync and block until it completes.
+    /// Trigger an offerbook sync and wait up to ten minutes for completion.
     pub fn sync_and_wait(&self) -> Result<(), TakerError> {
-        let (done_tx, done_rx) = mpsc::channel();
-        self.cmd_tx.send(SyncCommand::SyncNow(done_tx))?;
-        done_rx.recv()?;
-        Ok(())
+        sync_and_wait(&self.cmd_tx, OFFER_SYNC_WAIT_TIMEOUT)
     }
 
     /// Run a single-maker offer fetch + fidelity verification cycle for `address`
@@ -501,12 +500,9 @@ impl OfferSyncHandle {
         }
     }
 
-    /// Trigger an offerbook sync and block until it completes.
+    /// Trigger an offerbook sync and wait up to ten minutes for completion.
     pub fn sync_and_wait(&self) -> Result<(), TakerError> {
-        let (done_tx, done_rx) = mpsc::channel();
-        self.cmd_tx.send(SyncCommand::SyncNow(done_tx))?;
-        done_rx.recv()?;
-        Ok(())
+        sync_and_wait(&self.cmd_tx, OFFER_SYNC_WAIT_TIMEOUT)
     }
 
     /// Run a single-maker offer fetch + fidelity verification cycle for `address`
@@ -526,6 +522,19 @@ impl OfferSyncHandle {
                 "Maker {address_str} was removed before the poll could record a result"
             ))
         })
+    }
+}
+
+fn sync_and_wait(cmd_tx: &mpsc::Sender<SyncCommand>, timeout: Duration) -> Result<(), TakerError> {
+    let (done_tx, done_rx) = mpsc::channel();
+    cmd_tx.send(SyncCommand::SyncNow(done_tx))?;
+    match done_rx.recv_timeout(timeout) {
+        Ok(()) => Ok(()),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            log::warn!("Offer sync exceeded {timeout:?}; using the current offerbook");
+            Ok(())
+        }
+        Err(e @ mpsc::RecvTimeoutError::Disconnected) => Err(e.into()),
     }
 }
 
@@ -1454,5 +1463,13 @@ mod tests {
             book.makers[0].state,
             MakerState::Unresponsive { retries: 1 }
         );
+    }
+
+    #[test]
+    fn timed_sync_uses_current_book_when_ack_is_missing() {
+        let (cmd_tx, cmd_rx) = mpsc::channel();
+
+        sync_and_wait(&cmd_tx, Duration::ZERO).unwrap();
+        assert!(matches!(cmd_rx.recv().unwrap(), SyncCommand::SyncNow(_)));
     }
 }

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -456,6 +456,7 @@ impl Taker {
                     if is_last_maker {
                         // Only the last maker's contract is addressed to the taker.
                         self.exchange_create_incoming(&maker_contract, my_privkey)?;
+                        self.persist_incoming_swapcoins()?;
                     } else {
                         // Intermediate contracts (maker→maker) are watch-only for the taker.
                         let mut watchonly = Vec::new();

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -51,6 +51,7 @@ pub(crate) fn global_secp() -> &'static Secp256k1<All> {
 
 use crate::{
     error::NetError,
+    lock_debug,
     protocol::{contract::derive_maker_pubkey_and_nonce, error::ProtocolError},
     wallet::{SecretMnemonic, UTXOSpendInfo, WalletError},
 };
@@ -801,7 +802,7 @@ pub fn prompt_password(message: String) -> io::Result<String> {
     let mut password = String::new();
     let mut buf = [0u8; 1];
 
-    while stdin.lock().read(&mut buf)? == 1 {
+    while lock_debug!(stdin.lock()).read(&mut buf)? == 1 {
         let c = buf[0] as char;
 
         match c {
@@ -839,7 +840,7 @@ pub fn prompt_password(message: String) -> io::Result<String> {
 /// Writes a new wallet's seed phrase to stdout, shown once at wallet creation.
 /// Returns write errors instead of panicking like `println!`.
 pub fn print_new_wallet_seed(mnemonic: &SecretMnemonic) -> io::Result<()> {
-    let mut out = io::stdout().lock();
+    let mut out = lock_debug!(io::stdout().lock());
     writeln!(out, "\n========== New Wallet Seed Phrase ==========")?;
     writeln!(out, "{}", mnemonic.words())?;
     writeln!(

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -36,6 +36,7 @@ use serde_json::{json, Value};
 use std::path::Path;
 
 use crate::{
+    lock_debug,
     protocol::contract::create_multisig_redeemscript,
     utill::{
         compute_checksum, generate_keypair, get_hd_path_from_descriptor,
@@ -882,8 +883,7 @@ impl Wallet {
 
         // Snapshot everything the recovery needs, then drop the guard before any wait.
         let candidates = {
-            let mut w = wallet
-                .write()
+            let mut w = lock_debug!(wallet.write())
                 .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
 
             let candidates: Vec<_> = w
@@ -1007,8 +1007,7 @@ impl Wallet {
             // A retry must rebuild the same transaction. Persist its destination
             // before broadcasting so a failed wait cannot burn another index.
             let recovery_address = {
-                let mut w = wallet
-                    .write()
+                let mut w = lock_debug!(wallet.write())
                     .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
                 let stored = w
                     .store
@@ -1062,7 +1061,7 @@ impl Wallet {
                             outcome.resolved.push((contract_txid, txid));
 
                             // Re-acquire the guard only to record the recovery.
-                            let mut w = wallet.write().map_err(|_| {
+                            let mut w = lock_debug!(wallet.write()).map_err(|_| {
                                 WalletError::General("wallet lock poisoned".to_string())
                             })?;
                             w.remove_outgoing_swapcoin(&swap_id);
@@ -1078,8 +1077,7 @@ impl Wallet {
             }
         }
 
-        let mut w = wallet
-            .write()
+        let mut w = lock_debug!(wallet.write())
             .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
 
         for id in &discarded {
@@ -2769,8 +2767,7 @@ impl Wallet {
 
         // Snapshot everything the sweep needs, then drop the guard before any wait.
         let completed_swapcoins = {
-            let mut w = wallet
-                .write()
+            let mut w = lock_debug!(wallet.write())
                 .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
 
             let completed_swapcoins: Vec<_> = w
@@ -2955,8 +2952,7 @@ impl Wallet {
             // grow the watch window forever. Take the guard just for this, so
             // nothing below waits with it held.
             let internal_address = {
-                let mut w = wallet
-                    .write()
+                let mut w = lock_debug!(wallet.write())
                     .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
                 let addr = w.get_next_internal_addresses(1, AddressType::P2TR)?[0].clone();
                 // Mark the sweep target before broadcast, not after confirmation: a
@@ -3001,7 +2997,7 @@ impl Wallet {
                             log::info!("Successfully swept incoming swap coin: {}", swap_id);
 
                             // Re-acquire the guard only to drop the swept coin.
-                            let mut w = wallet.write().map_err(|_| {
+                            let mut w = lock_debug!(wallet.write()).map_err(|_| {
                                 WalletError::General("wallet lock poisoned".to_string())
                             })?;
                             w.remove_incoming_swapcoin(&swap_id);
@@ -3013,8 +3009,7 @@ impl Wallet {
                                 e
                             );
                             // Sweep never happened; unmark the address.
-                            wallet
-                                .write()
+                            lock_debug!(wallet.write())
                                 .map_err(|_| {
                                     WalletError::General("wallet lock poisoned".to_string())
                                 })?
@@ -3031,8 +3026,7 @@ impl Wallet {
                         e
                     );
                     // Sweep never happened; unmark the address.
-                    wallet
-                        .write()
+                    lock_debug!(wallet.write())
                         .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?
                         .store
                         .swept_incoming_swapcoins
@@ -3041,8 +3035,7 @@ impl Wallet {
             }
         }
 
-        let w = wallet
-            .write()
+        let w = lock_debug!(wallet.write())
             .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
         w.save_to_disk()?;
         if !outcome.is_empty() {

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -870,17 +870,18 @@ impl Wallet {
 
     /// Attempt to recover timelocked outgoing swapcoins.
     ///
-    /// Takes the wallet lock, not a guard: the confirmation waits run on a fresh
-    /// backend connection with no guard held, so a slow tx cannot wedge the wallet.
+    /// The caller supplies the backend connection: the confirmation waits run
+    /// on it with no wallet guard held, so a slow tx cannot wedge the wallet.
     pub fn recover_timelocked_swapcoins(
         wallet: &std::sync::RwLock<Wallet>,
+        chain: &AnyBlockchain,
         fee_rate: f64,
         shutdown: &std::sync::atomic::AtomicBool,
     ) -> Result<RecoveryOutcome, WalletError> {
         let mut outcome = RecoveryOutcome::default();
 
         // Snapshot everything the recovery needs, then drop the guard before any wait.
-        let (candidates, chain) = {
+        let candidates = {
             let mut w = wallet
                 .write()
                 .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
@@ -902,8 +903,7 @@ impl Wallet {
 
             w.sync_and_save(shutdown)?;
 
-            let chain = w.blockchain.new_connection()?;
-            (candidates, chain)
+            candidates
         };
 
         let current_height = chain.get_block_count()? as u32;
@@ -953,7 +953,7 @@ impl Wallet {
         for (swap_id, swapcoin, timelock) in to_recover {
             let contract_txid = swapcoin.contract_tx.compute_txid();
             let contract_vout = swapcoin.get_contract_output_vout();
-            match Self::ensure_contract_on_chain(&chain, &swap_id, &swapcoin)? {
+            match Self::ensure_contract_on_chain(chain, &swap_id, &swapcoin)? {
                 ContractChainState::OnChain => {}
                 ContractChainState::Discarded => {
                     discarded.push(swap_id.clone());
@@ -1046,7 +1046,7 @@ impl Wallet {
                             // leaves it for the next pass to rebroadcast; dropping it
                             // here would strand the funds if this tx never confirms.
                             let conf_height = wait_for_tx_confirmation(
-                                &chain,
+                                chain,
                                 &[txid],
                                 1,
                                 TX_BROADCAST_TIMEOUT,
@@ -2757,17 +2757,18 @@ impl Wallet {
     /// preimage cascade, the taker may end up with both the incoming sweep and
     /// its own timelock refund — the double cost lands on the faulty maker.
     ///
-    /// Takes the wallet lock, not a guard: the confirmation waits run on a fresh
-    /// backend connection with no guard held, so a slow tx cannot wedge the wallet.
+    /// The caller supplies the backend connection: the confirmation waits run
+    /// on it with no wallet guard held, so a slow tx cannot wedge the wallet.
     pub fn sweep_incoming_swapcoins(
         wallet: &std::sync::RwLock<Wallet>,
+        chain: &AnyBlockchain,
         feerate: f64,
         shutdown: &std::sync::atomic::AtomicBool,
     ) -> Result<RecoveryOutcome, WalletError> {
         let mut outcome = RecoveryOutcome::default();
 
         // Snapshot everything the sweep needs, then drop the guard before any wait.
-        let (completed_swapcoins, chain) = {
+        let completed_swapcoins = {
             let mut w = wallet
                 .write()
                 .map_err(|_| WalletError::General("wallet lock poisoned".to_string()))?;
@@ -2789,8 +2790,7 @@ impl Wallet {
 
             w.sync_and_save(shutdown)?;
 
-            let chain = w.blockchain.new_connection()?;
-            (completed_swapcoins, chain)
+            completed_swapcoins
         };
 
         log::info!(
@@ -2871,7 +2871,7 @@ impl Wallet {
                         swap_id
                     );
                     match wait_for_tx_confirmation(
-                        &chain,
+                        chain,
                         &[utxo_txid],
                         1,
                         TX_BROADCAST_TIMEOUT,
@@ -2984,7 +2984,7 @@ impl Wallet {
                     match chain.send_raw_transaction(&spend_tx) {
                         Ok(txid) => {
                             let conf_height = wait_for_tx_confirmation(
-                                &chain,
+                                chain,
                                 &[txid],
                                 1,
                                 TX_BROADCAST_TIMEOUT,

--- a/src/wallet/blockchain/corerpc.rs
+++ b/src/wallet/blockchain/corerpc.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::{BlockRef, Blockchain, WatchEvent};
-use crate::wallet::error::WalletError;
+use crate::{lock_debug, wallet::error::WalletError};
 
 /// Configuration for connecting to a Bitcoin Core node via JSON-RPC + ZMQ.
 #[derive(Debug, Clone)]
@@ -94,9 +94,7 @@ impl ZmqSubscriber {
     /// scan backstop the handshake window — without it, a transaction landing in
     /// that gap could be missed by both the scan and the ZMQ feed.
     fn ensure_connected(&self) -> Result<(), WalletError> {
-        let mut guard = self
-            .socket
-            .lock()
+        let mut guard = lock_debug!(self.socket.lock())
             .map_err(|_| WalletError::Zmq("ZMQ socket mutex poisoned".to_string()))?;
         if guard.is_some() {
             return Ok(());
@@ -129,7 +127,7 @@ impl ZmqSubscriber {
             log::warn!("ZMQ connect {}: {e:?}", self.addr);
             return None;
         }
-        let mut guard = self.socket.lock().ok()?;
+        let mut guard = lock_debug!(self.socket.lock()).ok()?;
         let received = {
             let socket = guard.as_ref()?;
             socket.recv_multipart(zmq::DONTWAIT)

--- a/src/wallet/blockchain/electrum.rs
+++ b/src/wallet/blockchain/electrum.rs
@@ -38,7 +38,7 @@ use electrum_client::{
 use serde_json::{json, Value};
 
 use super::{network_from_electrum_genesis, BlockRef, Blockchain, HdOrigin, WatchEvent};
-use crate::wallet::error::WalletError;
+use crate::{lock_debug, wallet::error::WalletError};
 
 /// Configuration for connecting to an Electrum-protocol server.
 ///
@@ -433,8 +433,7 @@ impl Electrum {
     /// Outpoints currently holding this script's subscription open. Zero means no
     /// entry exists, so the server was told to unsubscribe.
     pub fn subscription_watchers(&self, spk: &Script) -> usize {
-        self.notifier
-            .lock()
+        lock_debug!(self.notifier.lock())
             .unwrap_or_else(|e| {
                 log::warn!("electrum notifier lock poisoned; recovering");
                 e.into_inner()
@@ -530,7 +529,7 @@ impl Electrum {
         &self,
         f: &impl Fn(&ElectrumClient) -> Result<T, electrum_client::Error>,
     ) -> Result<T, electrum_client::Error> {
-        let client = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        let client = lock_debug!(self.inner.read()).unwrap_or_else(|e| e.into_inner());
         f(&client)
     }
 
@@ -538,7 +537,7 @@ impl Electrum {
     /// for re-arming, since the new socket carries none.
     fn reconnect_client(&self) -> Result<(), electrum_client::Error> {
         let fresh = ElectrumClient::from_config(&self.config.url, client_config(&self.config))?;
-        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        let mut guard = lock_debug!(self.inner.write()).unwrap_or_else(|e| e.into_inner());
         *guard = fresh;
         self.needs_rearm.store(true, Ordering::SeqCst);
         self.reconnects.fetch_add(1, Ordering::Relaxed);
@@ -943,9 +942,7 @@ impl Blockchain for Electrum {
         minconf: Option<usize>,
         maxconf: Option<usize>,
     ) -> Result<Vec<ListUnspentResultEntry>, WalletError> {
-        let watched: Vec<ScriptBuf> = self
-            .watched
-            .lock()
+        let watched: Vec<ScriptBuf> = lock_debug!(self.watched.lock())
             .map_err(poisoned)?
             .iter()
             .cloned()
@@ -1039,9 +1036,7 @@ impl Blockchain for Electrum {
         skip: Option<usize>,
         _include_watchonly: Option<bool>,
     ) -> Result<Vec<ListTransactionResult>, WalletError> {
-        let watched: Vec<ScriptBuf> = self
-            .watched
-            .lock()
+        let watched: Vec<ScriptBuf> = lock_debug!(self.watched.lock())
             .map_err(poisoned)?
             .iter()
             .cloned()
@@ -1192,14 +1187,14 @@ impl Blockchain for Electrum {
     fn watch_script(&self, script: &Script, hd: Option<HdOrigin>) {
         // Skipping the insert on a poisoned lock hides this script's UTXOs from
         // `list_unspent` for the rest of the process, with nothing in the log.
-        let mut watched = self.watched.lock().unwrap_or_else(|e| {
+        let mut watched = lock_debug!(self.watched.lock()).unwrap_or_else(|e| {
             log::warn!("electrum watched-scripts lock poisoned; recovering");
             e.into_inner()
         });
         watched.insert(script.to_owned());
         drop(watched);
         if let Some(hd) = hd {
-            let mut paths = self.hd_paths.lock().unwrap_or_else(|e| {
+            let mut paths = lock_debug!(self.hd_paths.lock()).unwrap_or_else(|e| {
                 log::warn!("electrum hd-paths lock poisoned; recovering");
                 e.into_inner()
             });
@@ -1208,8 +1203,7 @@ impl Blockchain for Electrum {
     }
 
     fn hd_origin_for_script(&self, script: &Script) -> Option<HdOrigin> {
-        self.hd_paths
-            .lock()
+        lock_debug!(self.hd_paths.lock())
             .unwrap_or_else(|e| {
                 log::warn!("electrum hd-paths lock poisoned; recovering");
                 e.into_inner()
@@ -1219,7 +1213,7 @@ impl Blockchain for Electrum {
     }
 
     fn subscribe_script(&self, spk: &Script, watch: OutPoint) -> Result<(), WalletError> {
-        let mut guard = self.notifier.lock().map_err(poisoned)?;
+        let mut guard = lock_debug!(self.notifier.lock()).map_err(poisoned)?;
         let state = &mut *guard;
         // Arm the server side first, even when a local entry already exists: a
         // reconnect leaves the entry behind with no subscription under it.
@@ -1266,7 +1260,7 @@ impl Blockchain for Electrum {
     }
 
     fn unsubscribe_script(&self, spk: &Script, watch: OutPoint) -> Result<(), WalletError> {
-        let mut guard = self.notifier.lock().map_err(poisoned)?;
+        let mut guard = lock_debug!(self.notifier.lock()).map_err(poisoned)?;
         if let Some(sub) = guard.subscriptions.get_mut(spk) {
             sub.watchers.remove(&watch);
             // Another watched outpoint still shares this script and needs the
@@ -1294,7 +1288,7 @@ impl Blockchain for Electrum {
     fn poll_event(&self) -> Option<WatchEvent> {
         // Recover a poisoned lock like `try_call` does; bailing here would
         // silence the watchtower for the process lifetime with no log line.
-        let mut guard = self.notifier.lock().unwrap_or_else(|e| {
+        let mut guard = lock_debug!(self.notifier.lock()).unwrap_or_else(|e| {
             log::warn!("electrum notifier lock poisoned; recovering");
             e.into_inner()
         });

--- a/src/watch_tower/registry_storage.rs
+++ b/src/watch_tower/registry_storage.rs
@@ -7,7 +7,10 @@ use std::{
 
 use bitcoin::{OutPoint, ScriptBuf, Transaction, Txid};
 
-use crate::watch_tower::{utils::FidelityAnnouncement, watcher_error::WatcherError};
+use crate::{
+    lock_debug,
+    watch_tower::{utils::FidelityAnnouncement, watcher_error::WatcherError},
+};
 
 /// Represents a UTXO being watched and records when it gets spent.
 #[derive(Debug, Clone)]
@@ -187,7 +190,7 @@ impl FileRegistry {
     where
         F: FnOnce(&mut RegistryData) -> T,
     {
-        let mut data = self.data.lock()?;
+        let mut data = lock_debug!(self.data.lock())?;
         Ok(f(&mut data))
     }
 }

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -103,6 +103,13 @@ impl WatchService {
                 })
                 .map_err(|_| WatcherError::SendError)?;
             match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
+                Ok(WatcherEvent::Error(error)) => {
+                    // The watcher answered with an error; callers must not read
+                    // it as "not spent".
+                    return Err(WatcherError::General(format!(
+                        "watcher could not answer request for {outpoint}: {error}"
+                    )));
+                }
                 Ok(event) => return Ok(event),
                 Err(RecvTimeoutError::Disconnected) => return Err(WatcherError::SendError),
                 Err(RecvTimeoutError::Timeout) => {
@@ -238,5 +245,19 @@ mod tests {
         let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
         let event = service.watch_request(OutPoint::null()).unwrap();
         assert!(matches!(event, WatcherEvent::NoOutpoint));
+    }
+
+    #[test]
+    fn error_event_is_returned_as_error() {
+        let (tx, rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            if let Ok(WatcherCommand::WatchRequest { reply, .. }) = rx.recv() {
+                _ = reply.send(WatcherEvent::Error("registry lock poisoned".to_string()));
+            }
+            Ok(())
+        });
+        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let err = service.watch_request(OutPoint::null()).unwrap_err();
+        assert!(matches!(err, WatcherError::General(_)));
     }
 }

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -1,7 +1,7 @@
 //! Public watchtower service for sending commands to and receiving events from the watcher.
 
 use bitcoin::{OutPoint, ScriptBuf};
-use crossbeam_channel::unbounded;
+use crossbeam_channel::{unbounded, RecvTimeoutError};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -9,6 +9,7 @@ use std::{
         Arc, Mutex,
     },
     thread::{self, JoinHandle},
+    time::Duration,
 };
 
 use crate::{
@@ -23,6 +24,15 @@ use crate::{
 /// Watcher thread handle, shared because [`WatchService`] is `Clone`.
 /// The `Option` is taken by whichever clone shuts down first.
 type WatcherHandle = Arc<Mutex<Option<JoinHandle<Result<(), WatcherError>>>>>;
+
+/// Attempts per watch query before an unanswered watcher is treated as fatal.
+const WATCH_REQUEST_ATTEMPTS: u32 = 3;
+
+/// Reply wait per attempt. Short in tests so the retry test stays fast.
+#[cfg(not(test))]
+const WATCH_REPLY_TIMEOUT: Duration = crate::utill::HEART_BEAT_INTERVAL;
+#[cfg(test)]
+const WATCH_REPLY_TIMEOUT: Duration = Duration::from_millis(50);
 
 /// Marker type for the Maker role in the watchtower.
 pub struct MakerRole;
@@ -81,21 +91,34 @@ impl WatchService {
     /// Queries whether a previously registered outpoint has been spent and
     /// waits for this query's own reply. The private channel is what stops
     /// concurrent callers from consuming each other's answers.
-    /// `None` means the watcher did not answer within a heartbeat, so callers
-    /// keep re-checking their shutdown flags when it is wedged.
-    /// Errs if the watcher thread is gone.
-    pub fn watch_request(
-        &self,
-        outpoint: OutPoint,
-    ) -> Result<Option<WatcherEvent>, SendError<WatcherCommand>> {
-        let (reply_tx, reply_rx) = unbounded();
-        self.tx.send(WatcherCommand::WatchRequest {
-            outpoint,
-            reply: reply_tx,
-        })?;
-        Ok(reply_rx
-            .recv_timeout(crate::utill::HEART_BEAT_INTERVAL)
-            .ok())
+    /// The watcher answers every request, so silence means wedged or dead:
+    /// retried, then fatal — never readable as "not spent".
+    pub fn watch_request(&self, outpoint: OutPoint) -> Result<WatcherEvent, WatcherError> {
+        for attempt in 1..=WATCH_REQUEST_ATTEMPTS {
+            let (reply_tx, reply_rx) = unbounded();
+            self.tx
+                .send(WatcherCommand::WatchRequest {
+                    outpoint,
+                    reply: reply_tx,
+                })
+                .map_err(|_| WatcherError::SendError)?;
+            match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
+                Ok(event) => return Ok(event),
+                Err(RecvTimeoutError::Disconnected) => return Err(WatcherError::SendError),
+                Err(RecvTimeoutError::Timeout) => {
+                    if self.watcher_shutdown.load(Ordering::Relaxed) {
+                        // Teardown must not sit through the remaining attempts.
+                        return Err(WatcherError::Shutdown);
+                    }
+                    log::warn!(
+                        "watch request for {outpoint} unanswered (attempt {attempt}/{WATCH_REQUEST_ATTEMPTS})"
+                    );
+                }
+            }
+        }
+        Err(WatcherError::General(format!(
+            "watcher silent after {WATCH_REQUEST_ATTEMPTS} attempts"
+        )))
     }
 
     /// Stops monitoring an outpoint by removing its watch entry from the
@@ -165,4 +188,55 @@ pub fn start_maker_watch_service(
         .spawn(move || watcher.run(Arc::new(AtomicBool::new(true))))?;
 
     Ok(WatchService::new(tx_requests, handle, shutdown))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_handle() -> JoinHandle<Result<(), WatcherError>> {
+        thread::spawn(|| Ok(()))
+    }
+
+    #[test]
+    fn silent_watcher_gets_three_attempts_then_error() {
+        let (tx, rx) = mpsc::channel();
+        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(false)));
+        let err = service.watch_request(OutPoint::null()).unwrap_err();
+        assert!(matches!(err, WatcherError::General(_)));
+        // The receiver never answered, so every attempt landed in the queue.
+        assert_eq!(rx.try_iter().count(), WATCH_REQUEST_ATTEMPTS as usize);
+    }
+
+    #[test]
+    fn shutdown_flag_cuts_retries_short() {
+        let (tx, rx) = mpsc::channel();
+        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(true)));
+        let err = service.watch_request(OutPoint::null()).unwrap_err();
+        assert!(matches!(err, WatcherError::Shutdown));
+        assert!(rx.try_iter().count() < WATCH_REQUEST_ATTEMPTS as usize);
+    }
+
+    #[test]
+    fn dead_watcher_errors_without_retry() {
+        let (tx, rx) = mpsc::channel::<WatcherCommand>();
+        drop(rx);
+        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(false)));
+        let err = service.watch_request(OutPoint::null()).unwrap_err();
+        assert!(matches!(err, WatcherError::SendError));
+    }
+
+    #[test]
+    fn answered_request_returns_event_without_retry() {
+        let (tx, rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            if let Ok(WatcherCommand::WatchRequest { reply, .. }) = rx.recv() {
+                _ = reply.send(WatcherEvent::NoOutpoint);
+            }
+            Ok(())
+        });
+        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let event = service.watch_request(OutPoint::null()).unwrap();
+        assert!(matches!(event, WatcherEvent::NoOutpoint));
+    }
 }

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use crate::{
+    lock_debug,
     wallet::{AnyBlockchain, BackendConfig},
     watch_tower::{
         registry_storage::FileRegistry,
@@ -164,7 +165,9 @@ impl WatchService {
     pub fn shutdown(&self) {
         let _ = self.tx.send(WatcherCommand::Shutdown);
         self.watcher_shutdown.store(true, Ordering::Relaxed);
-        let handle = self.handle.lock().ok().and_then(|mut h| h.take());
+        let handle = lock_debug!(self.handle.lock())
+            .ok()
+            .and_then(|mut h| h.take());
         if let Some(handle) = handle {
             let thread = handle.thread().clone();
             crate::utill::log_shutdown_join_start("watch_service", &thread);

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -79,13 +79,29 @@ impl WatchService {
     }
 
     /// Re-arms the watches for every live contract in the wallet. The registry
-    /// is memory-only, so a restart begins with nothing watched.
-    /// Errs if the watcher thread is gone.
-    pub fn rebuild_watches(
-        &self,
-        watches: Vec<(OutPoint, ScriptBuf)>,
-    ) -> Result<(), SendError<WatcherCommand>> {
-        self.tx.send(WatcherCommand::RebuildWatches { watches })
+    /// is memory-only, so a restart begins with nothing watched. Blocks until
+    /// the rebuild (Core rescan included) replies, so startup never runs unwatched.
+    pub fn rebuild_watches(&self, watches: Vec<(OutPoint, ScriptBuf)>) -> Result<(), WatcherError> {
+        let (reply_tx, reply_rx) = unbounded();
+        self.tx
+            .send(WatcherCommand::RebuildWatches {
+                watches,
+                reply: reply_tx,
+            })
+            .map_err(|_| WatcherError::SendError)?;
+        // No total cap: a deep Core rescan legitimately takes minutes. The loop
+        // only exists so teardown can still cut the wait short.
+        loop {
+            match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
+                Ok(result) => return result.map_err(WatcherError::General),
+                Err(RecvTimeoutError::Disconnected) => return Err(WatcherError::SendError),
+                Err(RecvTimeoutError::Timeout) => {
+                    if self.watcher_shutdown.load(Ordering::Relaxed) {
+                        return Err(WatcherError::Shutdown);
+                    }
+                }
+            }
+        }
     }
 
     /// Queries whether a previously registered outpoint has been spent and
@@ -259,5 +275,36 @@ mod tests {
         let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
         let err = service.watch_request(OutPoint::null()).unwrap_err();
         assert!(matches!(err, WatcherError::General(_)));
+    }
+
+    #[test]
+    fn rebuild_watches_blocks_until_reply() {
+        let (tx, rx) = mpsc::channel();
+        let (reply_hold_tx, reply_hold_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            if let Ok(WatcherCommand::RebuildWatches { reply, .. }) = rx.recv() {
+                _ = reply_hold_tx.send(reply);
+            }
+            Ok(())
+        });
+        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let (done_tx, done_rx) = mpsc::channel();
+        let svc = service.clone();
+        let waiter = thread::spawn(move || _ = done_tx.send(svc.rebuild_watches(Vec::new())));
+        let reply = reply_hold_rx.recv().unwrap();
+        // The watcher has the command but has not replied, so the caller must
+        // still be blocked.
+        assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        _ = reply.send(Ok(()));
+        assert!(done_rx.recv().unwrap().is_ok());
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn rebuild_watches_returns_shutdown_without_reply() {
+        let (tx, _rx) = mpsc::channel();
+        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(true)));
+        let err = service.rebuild_watches(Vec::new()).unwrap_err();
+        assert!(matches!(err, WatcherError::Shutdown));
     }
 }

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -80,6 +80,9 @@ pub enum WatcherCommand {
     RebuildWatches {
         /// Contract outpoints and their `scriptPubKey`s.
         watches: Vec<(OutPoint, ScriptBuf)>,
+        /// Answered once the rebuild (Core rescan included) finishes, so
+        /// startup blocks until the watches are armed instead of racing it.
+        reply: CbSender<Result<(), String>>,
     },
     /// Query whether an outpoint has been spent.
     WatchRequest {
@@ -277,10 +280,12 @@ impl<R: Role> Watcher<R> {
                     self.pending_subscribes.push((outpoint, script_pubkey));
                 }
             }
-            WatcherCommand::RebuildWatches { watches } => {
+            WatcherCommand::RebuildWatches { watches, reply } => {
                 log::info!("Rebuilding {} watches from the wallet", watches.len());
                 for (outpoint, spk) in &watches {
                     if self.shutdown.load(Ordering::Relaxed) {
+                        // Reply before bailing out: the caller blocks on it.
+                        _ = reply.send(Ok(()));
                         return false;
                     }
                     if let Err(e) = self.registry.register_watch(*outpoint, spk.clone()) {
@@ -294,9 +299,12 @@ impl<R: Role> Watcher<R> {
                 // Electrum replays each script's whole history as `TxSeen`, so a
                 // spend from while we were down records itself. Core has no such
                 // feed and needs the blocks read back.
-                if !self.blockchain.is_electrum() {
-                    self.rescan_for_missed_spends(&watches);
-                }
+                let result = if self.blockchain.is_electrum() {
+                    Ok(())
+                } else {
+                    self.rescan_for_missed_spends(&watches)
+                };
+                _ = reply.send(result);
             }
             WatcherCommand::WatchRequest { outpoint, reply } => {
                 log::info!("Intercepted watch request: {outpoint}");
@@ -382,12 +390,15 @@ impl<R: Role> Watcher<R> {
 
     /// Reads blocks back from the oldest rebuilt contract to the tip, looking for
     /// spends that confirmed while we were down. Bitcoin Core only.
-    fn rescan_for_missed_spends(&mut self, watches: &[(OutPoint, ScriptBuf)]) {
+    fn rescan_for_missed_spends(
+        &mut self,
+        watches: &[(OutPoint, ScriptBuf)],
+    ) -> Result<(), String> {
         let mut oldest: Option<u64> = None;
         for (outpoint, _) in watches {
             if self.shutdown.load(Ordering::Relaxed) {
                 log::info!("watch rebuild rescan aborted before funding lookup: shutdown");
-                return;
+                return Ok(());
             }
             match self.blockchain.tx_block_height(&outpoint.txid) {
                 Ok(Some(height)) => {
@@ -400,10 +411,11 @@ impl<R: Role> Watcher<R> {
                 Err(e) => log::warn!("funding height lookup failed for {outpoint}: {e}"),
             }
         }
-        let Some(from) = oldest else { return };
-        if let Err(e) = self.scan_blocks(from) {
+        let Some(from) = oldest else { return Ok(()) };
+        self.scan_blocks(from).map_err(|e| {
             log::error!("block rescan from height {from} failed: {e:?}");
-        }
+            format!("block rescan from height {from} failed: {e:?}")
+        })
     }
 
     fn scan_blocks(&mut self, from: u64) -> Result<(), WatcherError> {

--- a/tests/integration/electrum_transport.rs
+++ b/tests/integration/electrum_transport.rs
@@ -366,6 +366,17 @@ fn reconnects_after_the_connection_drops() {
     let electrum = Electrum::new(&cfg).expect("connect via forwarder");
 
     let before = electrum.get_block_count().expect("tip before drop");
+    let addr = s
+        .bitcoind
+        .client
+        .get_new_address(None, None)
+        .unwrap()
+        .require_network(bitcoin::Network::Regtest)
+        .unwrap();
+    let spk = addr.script_pubkey();
+    electrum
+        .subscribe_script(&spk, dummy_watch(0))
+        .expect("subscribe before reconnect");
     s.forwarder.drop_connections();
 
     // Same answer, despite the socket having died underneath.
@@ -377,12 +388,23 @@ fn reconnects_after_the_connection_drops() {
         electrum.reconnect_count()
     );
 
-    // Subscriptions are re-armed after a rebuild, so watching still works.
-    let spk = bitcoin::ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([9u8; 20]));
-    electrum.watch_script(&spk, None);
-    electrum
-        .subscribe_script(&spk, dummy_watch(0))
-        .expect("subscribe after reconnect");
+    send_to_address(&s.bitcoind, &addr, bitcoin::Amount::from_sat(10_000));
+    generate_blocks(&s.bitcoind, 1);
+    wait_for_tip(&s, &electrum);
+    let expected_tip = s.bitcoind.client.get_block_count().unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let (mut saw_tx, mut saw_tip) = (false, false);
+    while !(saw_tx && saw_tip) && std::time::Instant::now() < deadline {
+        if let Some(event) = electrum.poll_event() {
+            let event = format!("{event:?}");
+            saw_tx |= event.starts_with("TxSeen");
+            saw_tip |= event.contains(&format!("height: {expected_tip}"));
+        } else {
+            thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+    assert!(saw_tx, "pre-reconnect script subscription was not re-armed");
+    assert!(saw_tip, "header subscription was not re-armed");
 
     drop(electrum);
     let _ = &s.bitcoind;

--- a/tests/integration/legacy_malformed_contract.rs
+++ b/tests/integration/legacy_malformed_contract.rs
@@ -104,3 +104,62 @@ fn test_legacy_taker_rejects_malformed_maker_funding_output() {
     test_framework.stop();
     block_generation_handle.join().unwrap();
 }
+
+#[test]
+fn test_legacy_taker_rejects_fee_skimming_maker() {
+    let makers_config_map = vec![(6103, Some(19053))];
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(
+            makers_config_map,
+            vec![TakerBehavior::Normal],
+            vec![MakerBehavior::FeeSkimming],
+        );
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+    generate_blocks(bitcoind, 1);
+    let summary = taker
+        .prepare_coinswap(
+            SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
+                .with_tx_count(3)
+                .with_required_confirms(1),
+        )
+        .expect("prepare Legacy swap");
+    let error = taker
+        .start_coinswap(&summary.swap_id)
+        .expect_err("reject fee skim");
+    assert!(
+        format!("{error:?}").contains("does not match expected"),
+        "unexpected error: {:?}",
+        error
+    );
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/taproot_reboot_recovery.rs
+++ b/tests/integration/taproot_reboot_recovery.rs
@@ -221,14 +221,17 @@ fn test_taproot_maker_reboot_recovery_preserves_funded_swapcoins() {
 /// t~20s restart both makers -> rebuild -> each reads the preimage revealed by
 ///       the party downstream and claims via hashlock in turn
 /// ```
-pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(protocol: ProtocolVersion) {
-    warn!("Running Test: Restart Rebuilds Watches ({protocol:?})");
+pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
+    protocol: ProtocolVersion,
+    crash_behavior: TakerBehavior,
+) {
+    warn!("Running Test: Restart Rebuilds Watches ({protocol:?}, {crash_behavior:?})");
 
     // The framework assigns real ports itself; these entries only set the count.
     let makers_config_map = vec![(0, None), (0, None)];
     // All three die holding unclaimed contracts, none of them recovering in
     // process, so only the restarts can settle anything.
-    let taker_behavior = vec![TakerBehavior::CrashBeforeRecovery];
+    let taker_behavior = vec![crash_behavior];
     let maker_behaviors = vec![
         MakerBehavior::CrashBeforeRecovery,
         MakerBehavior::CrashBeforeRecovery,
@@ -513,10 +516,35 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(protocol: ProtocolVer
 
 #[test]
 fn test_taproot_restart_rebuilds_watches() {
-    run_restart_rebuilds_watches::<BitcoindBackend>(ProtocolVersion::Taproot);
+    run_restart_rebuilds_watches::<BitcoindBackend>(
+        ProtocolVersion::Taproot,
+        TakerBehavior::CrashBeforeRecovery,
+    );
 }
 
 #[test]
 fn test_legacy_electrum_restart_rebuilds_watches() {
-    run_restart_rebuilds_watches::<ElectrumBackend>(ProtocolVersion::Legacy);
+    run_restart_rebuilds_watches::<ElectrumBackend>(
+        ProtocolVersion::Legacy,
+        TakerBehavior::CrashBeforeRecovery,
+    );
+}
+
+// The taker dies right after the contract exchange — before the old code ever
+// persisted what it was owed. The pre-restart `incoming count > 0` assertion
+// above is the proof: red without acceptance-time persistence, green with it.
+#[test]
+fn test_taproot_crash_after_contract_exchange() {
+    run_restart_rebuilds_watches::<BitcoindBackend>(
+        ProtocolVersion::Taproot,
+        TakerBehavior::CrashAfterContractExchange,
+    );
+}
+
+#[test]
+fn test_legacy_electrum_crash_after_contract_exchange() {
+    run_restart_rebuilds_watches::<ElectrumBackend>(
+        ProtocolVersion::Legacy,
+        TakerBehavior::CrashAfterContractExchange,
+    );
 }

--- a/tests/integration/taproot_taker_contract_validation.rs
+++ b/tests/integration/taproot_taker_contract_validation.rs
@@ -114,3 +114,66 @@ fn test_taproot_rejects_underfunded_maker_contract() {
     test_framework.stop();
     block_generation_handle.join().unwrap();
 }
+
+#[test]
+fn test_taproot_rejects_fee_skimming_maker() {
+    test_taproot_rejection(MakerBehavior::FeeSkimming, "does not match expected");
+}
+
+fn test_taproot_rejection(behavior: MakerBehavior, expected_error: &str) {
+    let makers_config_map = vec![(7103, Some(19062))];
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(
+            makers_config_map,
+            vec![TakerBehavior::Normal],
+            vec![behavior],
+        );
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+    generate_blocks(bitcoind, 1);
+    let summary = taker
+        .prepare_coinswap(
+            SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(30_000), 1)
+                .with_tx_count(3)
+                .with_required_confirms(1),
+        )
+        .expect("prepare Taproot swap");
+    let error = taker
+        .start_coinswap(&summary.swap_id)
+        .expect_err("reject fee skim");
+    assert!(
+        format!("{error:?}").contains(expected_error),
+        "unexpected error: {:?}",
+        error
+    );
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -685,7 +685,7 @@ impl TestFramework {
         if temp_dir.exists() {
             fs::remove_dir_all::<PathBuf>(temp_dir.clone()).unwrap();
         }
-        setup_logger(log::LevelFilter::Info, Some(temp_dir.clone()));
+        setup_logger(log::LevelFilter::Debug, Some(temp_dir.clone()));
         log::info!("📁 temporary directory : {}", temp_dir.display());
         let zmq_addr = format!("tcp://127.0.0.1:{}", 28332 + rand::random::<u16>() % 1000);
         let bitcoind = init_bitcoind(&temp_dir, zmq_addr.clone());


### PR DESCRIPTION
## Summary

Follow-up hardening fixes from the audit (wave 2, after #973), plus a second pass addressing review findings on the first batch.

**Audit fixes**

- **Cap concurrent swap admissions at 30.** The maker accepted every swap request, so an attacker could stack unbounded swaps whose funding never confirms, pinning a connection thread and reserved liquidity on each. New swaps past the cap get a protocol reject so the taker can move to the next maker; reconnects rejoin without counting.
- **Persist incoming swapcoins at contract acceptance.** A taker that crashed between acceptance and finalization lost every record of the incoming contracts it was owed — they lived only in memory until finalization. They are now saved at acceptance and swept through the existing recovery path after a restart. Nothing changes on the wire.
- **Share one connection per recovery pass.** Both recovery loops opened a fresh backend connection per recovery step; on Tor-proxied Electrum each one is a circuit handshake. Each pass now opens one lazy connection, shared by the sweep and timelock steps, and idle passes pay nothing.
- **Bound offerbook sync waits.** Offerbook refreshes no longer wait forever when a backend stalls; both sync entry points are bounded consistently and cached offers stay usable after ten minutes. Maker handshakes still validate cached offers selected after the deadline.
- **Retry watchtower queries, then fail loudly.** A dead or wedged watchtower was logged and ignored: maker recovery could read a failed query as "no preimage" and take the timelock path while a hashlock spend existed. Every query now retries three times on silence, then fails the work it serves.

**Review follow-ups**

- **Fix a self-deadlock at the final sweep.** The taker held a wallet read guard across a sweep call that takes the write lock, hanging every successful swap before it could report. Connection creation now happens in its own statement so the guard drops first.
- **Treat watcher errors as failures, not "not spent".** A watcher error reply reached recovery as `Ok` and read as an unspent contract, silently skipping the preimage path. It now maps to an error and recovery aborts the pass, with a regression test.
- **Make capacity and parameter rejections terminal.** A rejected swap kept its connection in an advanced phase, so the taker could keep driving messages and get a contract funded for a swap the maker refused. Rejection now resets the connection state; the next message fails and closes the connection.
- **Classify admissions under the final lock.** A swap drained between the two admission locks skipped both the cap and the liquidity check. The new-or-reconnect decision is now made under the lock that admits, with the wallet balance read before the lock is taken.
- **Bind resent swap requests to admitted parameters.** A taker could reuse an active swap id with a larger amount — bypassing reservation checks — or roll a live swap back to an early phase, wiping its stored swapcoins. Identical resends are treated as reconnects (idle timer refreshed, stored state untouched); any parameter difference is rejected.
- **Block startup until watches are rebuilt.** Watch rebuilding at startup was fire-and-forget, so init could report success with live contracts unwatched. Startup now waits for the rebuild — Core rescan included — and fails if the rebuild fails.

## Related Issue

No single issue — audit follow-ups continuing from #973.

## Testing

- `cargo test --lib` — 133 passed, 0 failed; includes the new watch-service tests (retry/shutdown, error-as-Err, rebuild blocking).
- `test_taproot_coinswap` passes on both Core and Electrum backends — covers the final-sweep deadlock path.
- `taproot_taker_abort1` passes — covers admission acceptance and idle-reservation release.
- Crash-window restart tests for both protocols in `tests/integration/taproot_reboot_recovery.rs` cover the incoming-swapcoin persist.
- Watchtower changes covered by `test_taproot_maker_reboot_recovery_preserves_funded_swapcoins` and `test_taproot_restart_rebuilds_watches` — both pass.
- Reconnect and fee-skimming behavior covered in `tests/integration/legacy_malformed_contract.rs`, `taproot_taker_contract_validation.rs`, and `electrum_transport.rs`.
- `cargo fmt --check` — clean; clippy and all feature combinations pass via the pre-commit hook.

## Checklist
- [x] Tests were added or updated where needed
- [x] Formatting and lints pass
- [x] Documentation was updated where needed
- [x] Security or protocol impact is explained above, if applicable
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a limit of 30 simultaneous swaps, with clear rejection responses when capacity is reached.
  * Added validation to reject resent swaps with conflicting parameters.
  * Added retry handling for watchtower requests, including shutdown and disconnected-service detection.

* **Bug Fixes**
  * Improved recovery and sweeping after interruptions by preserving swap state earlier and reusing blockchain connections.
  * Startup reconstruction and watchtower recovery failures now stop processing instead of being ignored.
  * Recovery pauses and retries when blockchain connections are unavailable.
  * Offer synchronization handles delays gracefully without stalling queued requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

