### PR TITLE
Fail closed when maker watchtower exits

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -563,7 +563,9 @@ impl MakerServer {
             config.network = wallet_network;
         }
 
-        // Initialize watch service
+        // Initialize watch service. A failure here aborts init instead of
+        // entering recovery-only: that mode polls the same backend that
+        // just failed to build, so there is nothing to degrade to.
         let watch_service = crate::watch_tower::service::start_maker_watch_service(
             &config.backend,
             backend_shutdown,
@@ -571,7 +573,9 @@ impl MakerServer {
         .map_err(MakerError::Watcher)?;
 
         // The watcher starts empty, so re-arm every contract still live in the
-        // wallet. Without this a restart leaves them undefended.
+        // wallet. Without this a restart leaves them undefended. A failed
+        // rescan retries inside the watcher, so an Err here means the watcher
+        // is gone and the server will start in recovery-only mode.
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
         if let Err(e) = watch_service.rebuild_watches(watches) {

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -574,13 +574,9 @@ impl MakerServer {
         // wallet. Without this a restart leaves them undefended.
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
-        // This is also the watcher readiness barrier when the wallet has no
-        // contracts. A thread that fails during startup must keep the maker
-        // from listening for swaps.
-        watch_service.rebuild_watches(watches).map_err(|e| {
-            log::error!("could not initialize watches on startup: {e}");
-            MakerError::General("watcher initialization failed on startup")
-        })?;
+        if let Err(e) = watch_service.rebuild_watches(watches) {
+            log::error!("could not initialize watches on startup: {e}; recovery-only mode");
+        }
 
         let swap_tracker = MakerSwapTracker::load_or_create(&data_dir)?;
         let incomplete = swap_tracker.incomplete_swaps();
@@ -971,6 +967,17 @@ impl MakerServer {
         Ok(!lock_debug!(self.ongoing_swaps.lock())
             .map_err(|_| MakerError::MutexPossion)?
             .is_empty())
+    }
+
+    /// Whether this maker has an unfinished outgoing swapcoin for `swap_id`.
+    #[cfg(feature = "integration-test")]
+    pub fn has_unfinished_outgoing_swapcoin(&self, swap_id: &str) -> Result<bool, MakerError> {
+        let wallet = lock_debug!(self.wallet.read())
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+        let (_, outgoing) = wallet.find_unfinished_swapcoins();
+        Ok(outgoing
+            .iter()
+            .any(|coin| coin.swap_id.as_deref() == Some(swap_id)))
     }
 
     /// Verify the deniability proof for a specific swap.

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -574,14 +574,13 @@ impl MakerServer {
         // wallet. Without this a restart leaves them undefended.
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
-        // Contracts we cannot watch are contracts we cannot defend: a dead
-        // watcher at startup is fatal, not a warning.
-        if !watches.is_empty() {
-            watch_service.rebuild_watches(watches).map_err(|e| {
-                log::error!("could not rebuild watches on startup: {e}");
-                MakerError::General("watch rebuild failed on startup")
-            })?;
-        }
+        // This is also the watcher readiness barrier when the wallet has no
+        // contracts. A thread that fails during startup must keep the maker
+        // from listening for swaps.
+        watch_service.rebuild_watches(watches).map_err(|e| {
+            log::error!("could not initialize watches on startup: {e}");
+            MakerError::General("watcher initialization failed on startup")
+        })?;
 
         let swap_tracker = MakerSwapTracker::load_or_create(&data_dir)?;
         let incomplete = swap_tracker.incomplete_swaps();
@@ -1113,6 +1112,10 @@ impl MakerTrait for MakerServer {
 
     fn network(&self) -> Network {
         self.config.network
+    }
+
+    fn is_watchtower_alive(&self) -> bool {
+        self.watch_service.is_alive()
     }
 
     fn create_funding_transaction(

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -248,6 +248,9 @@ pub trait Maker: Send + Sync {
     /// Get the Bitcoin network.
     fn network(&self) -> bitcoin::Network;
 
+    /// Whether the watchtower can still protect newly committed funds.
+    fn is_watchtower_alive(&self) -> bool;
+
     /// Get the tweakable keypair for swap address derivation.
     fn get_tweakable_keypair(
         &self,
@@ -383,6 +386,17 @@ pub trait Maker: Send + Sync {
     /// Get the test behavior override.
     #[cfg(feature = "integration-test")]
     fn behavior(&self) -> MakerBehavior;
+}
+
+/// Fail closed if the watcher exited after this swap was admitted.
+pub(super) fn ensure_watchtower_alive(maker: &impl Maker) -> Result<(), MakerError> {
+    if maker.is_watchtower_alive() {
+        Ok(())
+    } else {
+        Err(MakerError::General(
+            "watchtower is down, refusing to commit funds",
+        ))
+    }
 }
 
 /// Maker configuration values.
@@ -560,6 +574,17 @@ fn handle_swap_details<M: Maker>(
     details: SwapDetails,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     state.expect_phase(&[SwapPhase::AwaitingSwapDetails])?;
+
+    if !maker.is_watchtower_alive() {
+        log::error!(
+            "[{}] Rejecting swap {} because the watchtower is down",
+            Maker::network_port(maker.as_ref()),
+            details.id
+        );
+        return Ok(Some(MakerToTakerMessage::AckSwapDetails(
+            AckSwapDetails::reject(),
+        )));
+    }
 
     log::info!(
         "[{}] Received SwapDetails: amount={}, timelock={}, protocol={:?}",

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -25,7 +25,7 @@ pub enum MakerBehavior {
     /// Normal operation (no test override).
     #[default]
     Normal,
-    /// Stop the watchtower before the maker's startup readiness barrier.
+    /// Stop the watchtower before the maker starts its network services.
     StopWatcherOnStartup,
     /// Receive contract sigs and save swapcoins, but skip funding broadcast
     /// and close the connection. Simulates last-maker misbehavior.
@@ -390,7 +390,7 @@ pub trait Maker: Send + Sync {
     fn behavior(&self) -> MakerBehavior;
 }
 
-/// Fail closed if the watcher exited after this swap was admitted.
+/// Fail closed after admission; persistence limits the check-to-broadcast race.
 pub(super) fn ensure_watchtower_alive(maker: &impl Maker) -> Result<(), MakerError> {
     if maker.is_watchtower_alive() {
         Ok(())

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -25,6 +25,8 @@ pub enum MakerBehavior {
     /// Normal operation (no test override).
     #[default]
     Normal,
+    /// Stop the watchtower before the maker's startup readiness barrier.
+    StopWatcherOnStartup,
     /// Receive contract sigs and save swapcoins, but skip funding broadcast
     /// and close the connection. Simulates last-maker misbehavior.
     SkipFundingBroadcast,

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -593,6 +593,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
             )?;
         }
     }
+    super::handlers::ensure_watchtower_alive(maker.as_ref())?;
 
     // Persist swapcoins (now carrying contract signatures) to the wallet
     // store BEFORE broadcasting funding txs. Without this, a crash after

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -878,24 +878,38 @@ fn recover_from_swap(
         r.recovery.phase = MakerRecoveryPhase::Monitoring;
     });
 
+    let mut watchtower_down_logged = false;
     while !maker.is_shutdown() {
         // --- Hashlock path: check if preimages are available ---
-        if let Err(e) =
-            check_for_preimage_via_watchtower(&maker, &outgoing_swapcoins, &incoming_swapcoins)
-        {
-            // A transient backend failure must abort this pass so we never
-            // choose the timelock path from a stale "not spent" answer. It must
-            // not terminate the maker's only recovery thread: the next pass can
-            // observe a preimage once the backend is reachable again.
-            log::warn!(
-                "[{}] Could not refresh contract watches: {:?}; retrying recovery",
-                maker.config.network_port,
-                e
-            );
-            if !maker.wait_for_shutdown(HEART_BEAT_INTERVAL) {
-                break;
+        if maker.watch_service.is_alive() {
+            if let Err(e) =
+                check_for_preimage_via_watchtower(&maker, &outgoing_swapcoins, &incoming_swapcoins)
+            {
+                if maker.watch_service.is_alive() {
+                    // A transient backend failure must abort this pass so we
+                    // never choose the timelock path from a stale answer.
+                    log::warn!(
+                        "[{}] Could not refresh contract watches: {:?}; retrying recovery",
+                        maker.config.network_port,
+                        e
+                    );
+                    if !maker.wait_for_shutdown(HEART_BEAT_INTERVAL) {
+                        break;
+                    }
+                    continue;
+                }
             }
-            continue;
+        }
+        if !maker.watch_service.is_alive() && !watchtower_down_logged {
+            // The hashlock path is unavailable for the rest of this process,
+            // but an in-flight swap must still reclaim any unspent outgoing
+            // contracts once their timelocks mature.
+            log::error!(
+                "[{}] Watchtower is down; continuing in-flight swap {} via timelock recovery",
+                maker.config.network_port,
+                swap_id
+            );
+            watchtower_down_logged = true;
         }
 
         // Check if all incoming swapcoins now have preimages

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -61,40 +61,45 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     if maker.behavior == super::handlers::MakerBehavior::StopWatcherOnStartup {
         maker.watch_service.stop_watcher_for_test();
     }
-    if !maker.watch_service.is_alive() {
-        return Err(MakerError::General(
-            "watchtower is down, refusing to start maker server",
-        ));
-    }
-
-    let listener = match TcpListener::bind(("127.0.0.1", maker.config.network_port)) {
-        Ok(l) => l,
-        Err(e) => {
+    let listener = if maker.watch_service.is_alive() {
+        let listener = TcpListener::bind(("127.0.0.1", maker.config.network_port)).map_err(|e| {
             log::warn!(
                 "Failed to bind network port {}: {}. Fidelity bond funds may be locked to this port.",
                 maker.config.network_port,
                 e
             );
-            return Err(MakerError::IO(e));
-        }
+            MakerError::IO(e)
+        })?;
+        listener.set_nonblocking(true).map_err(MakerError::IO)?;
+        Some(listener)
+    } else {
+        log::error!(
+            "[{}] Watchtower down; recovery-only mode",
+            maker.config.network_port
+        );
+        None
     };
-    listener.set_nonblocking(true).map_err(MakerError::IO)?;
 
     #[cfg(feature = "integration-test")]
-    let maker_address = format!("127.0.0.1:{}", maker.config.network_port);
+    let maker_address = listener
+        .is_some()
+        .then(|| format!("127.0.0.1:{}", maker.config.network_port));
     #[cfg(not(feature = "integration-test"))]
-    let maker_address = maker.get_tor_hostname()?;
+    let maker_address = listener
+        .is_some()
+        .then(|| maker.get_tor_hostname())
+        .transpose()?;
 
-    log::info!(
-        "[{}] Setting up fidelity bond...",
-        maker.config.network_port
-    );
-    let fidelity_proof = maker.setup_fidelity_bond(&maker_address)?;
-
-    spawn_nostr_broadcast_thread(&maker, fidelity_proof)?;
-
-    log::info!("[{}] Checking swap liquidity...", maker.config.network_port);
-    maker.check_swap_liquidity()?;
+    if let Some(maker_address) = maker_address.as_ref() {
+        log::info!(
+            "[{}] Setting up fidelity bond...",
+            maker.config.network_port
+        );
+        let fidelity_proof = maker.setup_fidelity_bond(maker_address)?;
+        spawn_nostr_broadcast_thread(&maker, fidelity_proof)?;
+        log::info!("[{}] Checking swap liquidity...", maker.config.network_port);
+        maker.check_swap_liquidity()?;
+    }
 
     // Check for unfinished swapcoins from a previous run and start recovery.
     {
@@ -167,12 +172,14 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
         );
     }
 
-    maker.is_setup_complete.store(true, Relaxed);
-    log::info!(
-        "[{}] Server setup complete! Listening on port {}",
-        maker.config.network_port,
-        maker.config.network_port
-    );
+    if listener.is_some() {
+        maker.is_setup_complete.store(true, Relaxed);
+        log::info!(
+            "[{}] Server setup complete! Listening on port {}",
+            maker.config.network_port,
+            maker.config.network_port
+        );
+    }
 
     // Spawn RPC server thread for maker-cli operations
     let maker_rpc = Arc::clone(&maker);
@@ -198,20 +205,24 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
         .map_err(MakerError::IO)?;
     maker.thread_pool.add_thread(idle_handle)?;
 
-    // Spawn fidelity bond renewal thread
-    let maker_fidelity = Arc::clone(&maker);
-    let maker_addr_fidelity = maker_address.clone();
-    let fidelity_handle = thread::Builder::new()
-        .name("fidelity-renewal".to_string())
-        .spawn(move || {
-            if let Err(e) = fidelity_renewal_loop(maker_fidelity, &maker_addr_fidelity) {
-                log::error!("Fidelity renewal loop error: {:?}", e);
-            }
-        })
-        .map_err(MakerError::IO)?;
-    maker.thread_pool.add_thread(fidelity_handle)?;
+    if let Some(maker_address) = maker_address {
+        let maker_fidelity = Arc::clone(&maker);
+        let fidelity_handle = thread::Builder::new()
+            .name("fidelity-renewal".to_string())
+            .spawn(move || {
+                if let Err(e) = fidelity_renewal_loop(maker_fidelity, &maker_address) {
+                    log::error!("Fidelity renewal loop error: {:?}", e);
+                }
+            })
+            .map_err(MakerError::IO)?;
+        maker.thread_pool.add_thread(fidelity_handle)?;
+    }
 
     while !maker.is_shutdown() {
+        let Some(listener) = listener.as_ref() else {
+            sleep(Duration::from_millis(100));
+            continue;
+        };
         match listener.accept() {
             Ok((stream, addr)) => {
                 log::info!(
@@ -642,9 +653,9 @@ const MIN_WITNESS_ITEM_FOR_HASHLOCK: usize = 2;
 /// Preimage length in bytes.
 const PREIMAGE_LEN: usize = 32;
 
-/// Check the watch tower for spends on outgoing contract outputs, extract
-/// preimages from hashlock spends, and update incoming swapcoins in the wallet.
-fn check_for_preimage_via_watchtower(
+/// Read spends through the watcher, or directly through the wallet backend
+/// after the watcher exits, then persist any revealed hashlock preimages.
+fn check_for_preimage(
     maker: &MakerServer,
     outgoing_swapcoins: &[crate::wallet::swapcoin::OutgoingSwapCoin],
     incoming_swapcoins: &[crate::wallet::swapcoin::IncomingSwapCoin],
@@ -654,6 +665,13 @@ fn check_for_preimage_via_watchtower(
 
     let mut seen_outpoints = HashSet::new();
     let mut preimages: Vec<[u8; 32]> = Vec::new();
+    let wallet = lock_debug!(maker.wallet.read())
+        .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+    let direct_chain = (!maker.watch_service.is_alive())
+        .then(|| wallet.blockchain.new_connection())
+        .transpose()
+        .map_err(MakerError::Wallet)?;
+    drop(wallet);
 
     // Query the watch tower for spends on each outgoing contract output.
     for outgoing in outgoing_swapcoins {
@@ -667,16 +685,26 @@ fn check_for_preimage_via_watchtower(
             // choosing timelock over hashlock — a stale miss refunds while a
             // preimage spend already exists. A failed query aborts this pass;
             // the recovery loop retries instead of refunding blind.
-            let reply = maker.watch_service.watch_request(outpoint).map_err(|e| {
-                log::warn!("watch request for {outpoint} failed: {e}");
-                MakerError::General("watchtower query failed")
-            })?;
+            let spending_tx = match direct_chain.as_ref() {
+                Some(chain) => chain
+                    .spending_transaction(
+                        &outpoint,
+                        outgoing.contract_tx.output[vout].script_pubkey.as_script(),
+                        None,
+                    )
+                    .map_err(MakerError::Wallet)?,
+                None => match maker.watch_service.watch_request(outpoint).map_err(|e| {
+                    log::warn!("watch request for {outpoint} failed: {e}");
+                    MakerError::General("watchtower query failed")
+                })? {
+                    crate::watch_tower::watcher::WatcherEvent::UtxoSpent {
+                        spending_tx, ..
+                    } => spending_tx,
+                    _ => None,
+                },
+            };
 
-            if let crate::watch_tower::watcher::WatcherEvent::UtxoSpent {
-                spending_tx: Some(spending_tx),
-                ..
-            } = reply
-            {
+            if let Some(spending_tx) = spending_tx {
                 // Extract preimages from the spending transaction's witnesses.
                 for input in &spending_tx.input {
                     let op = (input.previous_output.txid, input.previous_output.vout);
@@ -891,31 +919,23 @@ fn recover_from_swap(
     let mut watchtower_down_logged = false;
     while !maker.is_shutdown() {
         // --- Hashlock path: check if preimages are available ---
-        if maker.watch_service.is_alive() {
-            if let Err(e) =
-                check_for_preimage_via_watchtower(&maker, &outgoing_swapcoins, &incoming_swapcoins)
-            {
-                if maker.watch_service.is_alive() {
-                    // A transient backend failure must abort this pass so we
-                    // never choose the timelock path from a stale answer.
-                    log::warn!(
-                        "[{}] Could not refresh contract watches: {:?}; retrying recovery",
-                        maker.config.network_port,
-                        e
-                    );
-                    if !maker.wait_for_shutdown(HEART_BEAT_INTERVAL) {
-                        break;
-                    }
-                    continue;
-                }
+        if let Err(e) = check_for_preimage(&maker, &outgoing_swapcoins, &incoming_swapcoins) {
+            log::warn!(
+                "[{}] Could not refresh contract spends: {:?}; retrying recovery",
+                maker.config.network_port,
+                e
+            );
+            if !maker.wait_for_shutdown(HEART_BEAT_INTERVAL) {
+                break;
             }
+            continue;
+        }
+        if maker.is_shutdown() {
+            break;
         }
         if !maker.watch_service.is_alive() && !watchtower_down_logged {
-            // The hashlock path is unavailable for the rest of this process,
-            // but an in-flight swap must still reclaim any unspent outgoing
-            // contracts once their timelocks mature.
             log::error!(
-                "[{}] Watchtower is down; continuing in-flight swap {} via timelock recovery",
+                "[{}] Watchtower is down; directly polling swap {} for recovery",
                 maker.config.network_port,
                 swap_id
             );

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -57,6 +57,16 @@ const FIDELITY_BOND_UPDATE_INTERVAL: Duration = Duration::from_secs(600);
 pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     log::info!("[{}] Starting maker server", maker.config.network_port);
 
+    #[cfg(feature = "integration-test")]
+    if maker.behavior == super::handlers::MakerBehavior::StopWatcherOnStartup {
+        maker.watch_service.stop_watcher_for_test();
+    }
+    if !maker.watch_service.is_alive() {
+        return Err(MakerError::General(
+            "watchtower is down, refusing to start maker server",
+        ));
+    }
+
     let listener = match TcpListener::bind(("127.0.0.1", maker.config.network_port)) {
         Ok(l) => l,
         Err(e) => {

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -449,6 +449,7 @@ fn process_taproot_contract<M: Maker>(
                 .clone(),
         )?;
     }
+    super::handlers::ensure_watchtower_alive(maker.as_ref())?;
 
     // Persist swapcoins before broadcasting contract txs. A later broadcast
     // failure can leave earlier Taproot contract txs on-chain, and the wallet

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -740,16 +740,12 @@ impl Taker {
             )),
             shutdown.clone(),
         );
-        let handle = thread::Builder::new()
-            .name("Watcher thread".to_string())
-            .spawn(move || watcher.run(initial_sync_clone))
-            .map_err(|e| TakerError::General(format!("failed to spawn watcher thread: {e}")))?;
+        let watch_service = WatchService::spawn(tx_requests, shutdown, move || {
+            watcher.run(initial_sync_clone)
+        })
+        .map_err(|e| TakerError::General(format!("failed to spawn watcher thread: {e}")))?;
 
-        Ok((
-            WatchService::new(tx_requests, handle, shutdown),
-            registry_clone,
-            initial_sync_complete,
-        ))
+        Ok((watch_service, registry_clone, initial_sync_complete))
     }
 
     /// Load/merge taker config and check Tor status.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -570,12 +570,8 @@ impl Taker {
         let mut watches = wallet.incoming_contract_outpoints();
         watches.extend(wallet.outgoing_contract_outpoints());
         watches.extend(wallet.watchonly_contract_outpoints());
-        // Contracts we cannot watch are contracts we cannot defend: a dead
-        // watcher at startup is fatal, not a warning.
-        if !watches.is_empty() {
-            watch_service.rebuild_watches(watches).map_err(|e| {
-                TakerError::General(format!("could not rebuild watches on startup: {e}"))
-            })?;
+        if let Err(e) = watch_service.rebuild_watches(watches) {
+            log::error!("could not rebuild watches on startup: {e}; recovery remains active");
         }
 
         Self::init_taker_config(&config, &data_dir)?;
@@ -976,10 +972,25 @@ impl Taker {
                 swap_id, current_id
             )));
         }
+        #[cfg(feature = "integration-test")]
+        if self.behavior == TakerBehavior::StopWatcherBeforeSwap {
+            self.watch_service.stop_watcher_for_test();
+        }
+        if !self.watch_service.is_alive() {
+            return Err(TakerError::General("watchtower is down".into()));
+        }
 
         let initial_utxos = self.read_wallet()?.list_all_utxo();
 
         log::info!("Starting coinswap execution for id: {}", swap_id);
+
+        if self.swap_state()?.params.protocol == ProtocolVersion::Legacy {
+            let backend = self.read_wallet()?.blockchain.new_connection()?;
+            self.breach_detector = Some(super::background_services::BreachDetector::start(
+                self.watch_service.clone(),
+                backend,
+            )?);
+        }
 
         self.funding_initialize()?;
 
@@ -1153,8 +1164,9 @@ impl Taker {
             }
         }
 
-        // Finalization succeeded — stop breach detector.
+        // Finalization succeeded — disarm and stop the breach detector.
         if let Some(detector) = self.breach_detector.take() {
+            detector.disarm(&self.watch_service);
             detector.stop();
         }
 
@@ -1975,7 +1987,7 @@ impl Taker {
                     if self
                         .breach_detector
                         .as_ref()
-                        .is_some_and(|d| d.is_breached())
+                        .is_some_and(|d| d.requires_abort())
                     {
                         log::error!(
                             "Contract broadcast detected during finalization — aborting retries"
@@ -2744,6 +2756,10 @@ pub enum TakerBehavior {
     /// Normal behavior.
     #[default]
     Normal,
+    /// Stop the watcher immediately before the taker's funding gate.
+    StopWatcherBeforeSwap,
+    /// Stop the watcher after Legacy breach sentinels are armed.
+    StopWatcherAfterSentinels,
     /// Close connection early (after maker selection).
     CloseEarly,
     /// Drop after funds/contracts are broadcast but before finalization.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -984,6 +984,9 @@ impl Taker {
 
         log::info!("Starting coinswap execution for id: {}", swap_id);
 
+        // Taproot has no breach case: its contract output cannot be spent
+        // mid-swap — key-path needs both keys, the hashlock needs the
+        // taker's preimage, timelocks are immature — so no detector starts.
         if self.swap_state()?.params.protocol == ProtocolVersion::Legacy {
             let backend = self.read_wallet()?.blockchain.new_connection()?;
             self.breach_detector = Some(super::background_services::BreachDetector::start(

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -13,13 +13,13 @@ use std::{
     time::Duration,
 };
 
-use bitcoin::{OutPoint, Txid};
+use bitcoin::{OutPoint, ScriptBuf, Txid};
 
 use crate::{
     lock_debug,
     taker::error::TakerError,
     utill::HEART_BEAT_INTERVAL,
-    wallet::{Blockchain, RecoveryReport, Wallet},
+    wallet::{AnyBlockchain, Blockchain, RecoveryReport, Wallet},
     watch_tower::{service::WatchService, watcher::WatcherEvent},
 };
 
@@ -397,31 +397,34 @@ impl Drop for RecoveryLoop {
     }
 }
 
-/// Background thread that monitors sentinel outpoints for adversarial spends
-/// via the WatchService. Queries the watcher's file registry periodically;
-/// the watcher's ZMQ backend captures spending transactions in real-time.
-///
-/// - **Legacy**: sentinels are funding outpoints — if spent, a contract tx was broadcast.
-/// - **Taproot**: sentinels are contract outpoints — if spent during exchange, a script-path
-///   spend occurred (adversarial since key-path settlement hasn't happened yet).
+/// Monitors Legacy funding outpoints for an adversarial contract broadcast.
+/// The watcher is the primary source; a direct backend query preserves the
+/// fail-closed signal if the watcher exits.
 pub(crate) struct BreachDetector {
     breached: Arc<AtomicBool>,
+    unknown: Arc<AtomicBool>,
     /// Mapping of funding outpoint → expected contract txid.
     /// Only a spend whose txid matches the expected contract txid is adversarial.
     /// Cooperative spends (after finalization) produce a different txid.
-    sentinels: Arc<Mutex<Vec<(OutPoint, Txid)>>>,
+    sentinels: Arc<Mutex<Vec<(OutPoint, Txid, ScriptBuf)>>>,
     shutdown: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl BreachDetector {
     /// Spawn a background thread that polls the WatchService for sentinel spends.
-    pub(crate) fn start(watch_service: WatchService) -> std::io::Result<Self> {
+    pub(crate) fn start(
+        watch_service: WatchService,
+        backend: AnyBlockchain,
+    ) -> std::io::Result<Self> {
         let breached = Arc::new(AtomicBool::new(false));
-        let sentinels: Arc<Mutex<Vec<(OutPoint, Txid)>>> = Arc::new(Mutex::new(Vec::new()));
+        let unknown = Arc::new(AtomicBool::new(false));
+        let sentinels: Arc<Mutex<Vec<(OutPoint, Txid, ScriptBuf)>>> =
+            Arc::new(Mutex::new(Vec::new()));
         let shutdown = Arc::new(AtomicBool::new(false));
 
         let breached_clone = breached.clone();
+        let unknown_clone = unknown.clone();
         let sentinels_clone = sentinels.clone();
         let shutdown_clone = shutdown.clone();
 
@@ -436,26 +439,39 @@ impl BreachDetector {
 
                     let current_sentinels = match lock_debug!(sentinels_clone.lock()) {
                         Ok(guard) => guard.clone(),
-                        Err(_) => continue,
+                        Err(_) => {
+                            unknown_clone.store(true, Relaxed);
+                            continue;
+                        }
                     };
 
-                    for (outpoint, expected_contract_txid) in &current_sentinels {
-                        // The poll loop is the retry here: a failed query is
-                        // logged and re-asked on the next pass.
-                        let reply = match watch_service.watch_request(*outpoint) {
-                            Ok(reply) => reply,
-                            Err(e) => {
-                                log::error!(
-                                    "watch request for {outpoint} failed (watcher gone): {e}"
-                                );
-                                continue;
+                    let mut pass_unknown = false;
+                    for (outpoint, expected_contract_txid, spk) in &current_sentinels {
+                        let spending_tx = if watch_service.is_alive() {
+                            match watch_service.watch_request(*outpoint) {
+                                Ok(WatcherEvent::UtxoSpent { spending_tx, .. }) => spending_tx,
+                                Ok(_) => None,
+                                Err(e) => {
+                                    log::error!("watch request for {outpoint} failed: {e}");
+                                    pass_unknown = true;
+                                    continue;
+                                }
+                            }
+                        } else {
+                            match backend.spending_transaction(
+                                outpoint,
+                                spk.as_script(),
+                                Some(expected_contract_txid),
+                            ) {
+                                Ok(tx) => tx,
+                                Err(e) => {
+                                    log::error!("direct breach query for {outpoint} failed: {e}");
+                                    pass_unknown = true;
+                                    continue;
+                                }
                             }
                         };
-                        if let WatcherEvent::UtxoSpent {
-                            spending_tx: Some(ref tx),
-                            ..
-                        } = reply
-                        {
+                        if let Some(tx) = spending_tx {
                             let actual_txid = tx.compute_txid();
                             if actual_txid == *expected_contract_txid {
                                 // The funding outpoint was spent by the pre-signed contract tx.
@@ -476,11 +492,13 @@ impl BreachDetector {
                             );
                         }
                     }
+                    unknown_clone.store(pass_unknown, Relaxed);
                 }
             })?;
 
         Ok(Self {
             breached,
+            unknown,
             sentinels,
             shutdown,
             handle: Some(handle),
@@ -498,33 +516,31 @@ impl BreachDetector {
         watch_service: &WatchService,
         sentinels: &[(OutPoint, Txid, bitcoin::ScriptBuf)],
     ) -> Result<(), TakerError> {
-        // A sentinel that failed to register must not be tracked as armed:
-        // fail the swap step instead of pretending breach detection is live.
+        lock_debug!(self.sentinels.lock())
+            .map_err(|_| TakerError::General("breach sentinel lock poisoned".into()))?
+            .extend_from_slice(sentinels);
         for (outpoint, _, spk) in sentinels {
-            watch_service
-                .register_watch_request(*outpoint, spk.clone())
-                .map_err(|e| {
-                    TakerError::General(format!(
-                        "sentinel registration for {outpoint} failed (watcher gone): {e}"
-                    ))
-                })?;
-        }
-        if let Ok(mut guard) = lock_debug!(self.sentinels.lock()) {
-            #[cfg(debug_assertions)]
-            log::debug!(
-                "[WATCH_STATE] Source: taker::background_services::add_sentinels | Action: register_breach_sentinels | Added: {} | Total: {}",
-                sentinels.len(),
-                guard.len()
-            );
-            let storage: Vec<_> = sentinels.iter().map(|(op, txid, _)| (*op, *txid)).collect();
-            guard.extend_from_slice(&storage);
+            if let Err(e) = watch_service.register_watch_request(*outpoint, spk.clone()) {
+                log::error!("sentinel registration for {outpoint} failed: {e}; using fallback");
+            }
         }
         Ok(())
     }
 
-    /// Check whether an adversarial spend has been detected.
+    pub(crate) fn disarm(&self, watch_service: &WatchService) {
+        if let Ok(mut sentinels) = lock_debug!(self.sentinels.lock()) {
+            for (outpoint, _, spk) in sentinels.drain(..) {
+                _ = watch_service.unwatch(outpoint, spk);
+            }
+        }
+    }
+
     pub(crate) fn is_breached(&self) -> bool {
         self.breached.load(Relaxed)
+    }
+
+    pub(crate) fn requires_abort(&self) -> bool {
+        self.is_breached() || self.unknown.load(Relaxed)
     }
 
     /// Signal the background thread to stop and wait for it to finish.

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -152,11 +152,6 @@ impl Taker {
         // Track the previous hop's confirmation height to verify timelock staggering.
         let mut prev_confirm_height: u32 = 0;
 
-        // Background thread monitors funding outpoints for adversarial contract broadcasts.
-        self.breach_detector = Some(super::background_services::BreachDetector::start(
-            self.watch_service.clone(),
-        )?);
-
         // Flags to skip already-completed steps when retrying a maker iteration
         // after spare substitution (e.g., taker's funding is already on-chain).
         let mut taker_funding_broadcast = false;
@@ -307,6 +302,11 @@ impl Taker {
             }
 
             if is_first_peer && !taker_funding_broadcast {
+                if !self.watch_service.is_alive() {
+                    return Err(TakerError::General(
+                        "watchtower exited before funding".into(),
+                    ));
+                }
                 log::info!("Broadcasting funding transactions and waiting for confirmation");
                 {
                     let mut wallet = self.write_wallet()?;
@@ -389,6 +389,12 @@ impl Taker {
                     .collect::<Result<Vec<_>, TakerError>>()?; // An error here means something big is internally broken
                 if let Some(ref detector) = self.breach_detector {
                     detector.add_sentinels(&self.watch_service, &sentinels)?;
+                }
+                #[cfg(feature = "integration-test")]
+                if self.behavior == super::api::TakerBehavior::StopWatcherAfterSentinels
+                    && self.watch_service.is_alive()
+                {
+                    self.watch_service.stop_watcher_for_test();
                 }
             }
 
@@ -871,7 +877,7 @@ impl Taker {
             Some(&|| {
                 self.breach_detector
                     .as_ref()
-                    .is_some_and(|detector| detector.is_breached())
+                    .is_some_and(|detector| detector.requires_abort())
             }),
         )
         .map_err(breach_or_wallet_error)

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -751,6 +751,9 @@ impl Taker {
             required_confirms,
             arrival_timeout,
             None,
+            // Inert on taproot: no detector is started for it, and none is
+            // needed — no counterparty can spend the contract output
+            // mid-swap. Kept only for the shared wait helper's signature.
             Some(&|| {
                 self.breach_detector
                     .as_ref()

--- a/src/wallet/blockchain/corerpc.rs
+++ b/src/wallet/blockchain/corerpc.rs
@@ -20,7 +20,7 @@ use bitcoind::bitcoincore_rpc::{
     jsonrpc, Auth, Client, Error as CoreRpcError, RpcApi,
 };
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::{BlockRef, Blockchain, WatchEvent};
 use crate::{lock_debug, wallet::error::WalletError};
@@ -168,6 +168,11 @@ pub struct CoreRPC {
     zmq: ZmqSubscriber,
 }
 
+#[derive(Deserialize)]
+struct SpendingPrevout {
+    spendingtxid: Option<Txid>,
+}
+
 impl std::fmt::Debug for CoreRPC {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CoreRPC")
@@ -198,6 +203,38 @@ impl CoreRPC {
     /// its own connection without threading the config around separately.
     pub fn reconnect(&self) -> Result<Self, WalletError> {
         Self::new(&self.config)
+    }
+
+    pub(crate) fn spending_transaction(
+        &self,
+        outpoint: &OutPoint,
+    ) -> Result<Option<Transaction>, WalletError> {
+        let spends: Vec<SpendingPrevout> = self.rpc.call(
+            "gettxspendingprevout",
+            &[json!([{ "txid": outpoint.txid, "vout": outpoint.vout }])],
+        )?;
+        if let Some(txid) = spends.first().and_then(|spend| spend.spendingtxid) {
+            return self.get_raw_transaction(&txid, None).map(Some);
+        }
+        if self
+            .get_tx_out(&outpoint.txid, outpoint.vout, Some(true))?
+            .is_some()
+        {
+            return Ok(None);
+        }
+        let Some(start) = self.tx_block_height(&outpoint.txid)? else {
+            return Ok(None);
+        };
+        for height in start..=self.get_block_count()? {
+            if let Some(tx) = self.block_at_height(height)?.txdata.into_iter().find(|tx| {
+                tx.input
+                    .iter()
+                    .any(|input| input.previous_output == *outpoint)
+            }) {
+                return Ok(Some(tx));
+            }
+        }
+        Ok(None)
     }
 
     /// Name of the Bitcoin Core wallet this backend is bound to.

--- a/src/wallet/blockchain/corerpc.rs
+++ b/src/wallet/blockchain/corerpc.rs
@@ -222,6 +222,10 @@ impl CoreRPC {
         {
             return Ok(None);
         }
+        // None here means "funding never confirmed" or "node cannot serve
+        // the tx" (fresh, pruned, mid-rescan) — indistinguishable at this
+        // RPC, and only the first makes "no spend" true. Accepted as a rare
+        // silent miss; the real fix passes the caller-known height and errs.
         let Some(start) = self.tx_block_height(&outpoint.txid)? else {
             return Ok(None);
         };

--- a/src/wallet/blockchain/electrum.rs
+++ b/src/wallet/blockchain/electrum.rs
@@ -1364,7 +1364,9 @@ impl Blockchain for Electrum {
         if ping_due {
             state.last_ping = Some(std::time::Instant::now());
             if let Err(e) = self.call(|c| c.ping()) {
-                log::warn!("electrum notification ping failed: {e:?}");
+                // Without the ping the socket is never read and the watcher
+                // goes deaf while looking alive — loud, not a warning.
+                log::error!("electrum notification ping failed: {e:?}");
                 return None;
             }
         }

--- a/src/wallet/blockchain/electrum.rs
+++ b/src/wallet/blockchain/electrum.rs
@@ -284,6 +284,33 @@ impl std::fmt::Debug for Electrum {
 }
 
 impl Electrum {
+    pub(crate) fn spending_transaction(
+        &self,
+        outpoint: &OutPoint,
+        script: &Script,
+        expected_txid: Option<&Txid>,
+    ) -> Result<Option<Transaction>, WalletError> {
+        if let Some(txid) = expected_txid {
+            let tx = match self.call(|c| c.transaction_get(txid)) {
+                Ok(tx) => tx,
+                Err(WalletError::Electrum(ref e)) if is_unknown_txid(e) => return Ok(None),
+                Err(e) => return Err(e),
+            };
+            return Ok(tx
+                .input
+                .iter()
+                .any(|input| input.previous_output == *outpoint)
+                .then_some(tx));
+        }
+        for entry in self.call(|c| c.script_get_history(script))? {
+            let tx = self.call(|c| c.transaction_get(&entry.tx_hash))?;
+            if tx.input.iter().any(|i| i.previous_output == *outpoint) {
+                return Ok(Some(tx));
+            }
+        }
+        Ok(None)
+    }
+
     /// Connect to an Electrum server and derive the network from its genesis
     /// hash. Used by `AnyBlockchain::from_config`; each consumer gets its own
     /// connection.
@@ -420,6 +447,13 @@ impl Electrum {
     /// not the reconnect-on-failure path, which replaces a dead socket in place.
     pub fn reconnect(&self) -> Result<Self, WalletError> {
         Self::with_shutdown_flag(&self.config, self.shutdown.clone())
+    }
+
+    pub(crate) fn reconnect_with_shutdown(
+        &self,
+        shutdown: Arc<AtomicBool>,
+    ) -> Result<Self, WalletError> {
+        Self::with_shutdown_flag(&self.config, shutdown)
     }
 
     /// Times the transport was rebuilt since construction.

--- a/src/wallet/blockchain/mod.rs
+++ b/src/wallet/blockchain/mod.rs
@@ -382,6 +382,34 @@ impl AnyBlockchain {
             AnyBlockchain::Electrum(b) => Ok(AnyBlockchain::Electrum(b.reconnect()?)),
         }
     }
+
+    /// Open a connection with cancellation owned by the new consumer.
+    pub(crate) fn new_connection_with_shutdown(
+        &self,
+        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Result<Self, WalletError> {
+        match self {
+            AnyBlockchain::CoreRPC(b) => Ok(AnyBlockchain::CoreRPC(b.reconnect()?)),
+            AnyBlockchain::Electrum(b) => Ok(AnyBlockchain::Electrum(
+                b.reconnect_with_shutdown(shutdown)?,
+            )),
+        }
+    }
+
+    /// Return the mempool or confirmed transaction spending `outpoint`.
+    pub(crate) fn spending_transaction(
+        &self,
+        outpoint: &OutPoint,
+        script: &Script,
+        expected_txid: Option<&Txid>,
+    ) -> Result<Option<Transaction>, WalletError> {
+        match self {
+            AnyBlockchain::CoreRPC(b) => b.spending_transaction(outpoint).map(|spend| {
+                spend.filter(|tx| expected_txid.is_none_or(|txid| tx.compute_txid() == *txid))
+            }),
+            AnyBlockchain::Electrum(b) => b.spending_transaction(outpoint, script, expected_txid),
+        }
+    }
 }
 
 /// Dispatch each [`Blockchain`] method to the active backend variant.

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -82,8 +82,10 @@ impl WatchService {
         Ok(Self::from_parts(tx, handle, watcher_shutdown, alive))
     }
 
-    /// Sticky watcher availability; false after exit or failed startup initialization.
-    /// It does not probe backend progress or individual registrations.
+    /// Sticky watcher availability; false only after channel-level death:
+    /// thread exit, send failure, reply disconnect, or shutdown. A reply —
+    /// even an error — is proof the thread answered. Does not probe backend
+    /// progress or individual registrations.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Acquire)
     }
@@ -113,7 +115,9 @@ impl WatchService {
 
     /// Re-arms the watches for every live contract in the wallet. The registry
     /// is memory-only, so a restart begins with nothing watched. Blocks until
-    /// the rebuild (Core rescan included) replies, so startup never runs unwatched.
+    /// the rebuild (Core rescan included) replies, so startup never runs
+    /// unwatched. The watcher retries a failed rescan until it completes, so
+    /// an Err here means the watcher is gone or shutting down.
     pub fn rebuild_watches(&self, watches: Vec<(OutPoint, ScriptBuf)>) -> Result<(), WatcherError> {
         let (reply_tx, reply_rx) = unbounded();
         self.send_command(WatcherCommand::RebuildWatches {
@@ -125,12 +129,7 @@ impl WatchService {
         // only exists so teardown can still cut the wait short.
         loop {
             match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
-                Ok(result) => {
-                    return result.map_err(|error| {
-                        self.alive.store(false, Ordering::Release);
-                        WatcherError::General(error)
-                    })
-                }
+                Ok(result) => return result.map_err(WatcherError::General),
                 Err(RecvTimeoutError::Disconnected) => {
                     self.alive.store(false, Ordering::Release);
                     return Err(WatcherError::SendError);
@@ -139,6 +138,9 @@ impl WatchService {
                     if self.watcher_shutdown.load(Ordering::Relaxed) {
                         return Err(WatcherError::Shutdown);
                     }
+                    // A rescan legitimately takes minutes, but a stuck one is
+                    // invisible otherwise — keep the wait visible in logs.
+                    log::warn!("still waiting for watch rebuild reply");
                 }
             }
         }
@@ -179,7 +181,9 @@ impl WatchService {
                     if self.watcher_shutdown.load(Ordering::Relaxed) {
                         return Err(WatcherError::Shutdown);
                     }
-                    log::debug!("still waiting for watcher reply for {outpoint}");
+                    // Warn, not debug: an alive watcher that stops answering is
+                    // the wedge case liveness cannot see — it must show in logs.
+                    log::warn!("still waiting for watcher reply for {outpoint}");
                 }
             }
         }
@@ -407,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_watches_blocks_and_marks_failure_unavailable() {
+    fn rebuild_error_reply_keeps_liveness() {
         let (tx, rx) = mpsc::channel();
         let (reply_hold_tx, reply_hold_rx) = mpsc::channel();
         let handle = thread::spawn(move || {
@@ -426,7 +430,8 @@ mod tests {
         assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
         _ = reply.send(Err("rescan failed".to_string()));
         assert!(done_rx.recv().unwrap().is_err());
-        assert!(!service.is_alive());
+        // An answered reply — even an error — is not channel-level death.
+        assert!(service.is_alive());
         waiter.join().unwrap();
     }
 

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -3,6 +3,7 @@
 use bitcoin::{OutPoint, ScriptBuf};
 use crossbeam_channel::{unbounded, RecvTimeoutError};
 use std::{
+    panic::{self, AssertUnwindSafe},
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::{self, SendError, Sender as StdSender},
@@ -48,19 +49,52 @@ pub struct WatchService {
     handle: WatcherHandle,
     /// Role flag checked by the watcher and every Electrum connection it owns.
     watcher_shutdown: Arc<AtomicBool>,
+    /// Set while the watcher runs, then left false after any terminal exit.
+    alive: Arc<AtomicBool>,
 }
 
 impl WatchService {
-    /// Creates a service whose watcher and backend share the role shutdown flag.
-    pub fn new(
+    fn from_parts(
         tx: StdSender<WatcherCommand>,
         handle: JoinHandle<Result<(), WatcherError>>,
         watcher_shutdown: Arc<AtomicBool>,
+        alive: Arc<AtomicBool>,
     ) -> Self {
         Self {
             tx,
             handle: Arc::new(Mutex::new(Some(handle))),
             watcher_shutdown,
+            alive,
+        }
+    }
+
+    /// Spawns a watcher whose lifetime is reflected by [`Self::is_alive`].
+    pub(crate) fn spawn(
+        tx: StdSender<WatcherCommand>,
+        watcher_shutdown: Arc<AtomicBool>,
+        run: impl FnOnce() -> Result<(), WatcherError> + Send + 'static,
+    ) -> std::io::Result<Self> {
+        let alive = Arc::new(AtomicBool::new(true));
+        let thread_alive = alive.clone();
+        let handle = thread::Builder::new()
+            .name("Watcher thread".to_string())
+            .spawn(move || run_with_liveness(thread_alive, run))?;
+        Ok(Self::from_parts(tx, handle, watcher_shutdown, alive))
+    }
+
+    /// Whether the watcher thread is still available. This flag is sticky:
+    /// an exited watcher is never treated as healthy again without a restart.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
+    }
+
+    fn send_command(&self, command: WatcherCommand) -> Result<(), SendError<WatcherCommand>> {
+        match self.tx.send(command) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.alive.store(false, Ordering::Release);
+                Err(e)
+            }
         }
     }
 
@@ -71,7 +105,7 @@ impl WatchService {
         outpoint: OutPoint,
         script_pubkey: ScriptBuf,
     ) -> Result<(), SendError<WatcherCommand>> {
-        self.tx.send(WatcherCommand::RegisterWatchRequest {
+        self.send_command(WatcherCommand::RegisterWatchRequest {
             outpoint,
             script_pubkey,
         })
@@ -82,18 +116,20 @@ impl WatchService {
     /// the rebuild (Core rescan included) replies, so startup never runs unwatched.
     pub fn rebuild_watches(&self, watches: Vec<(OutPoint, ScriptBuf)>) -> Result<(), WatcherError> {
         let (reply_tx, reply_rx) = unbounded();
-        self.tx
-            .send(WatcherCommand::RebuildWatches {
-                watches,
-                reply: reply_tx,
-            })
-            .map_err(|_| WatcherError::SendError)?;
+        self.send_command(WatcherCommand::RebuildWatches {
+            watches,
+            reply: reply_tx,
+        })
+        .map_err(|_| WatcherError::SendError)?;
         // No total cap: a deep Core rescan legitimately takes minutes. The loop
         // only exists so teardown can still cut the wait short.
         loop {
             match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
                 Ok(result) => return result.map_err(WatcherError::General),
-                Err(RecvTimeoutError::Disconnected) => return Err(WatcherError::SendError),
+                Err(RecvTimeoutError::Disconnected) => {
+                    self.alive.store(false, Ordering::Release);
+                    return Err(WatcherError::SendError);
+                }
                 Err(RecvTimeoutError::Timeout) => {
                     if self.watcher_shutdown.load(Ordering::Relaxed) {
                         return Err(WatcherError::Shutdown);
@@ -114,12 +150,11 @@ impl WatchService {
     /// watcher disconnects the reply channel, and shutdown cuts the wait short.
     pub fn watch_request(&self, outpoint: OutPoint) -> Result<WatcherEvent, WatcherError> {
         let (reply_tx, reply_rx) = unbounded();
-        self.tx
-            .send(WatcherCommand::WatchRequest {
-                outpoint,
-                reply: reply_tx,
-            })
-            .map_err(|_| WatcherError::SendError)?;
+        self.send_command(WatcherCommand::WatchRequest {
+            outpoint,
+            reply: reply_tx,
+        })
+        .map_err(|_| WatcherError::SendError)?;
 
         loop {
             match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
@@ -131,7 +166,10 @@ impl WatchService {
                     )));
                 }
                 Ok(event) => return Ok(event),
-                Err(RecvTimeoutError::Disconnected) => return Err(WatcherError::SendError),
+                Err(RecvTimeoutError::Disconnected) => {
+                    self.alive.store(false, Ordering::Release);
+                    return Err(WatcherError::SendError);
+                }
                 Err(RecvTimeoutError::Timeout) => {
                     if self.watcher_shutdown.load(Ordering::Relaxed) {
                         return Err(WatcherError::Shutdown);
@@ -151,7 +189,7 @@ impl WatchService {
         outpoint: OutPoint,
         script_pubkey: ScriptBuf,
     ) -> Result<(), SendError<WatcherCommand>> {
-        self.tx.send(WatcherCommand::Unwatch {
+        self.send_command(WatcherCommand::Unwatch {
             outpoint,
             script_pubkey,
         })
@@ -160,8 +198,9 @@ impl WatchService {
     /// Signals the watcher to shut down gracefully and joins its thread,
     /// aborting any Electrum retry backoff it may be stuck in.
     pub fn shutdown(&self) {
-        let _ = self.tx.send(WatcherCommand::Shutdown);
+        let _ = self.send_command(WatcherCommand::Shutdown);
         self.watcher_shutdown.store(true, Ordering::Relaxed);
+        self.alive.store(false, Ordering::Release);
         let handle = lock_debug!(self.handle.lock())
             .ok()
             .and_then(|mut h| h.take());
@@ -175,11 +214,47 @@ impl WatchService {
                 Err(_) => "panic",
             };
             crate::utill::log_shutdown_join_done("watch_service", &thread, outcome);
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => log::error!("watcher thread exited with error: {e:?}"),
-                Err(_) => log::error!("watcher thread panicked"),
+            // The watcher wrapper logs the detailed result when it exits.
+        }
+    }
+
+    /// Stops only the watcher, leaving its owner running so integration tests
+    /// can exercise fail-closed maker behavior.
+    #[cfg(feature = "integration-test")]
+    pub fn stop_watcher_for_test(&self) {
+        let _ = self.send_command(WatcherCommand::Shutdown);
+        for _ in 0..500 {
+            if !self.is_alive() {
+                return;
             }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("watcher did not stop within the integration-test timeout");
+    }
+}
+
+/// Runs a watcher while publishing and logging its complete lifetime. Panics
+/// are logged here and then resumed so the retained join handle still reports
+/// the correct outcome during orderly shutdown.
+fn run_with_liveness(
+    alive: Arc<AtomicBool>,
+    run: impl FnOnce() -> Result<(), WatcherError>,
+) -> Result<(), WatcherError> {
+    alive.store(true, Ordering::Release);
+    let result = panic::catch_unwind(AssertUnwindSafe(run));
+    alive.store(false, Ordering::Release);
+    match result {
+        Ok(Ok(())) => {
+            log::info!("watcher thread exited cleanly");
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            log::error!("watcher thread exited with error: {e:?}");
+            Err(e)
+        }
+        Err(payload) => {
+            log::error!("watcher thread panicked");
+            panic::resume_unwind(payload)
         }
     }
 }
@@ -204,13 +279,11 @@ pub fn start_maker_watch_service(
         None,
         shutdown.clone(),
     );
-
     // Makers don't run discovery, so pass an already-complete flag.
-    let handle = thread::Builder::new()
-        .name("Watcher thread".to_string())
-        .spawn(move || watcher.run(Arc::new(AtomicBool::new(true))))?;
-
-    Ok(WatchService::new(tx_requests, handle, shutdown))
+    WatchService::spawn(tx_requests, shutdown, move || {
+        watcher.run(Arc::new(AtomicBool::new(true)))
+    })
+    .map_err(WatcherError::from)
 }
 
 #[cfg(test)]
@@ -219,6 +292,58 @@ mod tests {
 
     fn dummy_handle() -> JoinHandle<Result<(), WatcherError>> {
         thread::spawn(|| Ok(()))
+    }
+
+    fn test_service(
+        tx: StdSender<WatcherCommand>,
+        handle: JoinHandle<Result<(), WatcherError>>,
+        watcher_shutdown: bool,
+    ) -> WatchService {
+        WatchService::from_parts(
+            tx,
+            handle,
+            Arc::new(AtomicBool::new(watcher_shutdown)),
+            Arc::new(AtomicBool::new(true)),
+        )
+    }
+
+    #[test]
+    fn liveness_tracks_the_complete_thread_lifetime() {
+        let alive = Arc::new(AtomicBool::new(false));
+        let thread_alive = alive.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            run_with_liveness(thread_alive, || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(())
+            })
+        });
+
+        started_rx.recv().unwrap();
+        assert!(alive.load(Ordering::Acquire));
+        release_tx.send(()).unwrap();
+        assert!(handle.join().unwrap().is_ok());
+        assert!(!alive.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn liveness_is_cleared_on_error_and_panic() {
+        let errored = Arc::new(AtomicBool::new(false));
+        let result = run_with_liveness(errored.clone(), || {
+            Err(WatcherError::General("test error".to_string()))
+        });
+        assert!(result.is_err());
+        assert!(!errored.load(Ordering::Acquire));
+
+        let panicked = Arc::new(AtomicBool::new(false));
+        let result = panic::catch_unwind({
+            let panicked = panicked.clone();
+            move || run_with_liveness(panicked, || panic!("test panic"))
+        });
+        assert!(result.is_err());
+        assert!(!panicked.load(Ordering::Acquire));
     }
 
     #[test]
@@ -231,7 +356,7 @@ mod tests {
             }
             Ok(())
         });
-        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let service = test_service(tx, handle, false);
         let event = service.watch_request(OutPoint::null()).unwrap();
         assert!(matches!(event, WatcherEvent::NoOutpoint));
     }
@@ -239,7 +364,7 @@ mod tests {
     #[test]
     fn shutdown_flag_cuts_wait_short() {
         let (tx, rx) = mpsc::channel();
-        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(true)));
+        let service = test_service(tx, dummy_handle(), true);
         let err = service.watch_request(OutPoint::null()).unwrap_err();
         assert!(matches!(err, WatcherError::Shutdown));
         assert_eq!(rx.try_iter().count(), 1);
@@ -249,9 +374,10 @@ mod tests {
     fn dead_watcher_errors_without_retry() {
         let (tx, rx) = mpsc::channel::<WatcherCommand>();
         drop(rx);
-        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(false)));
+        let service = test_service(tx, dummy_handle(), false);
         let err = service.watch_request(OutPoint::null()).unwrap_err();
         assert!(matches!(err, WatcherError::SendError));
+        assert!(!service.is_alive());
     }
 
     #[test]
@@ -263,7 +389,7 @@ mod tests {
             }
             Ok(())
         });
-        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let service = test_service(tx, handle, false);
         let event = service.watch_request(OutPoint::null()).unwrap();
         assert!(matches!(event, WatcherEvent::NoOutpoint));
     }
@@ -277,7 +403,7 @@ mod tests {
             }
             Ok(())
         });
-        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let service = test_service(tx, handle, false);
         let err = service.watch_request(OutPoint::null()).unwrap_err();
         assert!(matches!(err, WatcherError::General(_)));
     }
@@ -292,7 +418,7 @@ mod tests {
             }
             Ok(())
         });
-        let service = WatchService::new(tx, handle, Arc::new(AtomicBool::new(false)));
+        let service = test_service(tx, handle, false);
         let (done_tx, done_rx) = mpsc::channel();
         let svc = service.clone();
         let waiter = thread::spawn(move || _ = done_tx.send(svc.rebuild_watches(Vec::new())));
@@ -308,7 +434,7 @@ mod tests {
     #[test]
     fn rebuild_watches_returns_shutdown_without_reply() {
         let (tx, _rx) = mpsc::channel();
-        let service = WatchService::new(tx, dummy_handle(), Arc::new(AtomicBool::new(true)));
+        let service = test_service(tx, dummy_handle(), true);
         let err = service.rebuild_watches(Vec::new()).unwrap_err();
         assert!(matches!(err, WatcherError::Shutdown));
     }

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -82,8 +82,8 @@ impl WatchService {
         Ok(Self::from_parts(tx, handle, watcher_shutdown, alive))
     }
 
-    /// Whether the watcher thread is still available. This flag is sticky:
-    /// an exited watcher is never treated as healthy again without a restart.
+    /// Sticky watcher availability; false after exit or failed startup initialization.
+    /// It does not probe backend progress or individual registrations.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Acquire)
     }
@@ -125,7 +125,12 @@ impl WatchService {
         // only exists so teardown can still cut the wait short.
         loop {
             match reply_rx.recv_timeout(WATCH_REPLY_TIMEOUT) {
-                Ok(result) => return result.map_err(WatcherError::General),
+                Ok(result) => {
+                    return result.map_err(|error| {
+                        self.alive.store(false, Ordering::Release);
+                        WatcherError::General(error)
+                    })
+                }
                 Err(RecvTimeoutError::Disconnected) => {
                     self.alive.store(false, Ordering::Release);
                     return Err(WatcherError::SendError);
@@ -218,18 +223,12 @@ impl WatchService {
         }
     }
 
-    /// Stops only the watcher, leaving its owner running so integration tests
-    /// can exercise fail-closed maker behavior.
+    /// Makes the watcher unavailable without stopping its owner, allowing
+    /// integration tests to exercise fail-closed behavior.
     #[cfg(feature = "integration-test")]
     pub fn stop_watcher_for_test(&self) {
         let _ = self.send_command(WatcherCommand::Shutdown);
-        for _ in 0..500 {
-            if !self.is_alive() {
-                return;
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        panic!("watcher did not stop within the integration-test timeout");
+        self.alive.store(false, Ordering::Release);
     }
 }
 
@@ -240,7 +239,6 @@ fn run_with_liveness(
     alive: Arc<AtomicBool>,
     run: impl FnOnce() -> Result<(), WatcherError>,
 ) -> Result<(), WatcherError> {
-    alive.store(true, Ordering::Release);
     let result = panic::catch_unwind(AssertUnwindSafe(run));
     alive.store(false, Ordering::Release);
     match result {
@@ -309,7 +307,7 @@ mod tests {
 
     #[test]
     fn liveness_tracks_the_complete_thread_lifetime() {
-        let alive = Arc::new(AtomicBool::new(false));
+        let alive = Arc::new(AtomicBool::new(true));
         let thread_alive = alive.clone();
         let (started_tx, started_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
@@ -409,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_watches_blocks_until_reply() {
+    fn rebuild_watches_blocks_and_marks_failure_unavailable() {
         let (tx, rx) = mpsc::channel();
         let (reply_hold_tx, reply_hold_rx) = mpsc::channel();
         let handle = thread::spawn(move || {
@@ -426,8 +424,9 @@ mod tests {
         // The watcher has the command but has not replied, so the caller must
         // still be blocked.
         assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
-        _ = reply.send(Ok(()));
-        assert!(done_rx.recv().unwrap().is_ok());
+        _ = reply.send(Err("rescan failed".to_string()));
+        assert!(done_rx.recv().unwrap().is_err());
+        assert!(!service.is_alive());
         waiter.join().unwrap();
     }
 

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -234,7 +234,11 @@ impl<R: Role> Watcher<R> {
             }
 
             // Stop and join the discovery thread on exit path.
-            shutdown_clone.store(true, Ordering::SeqCst);
+            // Only the Taker role owns a discovery child that needs this
+            // secondary stop signal. Maker shutdown is driven by its owner.
+            if R::RUN_DISCOVERY {
+                shutdown_clone.store(true, Ordering::SeqCst);
+            }
             if let Some(handle) = discovery_handle {
                 let thread = handle.thread().clone();
                 crate::utill::log_shutdown_join_start("watcher", &thread);

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -10,6 +10,7 @@ use std::{
         mpsc::{Receiver as StdReceiver, RecvTimeoutError},
         Arc,
     },
+    thread,
 };
 
 use bitcoin::{consensus::deserialize, Block, Network, OutPoint, ScriptBuf, Transaction};
@@ -298,15 +299,18 @@ impl<R: Role> Watcher<R> {
                         self.pending_subscribes.push((*outpoint, spk.clone()));
                     }
                 }
-                // Electrum replays each script's whole history as `TxSeen`, so a
-                // spend from while we were down records itself. Core has no such
-                // feed and needs the blocks read back.
-                let result = if self.blockchain.is_electrum() {
-                    Ok(())
-                } else {
-                    self.rescan_for_missed_spends(&watches)
-                };
-                _ = reply.send(result);
+                // Electrum replays each script's whole history as `TxSeen`.
+                // Core has no history feed, so a failed rescan retries until
+                // it completes — the reply only fails on shutdown. A node
+                // pruned past a live contract hangs startup here, loudly.
+                if !self.blockchain.is_electrum() {
+                    while !self.shutdown.load(Ordering::Relaxed)
+                        && self.rescan_for_missed_spends(&watches).is_err()
+                    {
+                        thread::sleep(HEART_BEAT_INTERVAL);
+                    }
+                }
+                _ = reply.send(Ok(()));
             }
             WatcherCommand::WatchRequest { outpoint, reply } => {
                 log::info!("Intercepted watch request: {outpoint}");
@@ -458,7 +462,9 @@ impl<R: Role> Watcher<R> {
                     false
                 }
                 Err(e) => {
-                    log::warn!("re-subscribe still failing for {outpoint}: {e}");
+                    // The outpoint is unwatched while this fails; loud so a
+                    // wedged backend shows before a swap depends on the watch.
+                    log::error!("re-subscribe still failing for {outpoint}: {e}");
                     true
                 }
             }

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -164,7 +164,7 @@ impl<R: Role> Watcher<R> {
             R::RUN_DISCOVERY
         );
 
-        let discovery_shutdown = self.shutdown.clone();
+        let discovery_shutdown = Arc::new(AtomicBool::new(false));
         let registry = self.registry.clone();
         let nostr_relays = self.nostr_relays.clone();
         let nostr_tor_config = self.nostr_tor_config.clone();
@@ -174,7 +174,9 @@ impl<R: Role> Watcher<R> {
             if R::RUN_DISCOVERY {
                 if let Some(nostr_tor_config) = nostr_tor_config {
                     // Discovery requires it's own dedicated backend to not overlap with regular watch requests.
-                    let chain = self.blockchain.new_connection()?;
+                    let chain = self
+                        .blockchain
+                        .new_connection_with_shutdown(discovery_shutdown.clone())?;
                     // The thread runs until shutdown, so its outcome is only
                     // known at the join below.
                     discovery_handle = Some(s.spawn(move || {
@@ -234,11 +236,7 @@ impl<R: Role> Watcher<R> {
             }
 
             // Stop and join the discovery thread on exit path.
-            // Only the Taker role owns a discovery child that needs this
-            // secondary stop signal. Maker shutdown is driven by its owner.
-            if R::RUN_DISCOVERY {
-                shutdown_clone.store(true, Ordering::SeqCst);
-            }
+            shutdown_clone.store(true, Ordering::SeqCst);
             if let Some(handle) = discovery_handle {
                 let thread = handle.thread().clone();
                 crate::utill::log_shutdown_join_start("watcher", &thread);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -36,6 +36,7 @@ mod taproot_taker_abort2;
 mod taproot_taker_abort3;
 mod taproot_timelock_recovery;
 mod wallet_backup;
+mod watchtower_liveness;
 
 mod concurrent_takers;
 mod duplicate_funding_outpoint;

--- a/tests/integration/malice2.rs
+++ b/tests/integration/malice2.rs
@@ -42,11 +42,18 @@ use std::{
 /// `electrum_tor.rs` can reuse the body over Tor.
 /// This is the only scenario driving the taker's breach detector.
 pub(crate) fn run_malice2<B: TestBackend>() {
+    run_malice2_with_taker_behavior::<B>(TakerBehavior::Normal, false);
+}
+
+fn run_malice2_with_taker_behavior<B: TestBackend>(
+    taker_behavior: TakerBehavior,
+    expect_direct_breach_detection: bool,
+) {
     // ---- Setup ----
     warn!("Running Test: Malice2 - Maker Broadcasts Contract After Setup");
 
     let makers_config_map = vec![(6702, Some(19701)), (16702, Some(19702))];
-    let taker_behavior = vec![TakerBehavior::Normal];
+    let taker_behavior = vec![taker_behavior];
     let maker_behaviors = vec![
         MakerBehavior::Normal,
         MakerBehavior::BroadcastContractAfterSetup,
@@ -128,6 +135,13 @@ pub(crate) fn run_malice2<B: TestBackend>() {
         "Swap should fail due to maker BroadcastContractAfterSetup behavior"
     );
     info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
+    if expect_direct_breach_detection {
+        wait_for_log(
+            &format!("{}/taker/debug.log", test_framework.temp_dir.display()),
+            "Breach detector: contract tx",
+            Duration::from_secs(30),
+        );
+    }
     taker.log_tracker_state();
 
     // Wait for makers to detect the drop and the outer timelock to mature;
@@ -256,4 +270,12 @@ pub(crate) fn run_malice2<B: TestBackend>() {
 #[test]
 fn test_malice2_maker_broadcast_contract() {
     run_malice2::<BitcoindBackend>();
+}
+
+#[test]
+fn test_malice2_detects_breach_after_watcher_exit() {
+    run_malice2_with_taker_behavior::<BitcoindBackend>(
+        TakerBehavior::StopWatcherAfterSentinels,
+        true,
+    );
 }

--- a/tests/integration/skip_funding_recovery.rs
+++ b/tests/integration/skip_funding_recovery.rs
@@ -2,8 +2,7 @@
 //!
 //! These tests verify recovery when the last maker skips broadcasting
 //! its funding transaction, forcing timelock-only recovery (hashlock
-//! recovery is impossible since the funding is never on-chain). The Legacy
-//! case also verifies that a funded maker recovers after its watcher exits.
+//! recovery is impossible since the funding is never on-chain).
 
 use bitcoin::Amount;
 use coinswap::{
@@ -36,8 +35,7 @@ use std::{
 ///    - Taker recovers outgoing (to Maker1) via timelock.
 ///    - Maker1 recovers outgoing (to Maker2) via timelock.
 ///    - Maker2 has nothing to recover (outgoing was never broadcast).
-#[test]
-fn test_legacy_timelock_only_recovery() {
+fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
     // ---- Setup ----
     warn!("Running Test: Legacy Timelock-Only Recovery");
 
@@ -124,8 +122,16 @@ fn test_legacy_timelock_only_recovery() {
     info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
     taker.log_tracker_state();
 
-    makers[0].watch_service.stop_watcher_for_test();
-    assert!(!makers[0].watch_service.is_alive());
+    if stop_watcher {
+        assert!(
+            makers[0]
+                .has_unfinished_outgoing_swapcoin(&summary.swap_id)
+                .unwrap(),
+            "Maker1 must have an outgoing swapcoin for the funded swap before watcher shutdown"
+        );
+        makers[0].watch_service.stop_watcher_for_test();
+        assert!(!makers[0].watch_service.is_alive());
+    }
 
     // Sleep budget: 60s maker idle timeout (test builds) + 225-block outer-hop
     // timelock (REFUND_LOCKTIME_BASE 150 + STEP 75, 2 makers) ≈ 135s at
@@ -262,6 +268,15 @@ fn test_legacy_timelock_only_recovery() {
     tracker_logger.stop();
     test_framework.stop();
     block_generation_handle.join().unwrap();
+}
+
+#[test]
+fn test_legacy_timelock_only_recovery() {
+    run_legacy_timelock_only_recovery(false);
+}
+
+pub(crate) fn run_legacy_timelock_recovery_without_watcher() {
+    run_legacy_timelock_only_recovery(true);
 }
 
 /// Test: Timelock-only recovery when last maker skips Taproot funding broadcast.

--- a/tests/integration/skip_funding_recovery.rs
+++ b/tests/integration/skip_funding_recovery.rs
@@ -2,7 +2,8 @@
 //!
 //! These tests verify recovery when the last maker skips broadcasting
 //! its funding transaction, forcing timelock-only recovery (hashlock
-//! recovery is impossible since the funding is never on-chain).
+//! recovery is impossible since the funding is never on-chain). The Legacy
+//! case also verifies that a funded maker recovers after its watcher exits.
 
 use bitcoin::Amount;
 use coinswap::{
@@ -122,6 +123,9 @@ fn test_legacy_timelock_only_recovery() {
     );
     info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
     taker.log_tracker_state();
+
+    makers[0].watch_service.stop_watcher_for_test();
+    assert!(!makers[0].watch_service.is_alive());
 
     // Sleep budget: 60s maker idle timeout (test builds) + 225-block outer-hop
     // timelock (REFUND_LOCKTIME_BASE 150 + STEP 75, 2 makers) ≈ 135s at

--- a/tests/integration/taproot_reboot_recovery.rs
+++ b/tests/integration/taproot_reboot_recovery.rs
@@ -22,6 +22,7 @@ use super::test_framework::*;
 
 use log::{info, warn};
 use std::{
+    net::TcpStream,
     sync::{atomic::Ordering::Relaxed, Arc},
     thread,
     time::Duration,
@@ -38,6 +39,14 @@ use std::{
 /// maker's watchtower sees that spend and uses the preimage to sweep its
 /// incoming contract from Maker1 — the same end state as a completed swap.
 pub(crate) fn run_reboot_recovery<B: TestBackend>() {
+    run_reboot_recovery_with_watcher::<B>(true);
+}
+
+pub(crate) fn run_reboot_recovery_without_watcher<B: TestBackend>() {
+    run_reboot_recovery_with_watcher::<B>(false);
+}
+
+fn run_reboot_recovery_with_watcher<B: TestBackend>(watcher_available: bool) {
     warn!("Running Test: Taproot Maker Reboot Recovery Preserves Funded Swapcoins");
 
     let makers_config_map = vec![(7602, Some(20601)), (17602, Some(20602))];
@@ -140,7 +149,11 @@ pub(crate) fn run_reboot_recovery<B: TestBackend>() {
     drop(victim);
     drop(makers);
 
-    let restarted = Arc::new(MakerServer::init(victim_config).unwrap());
+    let mut restarted_server = MakerServer::init(victim_config).unwrap();
+    if !watcher_available {
+        restarted_server.behavior = MakerBehavior::StopWatcherOnStartup;
+    }
+    let restarted = Arc::new(restarted_server);
     let restarted_thread = {
         let maker_clone = restarted.clone();
         thread::spawn(move || {
@@ -148,51 +161,84 @@ pub(crate) fn run_reboot_recovery<B: TestBackend>() {
         })
     };
 
-    wait_for_makers_setup(std::slice::from_ref(&restarted), 120);
-    thread::sleep(Duration::from_secs(5));
-
-    let after_incoming = restarted
-        .wallet
-        .read()
-        .unwrap()
-        .get_incoming_swapcoins_count();
     let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
     // Recovery takes longer under parallel load; wait for the markers instead
     // of asserting at a fixed wall-clock point.
-    wait_for_log(
-        &log_path,
-        "Incomplete swaps detected on startup",
-        Duration::from_secs(120),
-    );
-    wait_for_log(
-        &log_path,
-        "recover_from_swap started",
-        Duration::from_secs(120),
-    );
-    wait_for_log(
-        &log_path,
-        "Removed outgoing swapcoin",
-        Duration::from_secs(120),
-    );
-    let log_contents = std::fs::read_to_string(&log_path).unwrap();
-    assert!(
-        !log_contents.contains("Funding was never broadcast for swap"),
-        "reboot recovery took the unsafe discard path"
-    );
-    let recovered_via_hashlock = log_contents.contains("incoming swapcoins via hashlock");
+    if watcher_available {
+        wait_for_makers_setup(std::slice::from_ref(&restarted), 120);
+        thread::sleep(Duration::from_secs(5));
 
-    restarted.shutdown.store(true, Relaxed);
-    restarted_thread.join().unwrap();
+        let after_incoming = restarted
+            .wallet
+            .read()
+            .unwrap()
+            .get_incoming_swapcoins_count();
+        wait_for_log(
+            &log_path,
+            "Incomplete swaps detected on startup",
+            Duration::from_secs(120),
+        );
+        wait_for_log(
+            &log_path,
+            "recover_from_swap started",
+            Duration::from_secs(120),
+        );
+        wait_for_log(
+            &log_path,
+            "Removed outgoing swapcoin",
+            Duration::from_secs(120),
+        );
+        let log_contents = std::fs::read_to_string(&log_path).unwrap();
+        assert!(
+            !log_contents.contains("Funding was never broadcast for swap"),
+            "reboot recovery took the unsafe discard path"
+        );
+        let recovered_via_hashlock = log_contents.contains("incoming swapcoins via hashlock");
+
+        restarted.shutdown.store(true, Relaxed);
+        restarted_thread.join().unwrap();
+        assert!(
+            after_incoming > 0 || recovered_via_hashlock,
+            "maker reboot recovery lost funded incoming swapcoins without hashlock recovery; before={}, after={}",
+            before_incoming,
+            after_incoming
+        );
+    } else {
+        wait_for_log(
+            &log_path,
+            "Incomplete swaps detected on startup",
+            Duration::from_secs(120),
+        );
+        assert!(
+            TcpStream::connect(("127.0.0.1", restarted.config.network_port)).is_err(),
+            "recovery-only maker must not accept swap connections"
+        );
+        wait_for_log(
+            &log_path,
+            &format!(
+                "[{}] Recovered {} incoming swapcoins via hashlock",
+                restarted.config.network_port, before_incoming
+            ),
+            Duration::from_secs(120),
+        );
+        assert!(!restarted.is_setup_complete.load(Relaxed));
+        restarted_thread.join().unwrap();
+
+        let wallet = restarted.wallet.read().unwrap();
+        assert_eq!(
+            wallet.get_incoming_swapcoins_count(),
+            0,
+            "restarted maker did not sweep its incoming contracts"
+        );
+        assert_eq!(
+            wallet.get_outgoing_swapcoins_count(),
+            0,
+            "restarted maker did not clean up its spent outgoing contracts"
+        );
+    }
 
     test_framework.stop();
     block_generation_handle.join().unwrap();
-
-    assert!(
-        after_incoming > 0 || recovered_via_hashlock,
-        "maker reboot recovery lost funded incoming swapcoins without hashlock recovery; before={}, after={}",
-        before_incoming,
-        after_incoming
-    );
 }
 
 #[test]

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -7,8 +7,9 @@
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at the taproot contract sigs exchange phase.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
-//! 5. Everyone falls back to timelock recovery.
-//! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
+//! 5. Maker1's watcher exits while its funded swap is in flight.
+//! 6. Everyone falls back to timelock recovery.
+//! 7. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
 use coinswap::{
@@ -118,6 +119,11 @@ fn test_taproot_timelock_recovery() {
     );
     info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
     taker.log_tracker_state();
+
+    // A stopped watcher permanently removes the hashlock observation path, but it
+    // must not prevent this already-funded maker from reaching timelock recovery.
+    makers[0].watch_service.stop_watcher_for_test();
+    assert!(!makers[0].watch_service.is_alive());
 
     // Sleep budget: 60s maker idle timeout (test builds) + 225-block outer-hop
     // timelock (REFUND_LOCKTIME_BASE 150 + STEP 75, 2 makers) ≈ 135s at

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -7,9 +7,8 @@
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at the taproot contract sigs exchange phase.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
-//! 5. Maker1's watcher exits while its funded swap is in flight.
-//! 6. Everyone falls back to timelock recovery.
-//! 7. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
+//! 5. Everyone falls back to timelock recovery.
+//! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
 use coinswap::{
@@ -119,11 +118,6 @@ fn test_taproot_timelock_recovery() {
     );
     info!("Swap failed as expected: {:?}", swap_result.err().unwrap());
     taker.log_tracker_state();
-
-    // A stopped watcher permanently removes the hashlock observation path, but it
-    // must not prevent this already-funded maker from reaching timelock recovery.
-    makers[0].watch_service.stop_watcher_for_test();
-    assert!(!makers[0].watch_service.is_alive());
 
     // Sleep budget: 60s maker idle timeout (test builds) + 225-block outer-hop
     // timelock (REFUND_LOCKTIME_BASE 150 + STEP 75, 2 makers) ≈ 135s at

--- a/tests/integration/watchtower_liveness.rs
+++ b/tests/integration/watchtower_liveness.rs
@@ -12,33 +12,6 @@ use std::{sync::atomic::Ordering::Relaxed, thread};
 use super::test_framework::*;
 
 #[test]
-fn maker_server_does_not_start_when_watcher_exits() {
-    let (test_framework, _takers, makers, block_generation_handle) =
-        TestFramework::init::<BitcoindBackend>(
-            vec![(7901, Some(20900))],
-            Vec::new(),
-            vec![MakerBehavior::StopWatcherOnStartup],
-        );
-
-    let maker = makers[0].clone();
-    let error =
-        start_server(maker.clone()).expect_err("maker server started without a live watcher");
-    assert!(
-        format!("{error:?}").contains("watchtower is down, refusing to start maker server"),
-        "unexpected startup error: {:?}",
-        error
-    );
-    assert!(!maker.watch_service.is_alive());
-    assert!(!maker.is_setup_complete.load(Relaxed));
-
-    maker.watch_service.shutdown();
-    drop(maker);
-    drop(makers);
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
-}
-
-#[test]
 fn maker_rejects_new_swaps_after_watcher_exit() {
     let (test_framework, mut takers, makers, block_generation_handle) =
         TestFramework::init::<BitcoindBackend>(
@@ -103,4 +76,79 @@ fn maker_rejects_new_swaps_after_watcher_exit() {
         .for_each(|handle| handle.join().unwrap());
     test_framework.stop();
     block_generation_handle.join().unwrap();
+}
+
+#[test]
+fn taker_refuses_swap_before_funding_after_watcher_exit() {
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(
+            vec![(7903, Some(20902))],
+            vec![TakerBehavior::Normal],
+            vec![MakerBehavior::Normal],
+        );
+    let bitcoind = &test_framework.bitcoind;
+    let taker = &mut takers[0];
+
+    fund_taker(
+        taker,
+        bitcoind,
+        2,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        2,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+
+    let summary = taker
+        .prepare_coinswap(
+            SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
+                .with_tx_count(1)
+                .with_required_confirms(1),
+        )
+        .unwrap();
+    taker.behavior = TakerBehavior::StopWatcherBeforeSwap;
+    let error = taker.start_coinswap(&summary.swap_id).unwrap_err();
+    assert!(format!("{error:?}").contains("watchtower is down"));
+    assert_eq!(
+        taker
+            .get_wallet()
+            .read()
+            .unwrap()
+            .get_outgoing_swapcoins_count(),
+        0
+    );
+
+    drop(takers);
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+#[test]
+fn funded_maker_restarts_recovery_only_without_watcher() {
+    super::taproot_reboot_recovery::run_reboot_recovery_without_watcher::<BitcoindBackend>();
+}
+
+#[test]
+fn funded_legacy_maker_reaches_timelock_recovery_without_watcher() {
+    super::skip_funding_recovery::run_legacy_timelock_recovery_without_watcher();
 }

--- a/tests/integration/watchtower_liveness.rs
+++ b/tests/integration/watchtower_liveness.rs
@@ -12,6 +12,33 @@ use std::{sync::atomic::Ordering::Relaxed, thread};
 use super::test_framework::*;
 
 #[test]
+fn maker_server_does_not_start_when_watcher_exits() {
+    let (test_framework, _takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(
+            vec![(7901, Some(20900))],
+            Vec::new(),
+            vec![MakerBehavior::StopWatcherOnStartup],
+        );
+
+    let maker = makers[0].clone();
+    let error =
+        start_server(maker.clone()).expect_err("maker server started without a live watcher");
+    assert!(
+        format!("{error:?}").contains("watchtower is down, refusing to start maker server"),
+        "unexpected startup error: {:?}",
+        error
+    );
+    assert!(!maker.watch_service.is_alive());
+    assert!(!maker.is_setup_complete.load(Relaxed));
+
+    maker.watch_service.shutdown();
+    drop(maker);
+    drop(makers);
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+#[test]
 fn maker_rejects_new_swaps_after_watcher_exit() {
     let (test_framework, mut takers, makers, block_generation_handle) =
         TestFramework::init::<BitcoindBackend>(

--- a/tests/integration/watchtower_liveness.rs
+++ b/tests/integration/watchtower_liveness.rs
@@ -1,0 +1,79 @@
+//! Maker admission must fail closed after its watcher thread exits.
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{error::TakerError, SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+use super::test_framework::*;
+
+#[test]
+fn maker_rejects_new_swaps_after_watcher_exit() {
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(
+            vec![(7902, Some(20901))],
+            vec![TakerBehavior::Normal],
+            vec![MakerBehavior::Normal],
+        );
+    let bitcoind = &test_framework.bitcoind;
+
+    let taker = &mut takers[0];
+    fund_taker(
+        taker,
+        bitcoind,
+        2,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+    fund_makers(
+        &makers,
+        bitcoind,
+        2,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+
+    let maker = &makers[0];
+    assert!(maker.watch_service.is_alive());
+    maker.watch_service.stop_watcher_for_test();
+    assert!(!maker.watch_service.is_alive());
+
+    for protocol in [ProtocolVersion::Legacy, ProtocolVersion::Taproot] {
+        let result = taker.prepare_coinswap(
+            SwapParams::new(protocol, Amount::from_sat(500_000), 1)
+                .with_tx_count(1)
+                .with_required_confirms(1),
+        );
+        match result {
+            Err(TakerError::General(message)) => assert!(
+                message.contains("Maker 0 rejected swap"),
+                "unexpected admission error: {}",
+                message
+            ),
+            other => panic!("unexpected admission result: {:?}", other),
+        }
+    }
+
+    drop(takers);
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}


### PR DESCRIPTION

## Summary
- Added explicit watchtower liveness tracking that is cleared on clean exit, error, panic, or channel disconnection.
- Centralized watcher thread spawning so its complete lifecycle is observed and logged.
- Added a startup readiness barrier so makers do not begin serving swaps unless the watcher is operational.
- Reject new swaps when the maker’s watchtower is unavailable.
- Recheck watchtower liveness immediately before broadcasting funds for both Legacy and Taproot swaps.
- Preserve in-flight swap recovery by continuing down the timelock path when hashlock observation is no longer available.
- Added integration coverage proving new swaps are rejected and funded swaps still reach timelock recovery after watcher exit.

## Related Issue
Fixes #953 

## Testing
`cargo test --test integration watchtower_liveness --features integration-test -- --nocapture`

## Checklist
- [x] Tests were added or updated where needed
- [x] Formatting and lints pass
- [x] Documentation was updated where needed
- [x] Security or protocol impact is explained above, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added watchtower liveness monitoring and safer handling when monitoring stops.
  * Swaps now reject funding attempts when monitoring is unavailable.
  * Recovery can continue without an active watchtower, including direct blockchain checks.
  * Added fallback breach detection for taker swaps.

* **Bug Fixes**
  * Startup recovery no longer fails solely because watch reconstruction encounters an error.
  * Improved swap cleanup and recovery after watcher interruptions.

* **Tests**
  * Added integration coverage for watcher failures, recovery-only operation, and resumed swap safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->