### PR TITLE
Rebrand project from Coinswap to OpenSwap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug or unexpected behavior in CoinSwap
+about: Report a bug or unexpected behavior in OpenSwap
 title: "bug: "
 labels: ["bug"]
 assignees: ""
@@ -18,4 +18,4 @@ assignees: ""
 <!-- What should have happened? -->
 
 ## Environment and Logs
-<!-- Include the CoinSwap version, OS, setup, network, role, protocol version, and relevant logs. -->
+<!-- Include the OpenSwap version, OS, setup, network, role, protocol version, and relevant logs. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/citadel-tech/coinswap/security/advisories/new
+    url: https://github.com/citadel-foss/openswap/security/advisories/new
     about: >
       Do NOT open a public issue for security vulnerabilities.
       Report them privately via GitHub Security Advisories.
@@ -11,7 +11,7 @@ contact_links:
         - Logs and versions (`git rev-parse --short HEAD`, `rustc --version`, `bitcoind --version`, `tor --version`)
       We aim to follow responsible disclosure. Please give maintainers time to investigate and ship a fix before public disclosure.
   - name: Protocol Discussion
-    url: https://github.com/citadel-tech/coinswap/discussions
+    url: https://github.com/citadel-foss/openswap/discussions
     about: >
       For protocol design questions, RFCs, or open-ended ideas,
       start a GitHub Discussion instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest a new feature or improvement for CoinSwap
+about: Suggest a new feature or improvement for OpenSwap
 title: "feat: "
 labels: ["enhancement"]
 assignees: ""

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/coinswap
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/openswap
           tags: |
             # Tag for master branch
             type=ref,event=branch

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,10 +17,10 @@ jobs:
       run: ./docker-setup build
 
     - name: Test makerd
-      run: docker run --rm coinswap/coinswap:latest makerd --help
+      run: docker run --rm openswap/openswap:latest makerd --help
 
     - name: Test taker
-      run: docker run --rm coinswap/coinswap:latest taker --help
+      run: docker run --rm openswap/openswap:latest taker --help
 
     - name: Wait for services to be healthy
       run: |
@@ -30,5 +30,5 @@ jobs:
     - name: Check service status
       run: ./docker-setup status
 
-    - name: Stop Coinswap stack
+    - name: Stop OpenSwap stack
       run: ./docker-setup stop

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,10 +17,12 @@ jobs:
       run: ./docker-setup build
 
     - name: Test makerd
-      run: docker run --rm openswap/openswap:latest makerd --help
+      # TODO(rebrand): switch to openswap/openswap once the image is published
+      # on Docker Hub; until then pull the last published coinswap image.
+      run: docker run --rm coinswap/coinswap:latest makerd --help
 
     - name: Test taker
-      run: docker run --rm openswap/openswap:latest taker --help
+      run: docker run --rm coinswap/coinswap:latest taker --help
 
     - name: Wait for services to be healthy
       run: |

--- a/.github/workflows/notify-openswap-downstream.yml
+++ b/.github/workflows/notify-openswap-downstream.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: coinswap-downstream-compatibility-dispatch
+  group: openswap-downstream-compatibility-dispatch
   cancel-in-progress: true
 
 permissions: {}
@@ -23,15 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - downstream: coinswap-ffi
-            repository: citadel-tech/coinswap-ffi
-            secret_name: COINSWAP_FFI_DISPATCH_TOKEN
+          - downstream: openswap-ffi
+            repository: citadel-foss/openswap-ffi
+            secret_name: OPENSWAP_FFI_DISPATCH_TOKEN
           - downstream: maker-dashboard
-            repository: citadel-tech/maker-dashboard
-            secret_name: COINSWAP_MAKER_DASHBOARD_DISPATCH_TOKEN
+            repository: citadel-foss/maker-dashboard
+            secret_name: OPENSWAP_MAKER_DASHBOARD_DISPATCH_TOKEN
           - downstream: taker-app
-            repository: citadel-tech/taker-app
-            secret_name: COINSWAP_TAKER_APP_DISPATCH_TOKEN
+            repository: citadel-foss/taker-app
+            secret_name: OPENSWAP_TAKER_APP_DISPATCH_TOKEN
     steps:
       - name: Dispatch compatibility check
         env:
@@ -39,10 +39,10 @@ jobs:
           DOWNSTREAM_NAME: ${{ matrix.downstream }}
           DOWNSTREAM_REPOSITORY: ${{ matrix.repository }}
           DISPATCH_SECRET_NAME: ${{ matrix.secret_name }}
-          COINSWAP_SHA: ${{ github.sha }}
-          COINSWAP_REF: ${{ github.ref }}
-          COINSWAP_REPOSITORY: ${{ github.repository }}
-          COINSWAP_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          OPENSWAP_SHA: ${{ github.sha }}
+          OPENSWAP_REF: ${{ github.ref }}
+          OPENSWAP_REPOSITORY: ${{ github.repository }}
+          OPENSWAP_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         shell: bash
         run: |
@@ -55,19 +55,19 @@ jobs:
 
           payload_file="${RUNNER_TEMP}/${DOWNSTREAM_NAME}-dispatch.json"
           jq -n \
-            --arg event_type "coinswap-updated" \
-            --arg coinswap_sha "${COINSWAP_SHA}" \
-            --arg coinswap_ref "${COINSWAP_REF}" \
-            --arg coinswap_repository "${COINSWAP_REPOSITORY}" \
-            --arg coinswap_commit_url "${COINSWAP_COMMIT_URL}" \
+            --arg event_type "openswap-updated" \
+            --arg openswap_sha "${OPENSWAP_SHA}" \
+            --arg openswap_ref "${OPENSWAP_REF}" \
+            --arg openswap_repository "${OPENSWAP_REPOSITORY}" \
+            --arg openswap_commit_url "${OPENSWAP_COMMIT_URL}" \
             --arg triggering_actor "${TRIGGERING_ACTOR}" \
             '{
               event_type: $event_type,
               client_payload: {
-                coinswap_sha: $coinswap_sha,
-                coinswap_ref: $coinswap_ref,
-                coinswap_repository: $coinswap_repository,
-                coinswap_commit_url: $coinswap_commit_url,
+                openswap_sha: $openswap_sha,
+                openswap_ref: $openswap_ref,
+                openswap_repository: $openswap_repository,
+                openswap_commit_url: $openswap_commit_url,
                 triggering_actor: $triggering_actor
               }
             }' > "${payload_file}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,7 +138,7 @@ jobs:
           sudo systemctl stop tor@default.service tor.service || true
           mkdir -p /tmp/tor-it
           # Empty control password: `check_tor_status` sends AUTHENTICATE "" and
-          # the test helpers default COINSWAP_TOR_PASSWORD to empty.
+          # the test helpers default OPENSWAP_TOR_PASSWORD to empty.
           HASH="$(tor --hash-password '' | tail -n 1)"
           cat <<EOF > /tmp/tor-it/torrc
           SocksPort 9050
@@ -166,7 +166,7 @@ jobs:
       # `timeout-minutes` already bounds the run.
       - name: Run ${{ matrix.test }}
         env:
-          COINSWAP_TOR_IT: "1"
+          OPENSWAP_TOR_IT: "1"
         run: |
           cargo nextest run --features integration-test \
             --run-ignored=only --test-threads=1 --retries 2 \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
-# Contributing to CoinSwap
+# Contributing to OpenSwap
 
-Thank you for your interest in contributing to **CoinSwap**!
+Thank you for your interest in contributing to **OpenSwap**!
 
-We are building functioning, minimal-viable binaries and libraries for the trustless, peer-to-peer [Maxwell-Belcher CoinSwap protocol](https://github.com/citadel-tech/Coinswap-Protocol-Specification) on Bitcoin. This is **experimental security-critical software** — every change can affect atomicity, privacy (Tor), sybil resistance (fidelity bonds), or real BTC. Because of this, we maintain **very high standards** for code quality, testing, and human understanding.
+We are building functioning, minimal-viable binaries and libraries for the trustless, peer-to-peer [Maxwell-Belcher Atomic Swap protocol](https://github.com/citadel-foss/OpenSwap-Protocol-Specification) on Bitcoin. This is **experimental security-critical software** — every change can affect atomicity, privacy (Tor), sybil resistance (fidelity bonds), or real BTC. Because of this, we maintain **very high standards** for code quality, testing, and human understanding.
 
 We welcome contributions from everyone, but we expect contributors to understand the critical nature of this codebase.
-To understand the codebase, please refer to the [Deep Wiki](https://deepwiki.com/citadel-tech/coinswap).
+To understand the codebase, please refer to the [Deep Wiki](https://deepwiki.com/citadel-foss/openswap).
 
 ## Code of Conduct
 
 This project follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating, you agree to abide by it.
 
 ## Table of Contents
-- [Contributing to CoinSwap](#contributing-to-coinswap)
+- [Contributing to OpenSwap](#contributing-to-openswap)
   - [Code of Conduct](#code-of-conduct)
   - [Table of Contents](#table-of-contents)
   - [How Can I Contribute?](#how-can-i-contribute)
@@ -39,8 +39,8 @@ This project follows the [Contributor Covenant Code of Conduct](https://www.cont
 - Include steps to reproduce, regtest logs, environment (Docker vs native), and expected vs actual behavior.
 
 ### Suggesting Features or Protocol Changes
-- Use the [Feature Request issue template](.github/ISSUE_TEMPLATE/feature_request.md) or open a [discussion](https://github.com/citadel-tech/coinswap/discussions).
-- For protocol-level ideas, please reference the [CoinSwap protocol specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification) where possible.
+- Use the [Feature Request issue template](.github/ISSUE_TEMPLATE/feature_request.md) or open a [discussion](https://github.com/citadel-foss/openswap/discussions).
+- For protocol-level ideas, please reference the [OpenSwap protocol specification](https://github.com/citadel-foss/OpenSwap-Protocol-Specification) where possible.
 
 ### Code & Documentation Contributions
 See the Pull Request section below.
@@ -55,8 +55,8 @@ See the Pull Request section below.
 
 ### Recommended: One-Click Docker Stack
 ```bash
-git clone https://github.com/citadel-tech/coinswap.git
-cd coinswap
+git clone https://github.com/citadel-foss/openswap.git
+cd openswap
 ./docker-setup configure
 ./docker-setup start
 ```
@@ -64,8 +64,8 @@ See [`docs/docker.md`](docs/docker.md) for full details.
 
 ### Native Setup
 ```bash
-git clone https://github.com/citadel-tech/coinswap.git
-cd coinswap
+git clone https://github.com/citadel-foss/openswap.git
+cd openswap
 cargo build --release
 # Install binaries (optional)
 sudo install ./target/release/{taker,makerd,maker-cli} /usr/local/bin/
@@ -154,7 +154,7 @@ We strongly prefer thoughtful, human-driven contributions — even if fewer in n
 Security is the top priority.
 
 - **Never** report security issues in public issues or PRs.
-- Report privately via the [GitHub Security Advisory](https://github.com/citadel-tech/coinswap/security/advisories/new) feature. Alternatively, reach core maintainers directly via a private message in the [Matrix server](https://matrix.to/#/#citadel-foss:matrix.org).
+- Report privately via the [GitHub Security Advisory](https://github.com/citadel-foss/openswap/security/advisories/new) feature. Alternatively, reach core maintainers directly via a private message in the [Matrix server](https://matrix.to/#/#citadel-foss:matrix.org).
 - We follow responsible disclosure.
 
 Any change touching protocol logic, cryptography, or fund handling **must** preserve trustlessness and atomic guarantees.
@@ -162,11 +162,11 @@ Any change touching protocol logic, cryptography, or fund handling **must** pres
 ## Community & Getting Help
 
 - **Matrix**: [Citadel Matrix](https://matrix.to/#/#citadel-foss:matrix.org) (fastest for questions)
-- [GitHub Issues](https://github.com/citadel-tech/coinswap/issues) & [Discussions](https://github.com/citadel-tech/coinswap/discussions)
-- Look for [`good first issue`](https://github.com/citadel-tech/coinswap/labels/good%20first%20issue) or [`help wanted`](https://github.com/citadel-tech/coinswap/labels/help%20wanted) labels
+- [GitHub Issues](https://github.com/citadel-foss/openswap/issues) & [Discussions](https://github.com/citadel-foss/openswap/discussions)
+- Look for [`good first issue`](https://github.com/citadel-foss/openswap/labels/good%20first%20issue) or [`help wanted`](https://github.com/citadel-foss/openswap/labels/help%20wanted) labels
 
 ---
 
-**Thank you** for helping make CoinSwap more robust, private, and secure! 🧡
+**Thank you** for helping make OpenSwap more robust, private, and secure! 🧡
 
 Happy swapping.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "coinswap"
+name = "openswap"
 version = "0.2.2"
-authors = ["Developers at Citadel-Tech"]
+authors = ["Developers at Citadel FOSS"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-description = "Functioning, minimal-viable binaries and libraries to perform a trustless, p2p Maxwell-Belcher Coinswap Protocol"
+description = "Functioning, minimal-viable binaries and libraries to perform a trustless, p2p Maxwell-Belcher OpenSwap Protocol"
 license = "MIT OR Apache-2.0"          
-documentation = "https://docs.rs/coinswap"
-homepage = "https://github.com/citadel-tech/coinswap" 
-repository = "https://github.com/citadel-tech/coinswap" 
+documentation = "https://docs.rs/openswap"
+homepage = "https://github.com/citadel-foss/openswap" 
+repository = "https://github.com/citadel-foss/openswap" 
 categories = ["Bitcoin", "Atomic Swap", "HTLC"]   
-keywords = ["bitcoin", "HTLC", "coinswap"]  
+keywords = ["bitcoin", "HTLC", "openswap"]  
 
 [dependencies]
 bip39 =  { version = "2.1.0", features = ["rand"] }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-# Coinswap
-Functioning, minimal-viable binaries and libraries to perform a trustless, p2p [Maxwell-Belcher Coinswap Protocol](https://gist.github.com/chris-belcher/9144bd57a91c194e332fb5ca371d0964).
+# OpenSwap
+Functioning, minimal-viable binaries and libraries to perform a trustless, p2p [Maxwell-Belcher OpenSwap Protocol](https://gist.github.com/chris-belcher/9144bd57a91c194e332fb5ca371d0964).
 
-[![MIT or Apache-2.0 Licensed](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/citadel-tech/coinswap/blob/master/LICENSE)
-[![Build Status](https://github.com/citadel-tech/coinswap/actions/workflows/build.yaml/badge.svg)](https://github.com/citadel-tech/coinswap/actions/workflows/build.yaml)
-[![Lint Status](https://github.com/citadel-tech/coinswap/actions/workflows/lint.yaml/badge.svg)](https://github.com/citadel-tech/coinswap/actions/workflows/lint.yaml)
-[![Test Status](https://github.com/citadel-tech/coinswap/actions/workflows/test.yaml/badge.svg)](https://github.com/citadel-tech/coinswap/actions/workflows/test.yaml)
-[![Coverage](https://codecov.io/github/citadel-tech/coinswap/coverage.svg?branch=master)](https://codecov.io/github/citadel-tech/coinswap?branch=master)
+[![MIT or Apache-2.0 Licensed](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/citadel-foss/openswap/blob/master/LICENSE)
+[![Build Status](https://github.com/citadel-foss/openswap/actions/workflows/build.yaml/badge.svg)](https://github.com/citadel-foss/openswap/actions/workflows/build.yaml)
+[![Lint Status](https://github.com/citadel-foss/openswap/actions/workflows/lint.yaml/badge.svg)](https://github.com/citadel-foss/openswap/actions/workflows/lint.yaml)
+[![Test Status](https://github.com/citadel-foss/openswap/actions/workflows/test.yaml/badge.svg)](https://github.com/citadel-foss/openswap/actions/workflows/test.yaml)
+[![Coverage](https://codecov.io/github/citadel-foss/openswap/coverage.svg?branch=master)](https://codecov.io/github/citadel-foss/openswap?branch=master)
 [![Rustc Version 1.75.0+](https://img.shields.io/badge/rustc-1.75.0%2B-lightgrey.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
 
-[![Latest Release](https://img.shields.io/github/v/release/citadel-tech/coinswap?label=latest%20release&color=orange)](https://github.com/citadel-tech/coinswap/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/citadel-foss/openswap?label=latest%20release&color=orange)](https://github.com/citadel-foss/openswap/releases/latest)
 [![Website](https://img.shields.io/badge/website-citadelfoss.xyz-blue)](https://citadelfoss.xyz/)
 
 </div>
@@ -20,7 +20,7 @@ This project is under active development. Mainnet use is **NOT recommended.**
 
 # About
 
-Coinswap is a trustless, self-custodial [atomic swap](https://bitcoinops.org/en/topics/coinswap/) protocol built on Bitcoin. Unlike existing solutions that rely on centralized servers as [single points of failure](https://en.wikipedia.org/wiki/Single_point_of_failure), Coinswap's marketplace is seeded in the Bitcoin blockchain itself — no central host required, anyone with a Bitcoin node can participate. 
+OpenSwap is a trustless, self-custodial [atomic swap](https://bitcoinops.org/en/topics/openswap/) protocol built on Bitcoin. Unlike existing solutions that rely on centralized servers as [single points of failure](https://en.wikipedia.org/wiki/Single_point_of_failure), OpenSwap's marketplace is seeded in the Bitcoin blockchain itself — no central host required, anyone with a Bitcoin node can participate. 
 
 For a quicker dive into the idea, see the [**Website**](https://citadelfoss.xyz/).
 
@@ -36,9 +36,9 @@ For a quicker dive into the idea, see the [**Website**](https://citadelfoss.xyz/
 
 The project extends Chris Belcher's [teleport-transactions](https://github.com/bitcoin-teleport/teleport-transactions) proof-of-concept into a production-grade implementation with full protocol handling, functional testing, sybil resistance, CLI tools, and a GUI app. The same protocol can be extended for cross-chain swaps.
 
-For protocol-level details, see the [Coinswap Protocol Specifications](https://github.com/citadel-tech/Coinswap-Protocol-Specification).
+For protocol-level details, see the [OpenSwap Protocol Specifications](https://github.com/citadel-foss/OpenSwap-Protocol-Specification).
 
-For an in-depth exploration of the repository, it's recommended to use [Deep Wiki](https://deepwiki.com/citadel-tech/coinswap).
+For an in-depth exploration of the repository, it's recommended to use [Deep Wiki](https://deepwiki.com/citadel-foss/openswap).
 
 # Executables
 
@@ -49,21 +49,21 @@ This crate compiles into the following CLI binaries. Useful for integration test
 
 **[maker-cli](./docs/maker-cli.md)**: CLI controller for the `makerd`. Manage server, access wallet, view swap statistics, and more. [Demo](./docs/maker-cli.md)
 
-**[taker](./docs/taker.md)**: A command-line Coinswap client app to perform swaps, discover market, etc. [Demo](./docs/taker.md)
+**[taker](./docs/taker.md)**: A command-line OpenSwap client app to perform swaps, discover market, etc. [Demo](./docs/taker.md)
 
 ## GUI Apps
-GUI apps are built using the core library rust APIs ([taker api](https://github.com/citadel-tech/coinswap/blob/master/src/taker/api.rs), [maker api](https://github.com/citadel-tech/coinswap/blob/master/src/maker/api.rs)) and [FFIs](https://github.com/citadel-tech/coinswap-ffi) built on top of it to support other languages. Suitable for power users and UI/UX stress testing. 
+GUI apps are built using the core library rust APIs ([taker api](https://github.com/citadel-foss/openswap/blob/master/src/taker/api.rs), [maker api](https://github.com/citadel-foss/openswap/blob/master/src/maker/api.rs)) and [FFIs](https://github.com/citadel-foss/openswap-ffi) built on top of it to support other languages. Suitable for power users and UI/UX stress testing. 
 
-The apps provide the full suite of Coinswap operations at "near production" quality. They can be locally compiled from their respective repos, or download precompiled binaries from their release pages.  
+The apps provide the full suite of OpenSwap operations at "near production" quality. They can be locally compiled from their respective repos, or download precompiled binaries from their release pages.  
 
-**[taker-app](https://github.com/citadel-tech/taker-app)**: A Desktop Coinswap client, built with the JS FFIs, to manage the all operations of coinswap wallet, discover and manage marketplace, and much more.
+**[taker-app](https://github.com/citadel-foss/taker-app)**: A Desktop OpenSwap client, built with the JS FFIs, to manage the all operations of openswap wallet, discover and manage marketplace, and much more.
 
-**[maker-dashboard](https://github.com/citadel-tech/maker-dashboard)**: A Webapp for maker management dashboard, built in rust, designed for headless servers or desktops. Create and manage multiple makers, connect with the market, earn swap fees and much more, with a nice and useful UI.
+**[maker-dashboard](https://github.com/citadel-foss/maker-dashboard)**: A Webapp for maker management dashboard, built in rust, designed for headless servers or desktops. Create and manage multiple makers, connect with the market, earn swap fees and much more, with a nice and useful UI.
 
 Check the [demo doc](./docs/demo.md) for quick setup guides.
 
 > [!NOTE]
-> These apps should be considered as "examples", rather than products. We encourage all Bitcoin wallet developers to take a look at our [examples](https://github.com/citadel-tech/coinswap/tree/master/examples), [ffis](), and [apis](https://github.com/citadel-tech/coinswap/blob/master/src/taker/api.rs), to build their own apps, or integrate Coinswap within their existing apps. App ecosystem diversity is crucial for decentralization.
+> These apps should be considered as "examples", rather than products. We encourage all Bitcoin wallet developers to take a look at our [examples](https://github.com/citadel-foss/openswap/tree/master/examples), [ffis](), and [apis](https://github.com/citadel-foss/openswap/blob/master/src/taker/api.rs), to build their own apps, or integrate OpenSwap within their existing apps. App ecosystem diversity is crucial for decentralization.
 
 # Development
 
@@ -79,8 +79,8 @@ The [Test Framework](./tests/integration/test_framework/mod.rs) spawns toy marke
 
 ## Contributing
 
-- Browse [issues](https://github.com/citadel-tech/coinswap/issues), especially [`good first issue`](https://github.com/citadel-tech/coinswap/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-- Review [open PRs](https://github.com/citadel-tech/coinswap/pulls)
+- Browse [issues](https://github.com/citadel-foss/openswap/issues), especially [`good first issue`](https://github.com/citadel-foss/openswap/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+- Review [open PRs](https://github.com/citadel-foss/openswap/pulls)
 - Search for `TODO`s in the codebase
 - Read the [docs](./docs)
 - Read the [Contributing Guide](./CONTRIBUTING.md) — including the AI contributions policy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   bitcoind:
-    image: coinswap/${BITCOIN_IMAGE_NAME:-bitcoin-mutinynet}:${BITCOIN_TAG:-latest}
-    container_name: coinswap-bitcoind
+    image: openswap/${BITCOIN_IMAGE_NAME:-bitcoin-mutinynet}:${BITCOIN_TAG:-latest}
+    container_name: openswap-bitcoind
     profiles: ["internal-bitcoind"]
     command: >
       bitcoind 
@@ -23,7 +23,7 @@ services:
 
   tor:
     image: osminogin/tor-simple
-    container_name: coinswap-tor
+    container_name: openswap-tor
     profiles: ["internal-tor"]
     network_mode: "host"
     entrypoint: /bin/sh
@@ -57,8 +57,8 @@ services:
     restart: unless-stopped
 
   makerd:
-    image: coinswap/${IMAGE_NAME:-coinswap}:latest
-    container_name: coinswap-makerd
+    image: openswap/${IMAGE_NAME:-openswap}:latest
+    container_name: openswap-makerd
     profiles: ["external-tor"]
     network_mode: "host"
     command: &makerd-command
@@ -66,9 +66,9 @@ services:
       - -c
       - |
         sleep 15
-        mkdir -p /home/coinswap/.coinswap/maker
+        mkdir -p /home/openswap/.openswap/maker
         
-        cat > /home/coinswap/.coinswap/maker/config.toml << EOM
+        cat > /home/openswap/.openswap/maker/config.toml << EOM
         network_port = $${MAKER_NETWORK_PORT:-6102}
         rpc_port = $${MAKER_RPC_PORT:-6103}
         socks_port = $${TOR_SOCKS_PORT:-9050}
@@ -83,7 +83,7 @@ services:
         time_relative_fee_pct = $${TIME_RELATIVE_FEE_PCT:-0.0001}
         EOM
         
-        WALLET_NAME="$${BITCOIN_WALLET_NAME:-coinswap-maker}"
+        WALLET_NAME="$${BITCOIN_WALLET_NAME:-openswap-maker}"
         echo "INFO: Using wallet: $$WALLET_NAME"
 
         echo "[DEBUG] Running: makerd -t \"$${TOR_AUTH_PASSWORD}\" -r $${BITCOIN_RPC_HOST} -a $${BITCOIN_RPC_AUTH} $${MAKERD_EXTRA_ARGS} -w \"$$WALLET_NAME\""
@@ -92,7 +92,7 @@ services:
     ports:
       - "${MAKERD_RPC_PORT:-6103}:${MAKERD_RPC_PORT:-6103}"
     volumes:
-      - maker-data:/home/coinswap/.coinswap
+      - maker-data:/home/openswap/.openswap
     environment: &makerd-env
       - RUST_LOG=${RUST_LOG:-info}
       - MAKER_NETWORK_PORT=${MAKERD_PORT:-6102}
@@ -109,17 +109,17 @@ services:
       - BITCOIN_RPC_HOST=${BITCOIN_RPC_HOST}
       - BITCOIN_RPC_AUTH=${BITCOIN_RPC_AUTH:-user:password}
       - MAKERD_EXTRA_ARGS=${MAKERD_EXTRA_ARGS}
-      - BITCOIN_WALLET_NAME=${BITCOIN_WALLET_NAME:-coinswap-maker}
+      - BITCOIN_WALLET_NAME=${BITCOIN_WALLET_NAME:-openswap-maker}
     restart: unless-stopped
 
   makerd-internal:
-    image: coinswap/${IMAGE_NAME:-coinswap}:latest
-    container_name: coinswap-makerd
+    image: openswap/${IMAGE_NAME:-openswap}:latest
+    container_name: openswap-makerd
     profiles: ["internal-tor"]
     network_mode: "host"
     command: *makerd-command
     volumes:
-      - maker-data:/home/coinswap/.coinswap
+      - maker-data:/home/openswap/.openswap
     environment: *makerd-env
     restart: unless-stopped
     depends_on:
@@ -135,4 +135,4 @@ volumes:
 
 networks:
   default:
-    name: coinswap-network
+    name: openswap-network

--- a/docker-setup
+++ b/docker-setup
@@ -3,12 +3,12 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE_NAME="coinswap"
+IMAGE_NAME="openswap"
 BITCOIN_IMAGE_NAME="bitcoin-mutinynet"
 CONFIG_FILE="$SCRIPT_DIR/.docker-config"
 VERSION_FILE="$SCRIPT_DIR/docker/bitcoin-mutinynet.version"
 
-DEFAULT_BITCOIN_DATADIR="/home/coinswap/.bitcoin"
+DEFAULT_BITCOIN_DATADIR="/home/openswap/.bitcoin"
 DEFAULT_BITCOIN_NETWORK="signet"
 DEFAULT_BITCOIN_RPC_PORT="38332"
 DEFAULT_BITCOIN_ZMQ_PORT="28332"
@@ -50,7 +50,7 @@ load_config() {
 
 save_config() {
     cat > "$CONFIG_FILE" << EOF
-# Coinswap Docker Configuration
+# OpenSwap Docker Configuration
 BITCOIN_DATADIR="$BITCOIN_DATADIR"
 BITCOIN_NETWORK="$BITCOIN_NETWORK"
 BITCOIN_RPC_PORT="$BITCOIN_RPC_PORT"
@@ -117,7 +117,7 @@ setup_env() {
     TOR_AUTH_PASSWORD="${TOR_AUTH_PASSWORD:-$DEFAULT_TOR_AUTH}"
     USE_EXTERNAL_BITCOIND="${USE_EXTERNAL_BITCOIND:-false}"
     USE_EXTERNAL_TOR="${USE_EXTERNAL_TOR:-false}"
-    BITCOIN_WALLET_NAME="${BITCOIN_WALLET_NAME:-coinswap-maker}"
+    BITCOIN_WALLET_NAME="${BITCOIN_WALLET_NAME:-openswap-maker}"
     
     # export variables for docker-compose
     export IMAGE_NAME="${IMAGE_NAME}"
@@ -258,7 +258,7 @@ select_bitcoin_wallet() {
 
 configure_setup() {
     echo ""
-    print_info "Coinswap Docker Configuration"
+    print_info "OpenSwap Docker Configuration"
     echo "============================================"
     echo ""
     
@@ -349,8 +349,8 @@ configure_setup() {
         
         echo ""
         print_info "Wallet will be configured after bitcoind syncs."
-        read -p "Enter wallet name to create [coinswap-maker]: " wallet_name
-        BITCOIN_WALLET_NAME="${wallet_name:-coinswap-maker}"
+        read -p "Enter wallet name to create [openswap-maker]: " wallet_name
+        BITCOIN_WALLET_NAME="${wallet_name:-openswap-maker}"
     fi
     
     echo ""
@@ -423,7 +423,7 @@ configure_setup() {
     fi
     
     echo ""
-    print_info "Coinswap Maker Ports"
+    print_info "OpenSwap Maker Ports"
     echo "----------------------------------------"
     
     read -p "Makerd RPC port [${DEFAULT_MAKERD_RPC_PORT}]: " makerd_rpc
@@ -498,13 +498,13 @@ check_docker() {
 
 # Build the Docker image
 build_image() {
-    print_info "Building Coinswap Docker image..."
+    print_info "Building OpenSwap Docker image..."
     cd "$SCRIPT_DIR"
     
     if docker build -f docker/Dockerfile -t "${IMAGE_NAME}:latest" .; then
-        print_success "Coinswap image built successfully"
+        print_success "OpenSwap image built successfully"
     else
-        print_error "Failed to build Coinswap image"
+        print_error "Failed to build OpenSwap image"
         exit 1
     fi
 }
@@ -571,7 +571,7 @@ start_stack() {
     
     setup_env
     
-    print_info "Starting Coinswap stack with docker-compose..."
+    print_info "Starting OpenSwap stack with docker-compose..."
     print_info "Active Profiles: $COMPOSE_PROFILES"
     cd "$SCRIPT_DIR"
     
@@ -585,7 +585,7 @@ start_stack() {
         fi
         
         if [ $? -ne 0 ]; then
-            print_error "Failed to start Coinswap stack"
+            print_error "Failed to start OpenSwap stack"
             exit 1
         fi
         
@@ -601,20 +601,20 @@ start_stack() {
         if docker compose up -d; then
             start_makerd
         else
-            print_error "Failed to start Coinswap stack"
+            print_error "Failed to start OpenSwap stack"
             exit 1
         fi
     fi
 }
 
 stop_stack() {
-    print_info "Stopping Coinswap stack..."
+    print_info "Stopping OpenSwap stack..."
     cd "$SCRIPT_DIR"
     setup_env
     
     docker compose down
     
-    print_success "Coinswap stack stopped"
+    print_success "OpenSwap stack stopped"
 }
 
 show_logs() {
@@ -723,23 +723,23 @@ run_command() {
     local cmd="$1"
     shift
     setup_env
-    docker run --rm -it --network coinswap-network "${IMAGE_NAME}:latest" "$cmd" "$@"
+    docker run --rm -it --network openswap-network "${IMAGE_NAME}:latest" "$cmd" "$@"
 }
 
 show_help() {
-    echo "Coinswap Docker Setup Script"
+    echo "OpenSwap Docker Setup Script"
     echo ""
     echo "Usage: $0 [COMMAND]"
     echo ""
     echo "Commands:"
-    echo "  configure        Configure Coinswap Docker setup"
+    echo "  configure        Configure OpenSwap Docker setup"
     echo "  build            Build the Docker image"
     echo "  build-bitcoin    Build the Bitcoin Mutinynet Docker image"
-    echo "  start [options]  Start the full Coinswap stack"
+    echo "  start [options]  Start the full OpenSwap stack"
     echo "                   Options:"
     echo "                     -d, --default   Use default configuration without prompting"
-    echo "  stop             Stop the Coinswap stack"
-    echo "  restart          Restart the Coinswap stack"
+    echo "  stop             Stop the OpenSwap stack"
+    echo "  restart          Restart the OpenSwap stack"
     echo "  logs [service]   Show logs (optionally for specific service)"
     echo "                   Services: bitcoind, tor, makerd"
     echo "  status           Show status of running services"
@@ -793,7 +793,7 @@ case "${1:-}" in
     ;;
     "shell")
         setup_env
-        docker run --rm -it --network coinswap-network "coinswap/${IMAGE_NAME}:latest" /bin/sh
+        docker run --rm -it --network openswap-network "openswap/${IMAGE_NAME}:latest" /bin/sh
     ;;
     "makerd"|"maker-cli"|"taker"|"bitcoin-cli")
         run_command "$@"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Coinswap Dockerfile
+# OpenSwap Dockerfile
 # Contains makerd, maker-cli, and taker
 
 ## --- Builder Stage ---
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
     libgcc \
     musl-dev
 
-WORKDIR /usr/src/coinswap
+WORKDIR /usr/src/openswap
 COPY . .
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
@@ -46,26 +46,26 @@ RUN --mount=type=cache,target=/var/cache/apk \
     libgcc \
     musl-dev
 
-RUN adduser -D -u 1001 coinswap
+RUN adduser -D -u 1001 openswap
 
-RUN mkdir -p /app/bin /home/coinswap/.coinswap && \
-    chown -R coinswap:coinswap /app /home/coinswap
+RUN mkdir -p /app/bin /home/openswap/.openswap && \
+    chown -R openswap:openswap /app /home/openswap
 
-COPY --from=builder --chown=coinswap:coinswap /usr/src/coinswap/target/release/makerd /app/bin/
-COPY --from=builder --chown=coinswap:coinswap /usr/src/coinswap/target/release/maker-cli /app/bin/
-COPY --from=builder --chown=coinswap:coinswap /usr/src/coinswap/target/release/taker /app/bin/
+COPY --from=builder --chown=openswap:openswap /usr/src/openswap/target/release/makerd /app/bin/
+COPY --from=builder --chown=openswap:openswap /usr/src/openswap/target/release/maker-cli /app/bin/
+COPY --from=builder --chown=openswap:openswap /usr/src/openswap/target/release/taker /app/bin/
 
 RUN chmod +x /app/bin/*
 
-USER coinswap
+USER openswap
 WORKDIR /app
 
 ENV PATH="/app/bin:$PATH"
 
-ENV COINSWAP_DATA_DIR="/home/coinswap/.coinswap"
+ENV OPENSWAP_DATA_DIR="/home/openswap/.openswap"
 
 
 
-VOLUME ["/home/coinswap/.coinswap"]
+VOLUME ["/home/openswap/.openswap"]
 
 CMD ["makerd"]

--- a/docs/bitcoin.conf
+++ b/docs/bitcoin.conf
@@ -1,11 +1,11 @@
 [signet]
-# Custom Signet dedicated for the Coinswap Network. 
+# Custom Signet dedicated for the OpenSwap Network. 
 # This signet is maintained by Citadel FOSS Developers.
 signetchallenge=0014a3ec9c731da66d9725d54947aede5c830623f33d
 addnode=170.75.166.88:38333
 dnsseed=0
 
-# RPC Configurations for Coinswap operations
+# RPC Configurations for OpenSwap operations
 server=1
 rpcuser=user
 rpcpassword=password
@@ -23,10 +23,10 @@ txindex=1
 blockfilterindex=1
 
 [regtest]
-# Regtest network configurations for running Coinswap Taker and Maker
+# Regtest network configurations for running OpenSwap Taker and Maker
 fallbackfee=0.00001000
 
-# RPC Configurations for Coinswap operations
+# RPC Configurations for OpenSwap operations
 server=1
 rpcuser=user
 rpcpassword=password

--- a/docs/bitcoind.md
+++ b/docs/bitcoind.md
@@ -2,7 +2,7 @@
 
 In this tutorial, we will guide you through setting up [Mutinynet](https://github.com/benthecarman/bitcoin/tree/mutinynet-inq-29), which runs on the [inquisition hardfork](https://github.com/bitcoin-inquisition/bitcoin) of Bitcoin Core, to allow experimental consensus rules while maintaining compatibility with existing Bitcoin consensus rules.
 
-Coinswap doesn't need any experimental consensus. Mutinynet serves as a stable public Bitcoin Signet network to host the first movers of the coinswap marketplace.
+OpenSwap doesn't need any experimental consensus. Mutinynet serves as a stable public Bitcoin Signet network to host the first movers of the openswap marketplace.
 
 This tutorial will cover basic operations like setting up, creating wallets, getting funds, checking balances, and sending sats between two wallets using `bitcoin-cli`.
 
@@ -39,7 +39,7 @@ Copy this [`bitcoin.conf`](./bitcoin.conf) file from the docs folder into the da
 cp ./docs/bitcoin.conf ~/.bitcoin/bitcoin.conf
 ```
 
-This reference configuration contains the settings required to run `bitcoind` for Coinswap on either Mutinynet (Signet) or Regtest.
+This reference configuration contains the settings required to run `bitcoind` for OpenSwap on either Mutinynet (Signet) or Regtest.
 
 ---
 
@@ -59,7 +59,7 @@ Or, run local Regtest
 $ bitcoind -regtest 
 ```
 
-> **Note**: The Coinswap marketplace is live on Mutinynet. To access the market and perform swaps with other makers, start `bitcoind -signet`.
+> **Note**: The OpenSwap marketplace is live on Mutinynet. To access the market and perform swaps with other makers, start `bitcoind -signet`.
 
 Useful links for Mutinynet operations:
  - [Mutinynet Block Explorer](https://mutinynet.com/mining)
@@ -270,5 +270,5 @@ Alice's balance will be reduced by slightly more than 1 BTC: 1 BTC was sent to B
 
 ---
 
-We’ve set up `bitcoind`, created two wallets (`alice` and `bob`), generated blocks, and sent Bitcoin between the wallets. You are now ready to explore Bitcoin transactions and experiment with coinswap CLI apps.
+We’ve set up `bitcoind`, created two wallets (`alice` and `bob`), generated blocks, and sent Bitcoin between the wallets. You are now ready to explore Bitcoin transactions and experiment with openswap CLI apps.
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-# Coinswap All System Demo
+# OpenSwap All System Demo
 
 ### Prerequisites & Setup Guide
 
-Get your system ready to participate in the **Coinswap Live Demo** — run a maker, fire up the taker, and perform a real trustless swap on a custom signet.
+Get your system ready to participate in the **OpenSwap Live Demo** — run a maker, fire up the taker, and perform a real trustless swap on a custom signet.
 
 </div>
 
@@ -14,8 +14,8 @@ Get your system ready to participate in the **Coinswap Live Demo** — run a mak
 
 | App | Role | Repository |
 | --- | --- | --- |
-| 🗄️ **Maker Dashboard** | GUI to run and monitor your maker server | [`citadel-tech/maker-dashboard`](https://github.com/citadel-tech/maker-dashboard) |
-| 📱 **Taker App** | GUI client to fund a wallet and perform swaps | [`citadel-tech/taker-app`](https://github.com/citadel-tech/taker-app) |
+| 🗄️ **Maker Dashboard** | GUI to run and monitor your maker server | [`citadel-foss/maker-dashboard`](https://github.com/citadel-foss/maker-dashboard) |
+| 📱 **Taker App** | GUI client to fund a wallet and perform swaps | [`citadel-foss/taker-app`](https://github.com/citadel-foss/taker-app) |
 
 > 📥 **Download a pre-compiled binary (recommended for both apps).** Grab the binary for your OS from each app's **latest release** and run it — no toolchain required.
 >
@@ -36,13 +36,13 @@ Start `bitcoind` with the following `bitcoin.conf`:
 ```ini
 signet=1
 [signet]
-# Custom Signet dedicated for the Coinswap Network. 
+# Custom Signet dedicated for the OpenSwap Network. 
 # This signet is maintained by Citadel FOSS Developers.
 signetchallenge=0014a3ec9c731da66d9725d54947aede5c830623f33d
 addnode=170.75.166.88:38333
 dnsseed=0
 
-# RPC configuration for Coinswap operations
+# RPC configuration for OpenSwap operations
 server=1
 rpcuser=user
 rpcpassword=password
@@ -131,7 +131,7 @@ A GUI for running and monitoring your maker server.
 
 ### 📥 Download Pre-compiled Binary (Recommended)
 
-1. Visit the **[latest release](https://github.com/citadel-tech/maker-dashboard/releases/latest)**.
+1. Visit the **[latest release](https://github.com/citadel-foss/maker-dashboard/releases/latest)**.
 2. Download the **Maker Dashboard** binary for your operating system.
 3. Run the binary and follow the on-screen steps, then open <http://localhost:3000> in your browser to access the dashboard.
 
@@ -146,9 +146,9 @@ Make sure [Docker is installed](#2-docker--only-for-the-maker-dashboard-docker-f
   ```bash
   docker run -d --name maker-dashboard --network host \
     --volume ~/.config/maker-dashboard:/root/.config/maker-dashboard \
-    --volume ~/.coinswap:/root/.coinswap \
+    --volume ~/.openswap:/root/.openswap \
     --env MAKER_DASHBOARD_HOST=127.0.0.1 \
-    coinswap/maker-dashboard:master
+    openswap/maker-dashboard:master
   ```
 
 - **macOS:**
@@ -158,9 +158,9 @@ Make sure [Docker is installed](#2-docker--only-for-the-maker-dashboard-docker-f
   ```bash
   docker run -d --name maker-dashboard -p 127.0.0.1:3000:3000 \
     --volume ~/.config/maker-dashboard:/root/.config/maker-dashboard \
-    --volume ~/.coinswap:/root/.coinswap \
+    --volume ~/.openswap:/root/.openswap \
     --env MAKER_DASHBOARD_HOST=0.0.0.0 \
-    coinswap/maker-dashboard:master
+    openswap/maker-dashboard:master
   ```
 
 Open your browser and navigate to <http://localhost:3000> to access the dashboard.
@@ -172,23 +172,23 @@ Open your browser and navigate to <http://localhost:3000> to access the dashboar
 > Use this only if the options above don't work. Requires the [build-from-source prerequisites](#3-build-from-source-prerequisites--only-if-you-self-compile) above (Rust, Node.js v18+, and the `libtor` native build tools).
 
 ```bash
-git clone https://github.com/citadel-tech/maker-dashboard.git
+git clone https://github.com/citadel-foss/maker-dashboard.git
 cd maker-dashboard
 make build
 make run
 ```
 
-`make build` compiles the Rust backend (`cargo build --release`) and the frontend (`cd frontend && npm install && npm run build`). Once running, open <http://localhost:3000> in your browser. See the project's [README](https://github.com/citadel-tech/maker-dashboard#readme) for advanced/per-component steps.
+`make build` compiles the Rust backend (`cargo build --release`) and the frontend (`cd frontend && npm install && npm run build`). Once running, open <http://localhost:3000> in your browser. See the project's [README](https://github.com/citadel-foss/maker-dashboard#readme) for advanced/per-component steps.
 
 ---
 
 ## 📱 Taker App
 
-A GUI swap client to fund a wallet and perform Coinswaps.
+A GUI swap client to fund a wallet and perform OpenSwaps.
 
 ### 📥 Download Pre-compiled Binary (Recommended)
 
-1. Visit the **[latest release](https://github.com/citadel-tech/taker-app/releases/latest)**.
+1. Visit the **[latest release](https://github.com/citadel-foss/taker-app/releases/latest)**.
 2. Download the **Taker App** binary for your operating system.
 3. Run the binary and follow the on-screen onboarding steps.
 
@@ -197,13 +197,13 @@ A GUI swap client to fund a wallet and perform Coinswaps.
 > Use this only if the options above don't work. Requires the [build-from-source prerequisites](#3-build-from-source-prerequisites--only-if-you-self-compile) above (Rust, Node.js v18+, and the `libtor` native build tools).
 
 ```bash
-git clone https://github.com/citadel-tech/taker-app.git
+git clone https://github.com/citadel-foss/taker-app.git
 cd taker-app
-npm install      # the `prepare` step clones coinswap-ffi and builds the native modules (~2-3 min)
+npm install      # the `prepare` step clones openswap-ffi and builds the native modules (~2-3 min)
 npm run dist     # production build
 ```
 
-For a live development build, use `npm run dev` instead. See the project's [README](https://github.com/citadel-tech/taker-app#readme) for details.
+For a live development build, use `npm run dev` instead. See the project's [README](https://github.com/citadel-foss/taker-app#readme) for details.
 
 ---
 
@@ -214,4 +214,4 @@ For a live development build, use `npm run dev` instead. See the project's [READ
 3. Wait for the funding transaction to confirm (track it on the **[Block Explorer](https://mempool.citadelfoss.xyz/)**).
 4. Pick an available maker from the marketplace and start your swap. 🎉
 
-> 🆘 Something didn't work as expected? Please report an [Issue](https://github.com/citadel-tech/coinswap/issues) or ping the devs in the [community forum](https://matrix.to/#/#ciatdel-foss:matrix.org).
+> 🆘 Something didn't work as expected? Please report an [Issue](https://github.com/citadel-foss/openswap/issues) or ping the devs in the [community forum](https://matrix.to/#/#ciatdel-foss:matrix.org).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
-# Coinswap Docker
+# OpenSwap Docker
 
-A dockerized version of the **Complete Coinswap Backend**.
+A dockerized version of the **Complete OpenSwap Backend**.
 
 The Docker spawns multiple containers, with Mutinynet, Tor, makerd, maker-cli, and taker configured to communicate with each other.
 
@@ -8,16 +8,16 @@ Various subsets of the stack can be used for different application needs and env
 
 ## Overview
 
-The Docker setup provides a complete environment for running any Coinswap applications:
+The Docker setup provides a complete environment for running any OpenSwap applications:
 
-- **Single unified Dockerfile** containing all Coinswap components
+- **Single unified Dockerfile** containing all OpenSwap components
 - **Alpine Linux 3.20** base image for minimal size
 - **Rust 1.90.0** for building the applications
 - **Custom Bitcoin Mutinynet image** for Signet testing
 - **External Tor image** (`osminogin/tor-simple`)
 - **Interactive configuration** with automatic service detection
 - **Docker Compose Profiles** for flexible deployment
-- **Coinswap binaries:** `makerd`, `maker-cli`, `taker`
+- **OpenSwap binaries:** `makerd`, `maker-cli`, `taker`
 
 ## Architecture
 
@@ -33,7 +33,7 @@ graph TD
     tor_vol["tor-data"]
     maker_vol["maker-data"]
     
-    network["coinswap-network"]
+    network["openswap-network"]
     
     makerd <-->|"RPC calls <br> (on bitcoind rpc-port)"| bitcoind
     makerd -->|SOCKS proxy| tor
@@ -67,11 +67,11 @@ The Docker setup uses:
 
 ### Using the Setup Script (Recommended)
 
-The `docker-setup` script provides an interactive way to configure and run Coinswap:
+The `docker-setup` script provides an interactive way to configure and run OpenSwap:
 
 ```bash
-git clone https://github.com/citadel-tech/coinswap.git
-cd coinswap
+git clone https://github.com/citadel-foss/openswap.git
+cd openswap
 
 # Interactive configuration
 ./docker-setup configure
@@ -118,8 +118,8 @@ Configuration is saved to `.docker-config` and reused on subsequent runs.
 The build process creates a single image containing all binaries:
 
 ```bash
-git clone https://github.com/citadel-tech/coinswap.git
-cd coinswap
+git clone https://github.com/citadel-foss/openswap.git
+cd openswap
 
 # Build using the setup script
 ./docker-setup build
@@ -128,12 +128,12 @@ cd coinswap
 ./docker-setup build-bitcoin
 
 # Or build manually
-docker build -f docker/Dockerfile -t coinswap:latest .
+docker build -f docker/Dockerfile -t openswap:latest .
 ```
 
 ### Available Images
 
-- **coinswap**: Contains `makerd`, `maker-cli`, and `taker`
+- **openswap**: Contains `makerd`, `maker-cli`, and `taker`
 - **bitcoin-mutinynet**: Custom Bitcoin Core node for Mutinynet network
 
 ## Running Applications
@@ -148,16 +148,16 @@ Run the maker daemon with persistent data storage:
 
 # Or manually with specific image
 docker run -d \
-  --name coinswap-makerd \
+  --name openswap-makerd \
   -p 6102:6102 \
   -p 6103:6103 \
-  -v coinswap-maker-data:/home/coinswap/.coinswap \
-  --network coinswap-network \
-  coinswap:latest makerd
+  -v openswap-maker-data:/home/openswap/.openswap \
+  --network openswap-network \
+  openswap:latest makerd
 ```
 
 **Port mappings:**
-- `6102`: Maker network port for coinswap protocol
+- `6102`: Maker network port for openswap protocol
 - `6103`: Maker RPC port for `maker-cli` commands
 
 ### Maker CLI
@@ -171,9 +171,9 @@ Control the maker daemon:
 ./docker-setup maker-cli stop
 
 # Or manually
-docker run --rm --network coinswap-network coinswap:latest maker-cli ping
-docker run --rm --network coinswap-network coinswap:latest maker-cli wallet-balance
-docker run --rm --network coinswap-network coinswap:latest maker-cli stop
+docker run --rm --network openswap-network openswap:latest maker-cli ping
+docker run --rm --network openswap-network openswap:latest maker-cli wallet-balance
+docker run --rm --network openswap-network openswap:latest maker-cli stop
 ```
 
 ### Taker
@@ -186,9 +186,9 @@ Run taker operations:
 
 # Or manually
 docker run --rm -it \
-  -v coinswap-taker-data:/home/coinswap/.coinswap \
-  --network coinswap-network \
-  coinswap:latest taker --help
+  -v openswap-taker-data:/home/openswap/.openswap \
+  --network openswap-network \
+  openswap:latest taker --help
 ```
 
 ## Docker Compose Setup
@@ -236,5 +236,5 @@ docker compose logs -f makerd
 ./docker-setup shell
 
 # or manually
-docker run --rm -it coinswap:latest sh
+docker run --rm -it openswap:latest sh
 ```

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -30,18 +30,18 @@ This will display a detailed guide about the app and its capabilities.
 #### **Output:**
 
 ```bash
-coinswap 0.1.0
-Developers at Citadel-Tech
+openswap 0.1.0
+Developers at Citadel FOSS
 A simple command line app to operate the makerd server.
 
 The app works as an RPC client for makerd, useful to access the server, retrieve information, and
 manage server operations.
 
 For more detailed usage information, please refer:
-https://github.com/citadel-tech/coinswap/blob/master/docs/maker-cli.md
+https://github.com/citadel-foss/openswap/blob/master/docs/maker-cli.md
 
 This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-tech/coinswap/issues
+https://github.com/citadel-foss/openswap/issues
 
 USAGE:
     maker-cli [OPTIONS] <SUBCOMMAND>
@@ -148,7 +148,7 @@ $ ./maker-cli show-data-dir
 **Output:**
 
 ```bash
-<home_directory>/coinswap/maker
+<home_directory>/openswap/maker
 ```
 
 This is where all the maker's data is stored.
@@ -264,11 +264,11 @@ This confirms the balance of our fidelity UTXOs matches the amount we set when c
 
 ---
 
-For more details about fidelity bonds, refer to the [Fidelity Bond Documentation](https://github.com/citadel-tech/Coinswap-Protocol-Specification/blob/main/v1/4_fidelity.md).
+For more details about fidelity bonds, refer to the [Fidelity Bond Documentation](https://github.com/citadel-foss/OpenSwap-Protocol-Specification/blob/main/v1/4_fidelity.md).
 
 ---
 
-Next, we’ll explore other UTXOs and balances in Coinswap.
+Next, we’ll explore other UTXOs and balances in OpenSwap.
 
 ### Other UTXOs and Their Balances
 
@@ -279,7 +279,7 @@ $ ./maker-cli list-utxo-swap
 []
 ```
 
-This lists UTXOs received from incoming swaps. Since we have not done any coinswap yet, we have no swap UTXOs and thus no swap balances.
+This lists UTXOs received from incoming swaps. Since we have not done any openswap yet, we have no swap UTXOs and thus no swap balances.
 
 #### Contract UTXOs
 
@@ -288,7 +288,7 @@ $ ./maker-cli list-utxo-contract
 []
 ```
 
-This lists HTLC contract UTXOs. As mentioned above: We haven't participated in any coinswap transactions yet, so we don't have any unsuccessful coinswaps. Therefore, we have no `contract UTXOs` and no balance in this category.
+This lists HTLC contract UTXOs. As mentioned above: We haven't participated in any openswap transactions yet, so we don't have any unsuccessful openswaps. Therefore, we have no `contract UTXOs` and no balance in this category.
 
 Both categories show zero balances as confirmed by our `get-balances` output:
 
@@ -436,8 +436,8 @@ success
 This syncs the maker wallet with the current blockchain state. On `makerd`, we will see:
 
 ```bash
-INFO coinswap::maker::rpc::server - Starting wallet sync.
-INFO coinswap::maker::rpc::server - Wallet sync success.
+INFO openswap::maker::rpc::server - Starting wallet sync.
+INFO openswap::maker::rpc::server - Wallet sync success.
 ```
 
 ### Checking Wallet Balances and UTXOs:
@@ -568,19 +568,19 @@ Shutdown Initiated
 This shuts down the makerd server. Once you run this command, the maker server initiates a shutdown, and we'll see the following logs indicating the shutdown process:
 
 ```bash
- INFO coinswap::maker::server - [6102] Maker is shutting down.
- INFO coinswap::maker::api - Joining 4 threads
- INFO coinswap::maker::api - [6102] Thread RPC Thread joined
- INFO coinswap::maker::api - [6102] Thread Contract Watcher Thread joined
- INFO coinswap::maker::api - [6102] Thread Idle Client Checker Thread joined
- INFO coinswap::maker::api - [6102] Thread Bitcoin Core Connection Checker Thread joined
- INFO coinswap::maker::api - Successfully joined 4 threads
- INFO coinswap::maker::server - Shutdown wallet sync initiated.
- INFO coinswap::maker::server - Shutdown wallet syncing completed.
- INFO coinswap::maker::server - Wallet file saved to disk.
- INFO coinswap::maker::server - Maker Server is shut down successfully
+ INFO openswap::maker::server - [6102] Maker is shutting down.
+ INFO openswap::maker::api - Joining 4 threads
+ INFO openswap::maker::api - [6102] Thread RPC Thread joined
+ INFO openswap::maker::api - [6102] Thread Contract Watcher Thread joined
+ INFO openswap::maker::api - [6102] Thread Idle Client Checker Thread joined
+ INFO openswap::maker::api - [6102] Thread Bitcoin Core Connection Checker Thread joined
+ INFO openswap::maker::api - Successfully joined 4 threads
+ INFO openswap::maker::server - Shutdown wallet sync initiated.
+ INFO openswap::maker::server - Shutdown wallet syncing completed.
+ INFO openswap::maker::server - Wallet file saved to disk.
+ INFO openswap::maker::server - Maker Server is shut down successfully
 ```
 
 ---
 
-And that's it! Now you are ready to be a maker in the Coinswap network. Start your maker servers, perform coinswaps, and enjoy earning fees from takers who participate in coinswaps with you.
+And that's it! Now you are ready to be a maker in the OpenSwap network. Start your maker servers, perform openswaps, and enjoy earning fees from takers who participate in openswaps with you.

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -2,7 +2,7 @@
 
 The **Maker** is the party that provides liquidity for a coin swap initiated by a **Taker**. In return, the Maker earns a fee for facilitating the swap.
 
-The Maker component is based on the `makerd/maker-cli` architecture, which is similar to `bitcoind/bitcoin-cli`. The `makerd` is a background daemon that handles the heavy tasks in the **Coinswap** protocol, such as maintaining fidelity bonds, and processing Taker requests.
+The Maker component is based on the `makerd/maker-cli` architecture, which is similar to `bitcoind/bitcoin-cli`. The `makerd` is a background daemon that handles the heavy tasks in the **OpenSwap** protocol, such as maintaining fidelity bonds, and processing Taker requests.
 
 The `makerd` server should run 24/7 to ensure it can process Taker requests and facilitate coin swaps at any time.
 
@@ -13,9 +13,9 @@ The `maker-cli` is a command-line application that allows you to operate and man
 
 ## Data, Configuration, and Wallets
 
-Maker stores all its data in a directory located by default at `$HOME/.coinswap/maker`. This directory contains the following important files:
+Maker stores all its data in a directory located by default at `$HOME/.openswap/maker`. This directory contains the following important files:
 
-### **1. Default Maker Configuration (`~/.coinswap/maker/config.toml`):**
+### **1. Default Maker Configuration (`~/.openswap/maker/config.toml`):**
 
 ```toml
 network_port = 6102
@@ -31,7 +31,7 @@ base_fee = 500
 amount_relative_fee_pct = 0.0025
 time_relative_fee_pct = 0.0001
 ```
-- `network_port`: TCP port where the Maker listens for incoming Coinswap protocol messages.
+- `network_port`: TCP port where the Maker listens for incoming OpenSwap protocol messages.
 - `rpc_port`: The port through which `makerd` listens for RPC commands from `maker-cli`.
 - `socks_port`: The Tor Socks Port.  Check the [tor doc](tor.md) for more details.
 - `control_port`: The Tor Control Port. Check the [tor doc](tor.md) for more details.
@@ -47,13 +47,13 @@ time_relative_fee_pct = 0.0001
 
 
 > **Important:**  
-> At the moment, Coinswap operates only on the **TOR** network. The `connection_type` is hardcoded to `TOR`, and the app will only work with this network until multi-network support is added.
+> At the moment, OpenSwap operates only on the **TOR** network. The `connection_type` is hardcoded to `TOR`, and the app will only work with this network until multi-network support is added.
 
 ### 2. **wallets Directory**
 
 This folder contains the wallet files used by the Maker to store wallet data, including private keys. Ensure these wallet files are backed up securely.
 
-The default wallet directory is `$HOME/.coinswap/maker/wallets`.
+The default wallet directory is `$HOME/.openswap/maker/wallets`.
 
 ### 3. **debug.log**
 
@@ -104,9 +104,9 @@ This will display information about the `makerd` binary and its options.
 **Output:**
 
 ```bash
-coinswap 0.1.2
-Developers at Citadel-Tech
-Coinswap Maker Server
+openswap 0.1.2
+Developers at Citadel FOSS
+OpenSwap Maker Server
 
 The server requires a Bitcoin Core RPC connection running in Testnet4. It requires a starting
 balance, around 50,000 sats for Fidelity + Swap Liquidity (suggested 50,000 sats). So top up with at
@@ -120,10 +120,10 @@ requests. As it performs swaps for clients, it keeps earning fees.
 The server is operated with the maker-cli app, for all basic wallet related operations.
 
 For more detailed usage information, please refer to the [Maker
-Doc] https://github.com/citadel-tech/coinswap/blob/master/docs/makerd.md
+Doc] https://github.com/citadel-foss/openswap/blob/master/docs/makerd.md
 
 This is early beta, and there are known and unknown bugs. Please report issues in the [Project Issue
-Board] https://github.com/citadel-tech/coinswap/issues
+Board] https://github.com/citadel-foss/openswap/issues
 
 USAGE:
     makerd [OPTIONS]
@@ -135,7 +135,7 @@ OPTIONS:
             [default: user:password]
 
     -d, --data-directory <DATA_DIRECTORY>
-            Optional data directory. Default value: "~/.coinswap/maker"
+            Optional data directory. Default value: "~/.openswap/maker"
 
     -h, --help
             Print help information
@@ -185,59 +185,59 @@ To start `makerd`, run the following command:
 $ ./makerd -a user:password -r 127.0.0.1:38332
 ```
 
-This will launch `makerd` and connect it to the Bitcoin RPC core running on its RPC port, using the default data directory for `maker` located at `$HOME/.coinswap/maker`.
+This will launch `makerd` and connect it to the Bitcoin RPC core running on its RPC port, using the default data directory for `maker` located at `$HOME/.openswap/maker`.
 
 **What happens next:**
 
-- **Wallet Loading**: If an existing wallet file is found at `$HOME/.coinswap/maker/wallets`, `makerd` will load it:
+- **Wallet Loading**: If an existing wallet file is found at `$HOME/.openswap/maker/wallets`, `makerd` will load it:
 
   ```bash
-  INFO coinswap::wallet::api - Wallet file at "/path/to/maker-wallet" successfully loaded.
+  INFO openswap::wallet::api - Wallet file at "/path/to/maker-wallet" successfully loaded.
   ```
 
 - **New Wallet Creation**: If no wallet file is found, `makerd` will create a new wallet named `maker-wallet`:
 
   ```bash
-  INFO coinswap::wallet::api - Backup the Wallet Mnemonics.
+  INFO openswap::wallet::api - Backup the Wallet Mnemonics.
   ["harvest", "trust", "catalog", "degree", "oxygen", "business", "crawl", "enemy", "hamster", "music", "this", "idle"]
   
-  INFO coinswap::maker::api - New Wallet created at: "$HOME/.coinswap/maker/wallets/maker-wallet".
+  INFO openswap::maker::api - New Wallet created at: "$HOME/.openswap/maker/wallets/maker-wallet".
   ```
 
-- **Configuration File**: If no `config` file exists, `makerd` will create a default `config.toml` file at `$HOME/.coinswap/maker/config.toml`:
+- **Configuration File**: If no `config` file exists, `makerd` will create a default `config.toml` file at `$HOME/.openswap/maker/config.toml`:
 
    ```bash
-   WARN coinswap::maker::config - Maker config file not found, creating default config file at path: /tmp/coinswap/maker/config.toml
-   INFO coinswap::maker::config - Successfully loaded config file from: $HOME/.coinswap/maker/config.toml
+   WARN openswap::maker::config - Maker config file not found, creating default config file at path: /tmp/openswap/maker/config.toml
+   INFO openswap::maker::config - Successfully loaded config file from: $HOME/.openswap/maker/config.toml
    ```
 
 - **Wallet Sync**: The wallet will sync to catch up with the latest updates:
 
   ```bash
-  INFO coinswap::wallet::rpc - Initializing wallet sync and save
-  INFO coinswap::wallet::rpc - Completed wallet sync and save
+  INFO openswap::wallet::rpc - Initializing wallet sync and save
+  INFO openswap::wallet::rpc - Completed wallet sync and save
   ```
 
 - **TOR Initialization**: `makerd` will start the TOR process and listen for connections on a TOR address:
 
   ```bash
-  INFO coinswap::maker::server - [6102] Server is listening at 3xvc6tvf455afnogiwhzpztp7r5w43kq4r2yb5oootu7rog6k6rnq4id.onion:6102
+  INFO openswap::maker::server - [6102] Server is listening at 3xvc6tvf455afnogiwhzpztp7r5w43kq4r2yb5oootu7rog6k6rnq4id.onion:6102
   ```
 
 - **Fidelity Bond Check**: `makerd` checks for existing fidelity bonds. 
 
   **If an existing fidelity bond is found**:
   ```bash
-  INFO coinswap::wallet::fidelity - Fidelity Bond found | Index: 0 | Bond Value : 0.00043653 BTC
-  INFO coinswap::maker::server - Highest bond at outpoint fc11a129...c:0 | Amount 5000000 sats | Remaining Timelock for expiry : 536 Blocks
+  INFO openswap::wallet::fidelity - Fidelity Bond found | Index: 0 | Bond Value : 0.00043653 BTC
+  INFO openswap::maker::server - Highest bond at outpoint fc11a129...c:0 | Amount 5000000 sats | Remaining Timelock for expiry : 536 Blocks
   ```
 
   **If no fidelity bonds are found**, it will create one using the fidelity amount and timelock from the configuration file. By default, the fidelity amount is `50,000 sats` and the timelock is `13104 blocks`:
 
   ```bash
-  INFO coinswap::maker::server - No active Fidelity Bonds found. Creating one.
-  INFO coinswap::maker::server - Fidelity value chosen = 0.0005 BTC
-  INFO coinswap::maker::server - Fidelity Tx fee = 1000 sats
+  INFO openswap::maker::server - No active Fidelity Bonds found. Creating one.
+  INFO openswap::maker::server - Fidelity value chosen = 0.0005 BTC
+  INFO openswap::maker::server - Fidelity Tx fee = 1000 sats
   ```
 
   > **Note**: Currently, the transaction fee for the fidelity bond is hardcoded at `1000 sats`. This approach of directly considering `fee` not `fee rate` will be improved in v0.1.1 milestones.
@@ -250,38 +250,38 @@ This will launch `makerd` and connect it to the Bitcoin RPC core running on its 
 - **Fidelity Transaction Creation**: Once the server detects sufficient funding (for new setups), it will automatically create and broadcast a fidelity transaction using the funding UTXOs:
 
   ```bash
-  INFO coinswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 seen in mempool, waiting for confirmation.
+  INFO openswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 seen in mempool, waiting for confirmation.
   ```
   
 - **Fidelity Transaction Confirmation**: Once the transaction is confirmed:
   
   ```bash
-  INFO coinswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 confirmed at blockheight: 229349
-  INFO coinswap::maker::server - [6102] Successfully created fidelity bond
+  INFO openswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 confirmed at blockheight: 229349
+  INFO openswap::maker::server - [6102] Successfully created fidelity bond
   ```
 
 
 - **Thread Spawning**: Several threads will be spawned to handle specific tasks:
 
   ```bash
-  INFO coinswap::maker::server - [6102] Spawning contract-watcher thread
-  INFO coinswap::maker::server - [6102] Spawning Client connection status checker thread
-  INFO coinswap::maker::server - [6102] Spawning RPC server thread
-  INFO coinswap::maker::rpc::server - [6102] RPC socket binding successful at 127.0.0.1:6103
+  INFO openswap::maker::server - [6102] Spawning contract-watcher thread
+  INFO openswap::maker::server - [6102] Spawning Client connection status checker thread
+  INFO openswap::maker::server - [6102] Spawning RPC server thread
+  INFO openswap::maker::rpc::server - [6102] RPC socket binding successful at 127.0.0.1:6103
   ```
 
 - **Server Ready**: Finally, the `makerd` server is fully set up and ready to connect with other takers for coin swaps:
 
 ```bash
-INFO coinswap::maker::server - [6102] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
+INFO openswap::maker::server - [6102] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
 ```
 
 The server will display information about swap liquidity and continue listening for requests:
 
 ```bash
-INFO coinswap::maker::server - Swap Liquidity: 5001672 sats | Min: 10000 sats | Listening for requests.
-INFO coinswap::maker::server - [6102] Bitcoin Network: regtest
-INFO coinswap::maker::server - [6102] Spendable Wallet Balance: 0.05001672 BTC
+INFO openswap::maker::server - Swap Liquidity: 5001672 sats | Min: 10000 sats | Listening for requests.
+INFO openswap::maker::server - [6102] Bitcoin Network: regtest
+INFO openswap::maker::server - [6102] Spendable Wallet Balance: 0.05001672 BTC
 ```
 
 ---

--- a/docs/taker.md
+++ b/docs/taker.md
@@ -1,14 +1,14 @@
 # Taker Tutorial
 
-The **Taker** is the party that initiates the coinswap. It discovers makers, requests offers from them and selects suitable makers for the swap.
+The **Taker** is the party that initiates the openswap. It discovers makers, requests offers from them and selects suitable makers for the swap.
 
-In this tutorial, we will guide you through the process of setting up and running the taker, and conducting a coinswap.
+In this tutorial, we will guide you through the process of setting up and running the taker, and conducting a openswap.
 
 ## Setup
 
 ## Taker CLI
 
-The taker CLI is an application that allows you to perform coinswaps as a taker.
+The taker CLI is an application that allows you to perform openswaps as a taker.
 
 > **Warning:**  
 > Taker wallet files contain private keys required to spend your funds. Ensure these wallet files are backed up securely, and take appropriate measures to protect your private keys.
@@ -42,19 +42,19 @@ This will display a detailed guide about the app and its capabilities.
 #### **Output:**
 
 ```bash
-coinswap 0.1.2
-Developers at Citadel-Tech
-A simple command line app to operate as a CoinSwap client.
+openswap 0.1.2
+Developers at Citadel FOSS
+A simple command line app to operate as a OpenSwap client.
 
-The app works as a regular Bitcoin wallet with the added capability to perform coinswaps. The app
+The app works as a regular Bitcoin wallet with the added capability to perform openswaps. The app
 requires a running Bitcoin Core node with RPC access. It currently only runs on Testnet4. Suggested
 faucet for getting Signet coins (tor browser required): http://a4ovtjlwiclzy37bjaurcbb6wpl6dtckmlqwrywq7uoajeaz6kth4uyd.onion/
 
 For more detailed usage information, please refer:
-https://github.com/citadel-tech/coinswap/blob/master/docs/taker.md
+https://github.com/citadel-foss/openswap/blob/master/docs/taker.md
 
 This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-tech/coinswap/issues
+https://github.com/citadel-foss/openswap/issues
 
 USAGE:
     taker [OPTIONS] <SUBCOMMAND>
@@ -66,7 +66,7 @@ OPTIONS:
             [default: user:password]
 
     -d, --data-directory <DATA_DIRECTORY>
-            Optional data directory. Default value: "~/.coinswap/taker"
+            Optional data directory. Default value: "~/.openswap/taker"
 
     -h, --help
             Print help information
@@ -93,8 +93,8 @@ OPTIONS:
             wallet. Default: taker-wallet
 
 SUBCOMMANDS:
-    coinswap
-            Initiate the coinswap process
+    openswap
+            Initiate the openswap process
     fetch-offers
             Update the offerbook with current market offers and display them
     list-offers
@@ -149,7 +149,7 @@ SUBCOMMANDS:
 
 ### Generate a New Address
 
-Before you can perform coinswaps, you need to fund your wallet. First, generate a new receiving address:
+Before you can perform openswaps, you need to fund your wallet. First, generate a new receiving address:
 
 ```bash
 $ taker get-new-address
@@ -257,7 +257,7 @@ $ taker list-utxo-swap
 }
 ```
 
-This lists all UTXOs received in incoming swaps. Since we haven't performed any coinswaps yet, this list is empty.
+This lists all UTXOs received in incoming swaps. Since we haven't performed any openswaps yet, this list is empty.
 
 ### List Contract UTXOs
 
@@ -276,7 +276,7 @@ This lists all UTXOs that we need to claim via timelock. If you see entries in t
 
 ### Fetch Available Offers
 
-Now we are ready to initiate a coinswap. We are first going to sync the offer book to get a list of available makers:
+Now we are ready to initiate a openswap. We are first going to sync the offer book to get a list of available makers:
 
 ```bash
 $ taker fetch-offers
@@ -302,80 +302,80 @@ $ taker fetch-offers
 
 This will fetch the list of available makers and display their offers.
 
-### Initiate a Coinswap
+### Initiate a OpenSwap
 
-Now we can initiate a coinswap with the makers:
+Now we can initiate a openswap with the makers:
 
 ```bash
-$ taker coinswap
+$ taker openswap
 ```
 
-This will initiate a coinswap with the default parameters. The process typically takes several minutes to complete. You can monitor the swap progress by watching the debug log in a new terminal:
+This will initiate a openswap with the default parameters. The process typically takes several minutes to complete. You can monitor the swap progress by watching the debug log in a new terminal:
 
 ```bash
-tail -f ~/.coinswap/taker/debug.log
+tail -f ~/.openswap/taker/debug.log
 ```
 
 ```bash
 
-2025-09-03T18:58:34.830814322+05:30 INFO coinswap::utill - ✅ Logger initialized successfully
-2025-09-03T18:58:34.831885420+05:30 INFO coinswap::wallet::api - Wallet file at "/home/keraliss/.coinswap/taker/wallets/taker-wallet" successfully loaded.
-2025-09-03T18:58:34.831932106+05:30 INFO coinswap::taker::config - Successfully loaded config file from : /home/keraliss/.coinswap/taker/config.toml
-2025-09-03T18:58:34.832064049+05:30 INFO coinswap::utill - Tor is fully started and operational!
-2025-09-03T18:58:34.832636855+05:30 INFO coinswap::taker::api - Succesfully loaded offerbook at : "/home/keraliss/.coinswap/taker/offerbook.json"
-2025-09-03T18:58:34.832650756+05:30 INFO coinswap::wallet::rpc - Initializing wallet sync and save
-2025-09-03T18:58:35.157963973+05:30 INFO coinswap::wallet::rpc - Completed wallet sync and save
-2025-09-03T18:58:35.157987063+05:30 INFO coinswap::taker::api - Using regular UTXOs for coinswap
-2025-09-03T18:58:35.157991757+05:30 INFO coinswap::taker::api - Syncing Offerbook
-2025-09-03T18:58:35.158000831+05:30 INFO coinswap::taker::api - Fetching addresses from DNS: lp75qh3del4qot6fmkqq4taqm33pidvk63lncvhlwsllbwrl2f4g4qqd.onion:8080
-2025-09-03T18:58:44.794069324+05:30 INFO coinswap::taker::routines - Downloading offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:44.794123815+05:30 INFO coinswap::taker::routines - Downloading offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102
-2025-09-03T18:58:53.391435256+05:30 INFO coinswap::taker::routines - Downloaded offer from : rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102 
-2025-09-03T18:58:53.641409491+05:30 INFO coinswap::taker::routines - Downloaded offer from : ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202 
-2025-09-03T18:58:53.641555305+05:30 INFO coinswap::taker::api - Found offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102. Verifying Fidelity Proof
-2025-09-03T18:58:53.644582350+05:30 INFO coinswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
-2025-09-03T18:58:53.644600038+05:30 INFO coinswap::taker::api - Found offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202. Verifying Fidelity Proof
-2025-09-03T18:58:53.645776479+05:30 INFO coinswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
-2025-09-03T18:58:53.646061049+05:30 INFO coinswap::taker::api - Found 5 suitable makers for this swap round
-2025-09-03T18:58:53.646074741+05:30 INFO coinswap::taker::api - Initiating coinswap with id : c874d9f7ac7e6230
-2025-09-03T18:58:53.646081183+05:30 INFO coinswap::taker::api - Initializing First Hop.
-2025-09-03T18:58:53.646089505+05:30 INFO coinswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.700488732+05:30 INFO coinswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.702775316+05:30 INFO coinswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.706404936+05:30 INFO coinswap::wallet::spend - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.706461956+05:30 INFO coinswap::wallet::funding - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:34.830814322+05:30 INFO openswap::utill - ✅ Logger initialized successfully
+2025-09-03T18:58:34.831885420+05:30 INFO openswap::wallet::api - Wallet file at "/home/keraliss/.openswap/taker/wallets/taker-wallet" successfully loaded.
+2025-09-03T18:58:34.831932106+05:30 INFO openswap::taker::config - Successfully loaded config file from : /home/keraliss/.openswap/taker/config.toml
+2025-09-03T18:58:34.832064049+05:30 INFO openswap::utill - Tor is fully started and operational!
+2025-09-03T18:58:34.832636855+05:30 INFO openswap::taker::api - Succesfully loaded offerbook at : "/home/keraliss/.openswap/taker/offerbook.json"
+2025-09-03T18:58:34.832650756+05:30 INFO openswap::wallet::rpc - Initializing wallet sync and save
+2025-09-03T18:58:35.157963973+05:30 INFO openswap::wallet::rpc - Completed wallet sync and save
+2025-09-03T18:58:35.157987063+05:30 INFO openswap::taker::api - Using regular UTXOs for openswap
+2025-09-03T18:58:35.157991757+05:30 INFO openswap::taker::api - Syncing Offerbook
+2025-09-03T18:58:35.158000831+05:30 INFO openswap::taker::api - Fetching addresses from DNS: lp75qh3del4qot6fmkqq4taqm33pidvk63lncvhlwsllbwrl2f4g4qqd.onion:8080
+2025-09-03T18:58:44.794069324+05:30 INFO openswap::taker::routines - Downloading offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:58:44.794123815+05:30 INFO openswap::taker::routines - Downloading offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102
+2025-09-03T18:58:53.391435256+05:30 INFO openswap::taker::routines - Downloaded offer from : rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102 
+2025-09-03T18:58:53.641409491+05:30 INFO openswap::taker::routines - Downloaded offer from : ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202 
+2025-09-03T18:58:53.641555305+05:30 INFO openswap::taker::api - Found offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102. Verifying Fidelity Proof
+2025-09-03T18:58:53.644582350+05:30 INFO openswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
+2025-09-03T18:58:53.644600038+05:30 INFO openswap::taker::api - Found offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202. Verifying Fidelity Proof
+2025-09-03T18:58:53.645776479+05:30 INFO openswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
+2025-09-03T18:58:53.646061049+05:30 INFO openswap::taker::api - Found 5 suitable makers for this swap round
+2025-09-03T18:58:53.646074741+05:30 INFO openswap::taker::api - Initiating openswap with id : c874d9f7ac7e6230
+2025-09-03T18:58:53.646081183+05:30 INFO openswap::taker::api - Initializing First Hop.
+2025-09-03T18:58:53.646089505+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
+2025-09-03T18:58:53.700488732+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
+2025-09-03T18:58:53.702775316+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
+2025-09-03T18:58:53.706404936+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.706461956+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
 2025-09-03T18:58:53.706768325+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.708215981+05:30 ERROR coinswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.708262825+05:30 INFO coinswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.756678424+05:30 INFO coinswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.758990905+05:30 INFO coinswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.762458743+05:30 INFO coinswap::wallet::spend - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.762508683+05:30 INFO coinswap::wallet::funding - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.708215981+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-03T18:58:53.708262825+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
+2025-09-03T18:58:53.756678424+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
+2025-09-03T18:58:53.758990905+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
+2025-09-03T18:58:53.762458743+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.762508683+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
 2025-09-03T18:58:53.762721044+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.763710980+05:30 ERROR coinswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.763757893+05:30 INFO coinswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.813457799+05:30 INFO coinswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.815543924+05:30 INFO coinswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.819894556+05:30 INFO coinswap::wallet::spend - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.820038208+05:30 INFO coinswap::wallet::funding - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.763710980+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-03T18:58:53.763757893+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
+2025-09-03T18:58:53.813457799+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
+2025-09-03T18:58:53.815543924+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
+2025-09-03T18:58:53.819894556+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.820038208+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
 2025-09-03T18:58:53.820375931+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.821413777+05:30 ERROR coinswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.821551711+05:30 INFO coinswap::taker::api - Choosing next maker: ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:53.872796787+05:30 INFO coinswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.874726933+05:30 INFO coinswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.877062518+05:30 INFO coinswap::wallet::spend - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.877090094+05:30 INFO coinswap::wallet::funding - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.821413777+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-03T18:58:53.821551711+05:30 INFO openswap::taker::api - Choosing next maker: ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:58:53.872796787+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
+2025-09-03T18:58:53.874726933+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
+2025-09-03T18:58:53.877062518+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+2025-09-03T18:58:53.877090094+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
 2025-09-03T18:58:53.877509748+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:54.568365133+05:30 INFO coinswap::taker::api - ===> ReqContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:58.263137675+05:30 INFO coinswap::taker::api - <=== RespContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:58.263583864+05:30 INFO coinswap::taker::api - Total Funding Txs Fees: 0.00000440 BTC
-2025-09-03T18:58:58.263606558+05:30 INFO coinswap::taker::api - Transaction size: 220 vB (0.220 kvB)
-2025-09-03T18:58:58.291022378+05:30 INFO coinswap::taker::api - Broadcasted Funding tx. txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c
-2025-09-03T18:58:58.291105164+05:30 INFO coinswap::taker::api - Waiting for funding transaction confirmation. Txids : [5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c]
-2025-09-03T18:58:58.292556173+05:30 INFO coinswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 0 secs
-2025-09-03T18:58:59.062221277+05:30 INFO coinswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:59:29.063641719+05:30 INFO coinswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 30 secs
-2025-09-03T18:59:29.683684462+05:30 INFO coinswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:58:54.568365133+05:30 INFO openswap::taker::api - ===> ReqContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:58:58.263137675+05:30 INFO openswap::taker::api - <=== RespContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:58:58.263583864+05:30 INFO openswap::taker::api - Total Funding Txs Fees: 0.00000440 BTC
+2025-09-03T18:58:58.263606558+05:30 INFO openswap::taker::api - Transaction size: 220 vB (0.220 kvB)
+2025-09-03T18:58:58.291022378+05:30 INFO openswap::taker::api - Broadcasted Funding tx. txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c
+2025-09-03T18:58:58.291105164+05:30 INFO openswap::taker::api - Waiting for funding transaction confirmation. Txids : [5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c]
+2025-09-03T18:58:58.292556173+05:30 INFO openswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 0 secs
+2025-09-03T18:58:59.062221277+05:30 INFO openswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+2025-09-03T18:59:29.063641719+05:30 INFO openswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 30 secs
+2025-09-03T18:59:29.683684462+05:30 INFO openswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
 
 .
 .
@@ -383,17 +383,17 @@ tail -f ~/.coinswap/taker/debug.log
 .
 .
 
-2025-09-03T19:55:19.045810783+05:30 INFO coinswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:55:19.045831823+05:30 INFO coinswap::wallet::api - Next sync in 130 secs
-2025-09-03T19:57:29.047058307+05:30 INFO coinswap::wallet::api - Transaction confirmed at blockheight: 16032, txid : aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:57:29.047080134+05:30 INFO coinswap::wallet::api - Sweep Transaction aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d confirmed at blockheight: 16032
-2025-09-03T19:57:29.047090987+05:30 INFO coinswap::wallet::api - Successfully swept incoming swap coin, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:57:29.047106047+05:30 INFO coinswap::wallet::api - Successfully removed incoming swaps coins
-2025-09-03T19:57:29.047290187+05:30 INFO coinswap::taker::api - Successfully swept 1 incoming swap coins: [aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d]
-2025-09-03T19:57:29.047300886+05:30 INFO coinswap::taker::api - Successfully Completed Coinswap.
-2025-09-03T19:57:29.047307582+05:30 INFO coinswap::taker::api - Shutting down taker.
-2025-09-03T19:57:29.047631218+05:30 INFO coinswap::taker::api - offerbook data saved to disk.
-2025-09-03T19:57:29.047740527+05:30 INFO coinswap::taker::api - Wallet data saved to disk.
+2025-09-03T19:55:19.045810783+05:30 INFO openswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
+2025-09-03T19:55:19.045831823+05:30 INFO openswap::wallet::api - Next sync in 130 secs
+2025-09-03T19:57:29.047058307+05:30 INFO openswap::wallet::api - Transaction confirmed at blockheight: 16032, txid : aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
+2025-09-03T19:57:29.047080134+05:30 INFO openswap::wallet::api - Sweep Transaction aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d confirmed at blockheight: 16032
+2025-09-03T19:57:29.047090987+05:30 INFO openswap::wallet::api - Successfully swept incoming swap coin, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
+2025-09-03T19:57:29.047106047+05:30 INFO openswap::wallet::api - Successfully removed incoming swaps coins
+2025-09-03T19:57:29.047290187+05:30 INFO openswap::taker::api - Successfully swept 1 incoming swap coins: [aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d]
+2025-09-03T19:57:29.047300886+05:30 INFO openswap::taker::api - Successfully Completed OpenSwap.
+2025-09-03T19:57:29.047307582+05:30 INFO openswap::taker::api - Shutting down taker.
+2025-09-03T19:57:29.047631218+05:30 INFO openswap::taker::api - offerbook data saved to disk.
+2025-09-03T19:57:29.047740527+05:30 INFO openswap::taker::api - Wallet data saved to disk.
 ```
 
 ### Recovering Failed Swaps
@@ -418,16 +418,16 @@ $ taker  recover
 **Output:**
 
 ```bash
-2025-08-13T14:36:38.734842084+05:30 INFO coinswap::wallet::api - Unfinished incoming txids: []
-2025-08-13T14:36:38.734849418+05:30 INFO coinswap::wallet::api - Unfinished outgoing txids: []
-2025-08-13T14:36:38.752510411+05:30 INFO coinswap::taker::api - Recovery completed.
+2025-08-13T14:36:38.734842084+05:30 INFO openswap::wallet::api - Unfinished incoming txids: []
+2025-08-13T14:36:38.734849418+05:30 INFO openswap::wallet::api - Unfinished outgoing txids: []
+2025-08-13T14:36:38.752510411+05:30 INFO openswap::taker::api - Recovery completed.
 ```
 
 This will attempt to recover all funds from failed swaps. In this case, since there are no unfinished transactions (both incoming and outgoing txids arrays are empty), the recovery process completes immediately with no funds to recover.
 
 ## Data, Config and Wallets
 
-The taker stores all its data in a data directory. By default, the data directory is located at `$HOME/.coinswap/taker`. You can change the data directory by passing the `--data-directory` option to the `taker` command.
+The taker stores all its data in a data directory. By default, the data directory is located at `$HOME/.openswap/taker`. You can change the data directory by passing the `--data-directory` option to the `taker` command.
 
 The data directory contains the following files:
 
@@ -435,7 +435,7 @@ The data directory contains the following files:
 2. `debug.log` - The log file for the taker.
 3. `wallets` directory - Contains the wallet files for the taker.
 
-**Default Taker Configuration (`~/.coinswap/taker/config.toml`):**
+**Default Taker Configuration (`~/.openswap/taker/config.toml`):**
 
 ```toml
 control_port = 9051

--- a/docs/taproot.md
+++ b/docs/taproot.md
@@ -1,8 +1,8 @@
-# Taproot Coinswap Protocol Documentation
+# Taproot OpenSwap Protocol Documentation
 
 ## Overview
 
-This document describes the complete taproot-based coinswap protocol implementation using MuSig2 signatures for enhanced privacy and efficiency. The protocol enables trustless atomic swaps between a taker and multiple makers in a cyclic flow.
+This document describes the complete taproot-based openswap protocol implementation using MuSig2 signatures for enhanced privacy and efficiency. The protocol enables trustless atomic swaps between a taker and multiple makers in a cyclic flow.
 
 ## Protocol Architecture
 
@@ -204,7 +204,7 @@ let message = Message::from(sighash);
 ## Complete Protocol Summary
 
 ### Total Message Flow
-The complete taproot coinswap involves **16 messages** across 3 phases:
+The complete taproot openswap involves **16 messages** across 3 phases:
 
 1. **Discovery (8 messages)**: Offer fetching and swap negotiation
 2. **Contract Creation (4 messages)**: Cyclic contract setup

--- a/examples/taker_basic.rs
+++ b/examples/taker_basic.rs
@@ -1,6 +1,6 @@
 //! Basic Taker API Example
 //!
-//! This example demonstrates how to use the Coinswap Taker API:
+//! This example demonstrates how to use the OpenSwap Taker API:
 //! - Initialize a Taker instance with Bitcoin Core RPC
 //! - Check wallet balance and generate addresses
 //! - Fund the wallet with test coins
@@ -8,8 +8,8 @@
 //!
 //! ## Prerequisites
 //!
-//! This example requires Tor to be running for coinswap connections.
-//! See [Tor setup documentation](https://github.com/citadel-tech/coinswap/blob/master/docs/tor.md)
+//! This example requires Tor to be running for openswap connections.
+//! See [Tor setup documentation](https://github.com/citadel-foss/openswap/blob/master/docs/tor.md)
 //! for installation and configuration instructions.
 //!
 //! ## Usage
@@ -24,20 +24,20 @@ use bitcoind::{
     bitcoincore_rpc::{Auth, RpcApi},
     BitcoinD,
 };
-use coinswap::{
+use openswap::{
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, Taker, TakerInitConfig},
     wallet::{AddressType, BackendConfig, CoreRpcConfig},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Coinswap Taker Basic Example ===");
+    println!("=== OpenSwap Taker Basic Example ===");
     println!("NOTE: When prompted for encryption passphrase, press Enter for no encryption");
 
     // Clean up any existing wallet files to ensure fresh start
     let wallet_path = std::env::home_dir()
         .unwrap_or_else(std::env::temp_dir)
-        .join(".coinswap")
+        .join(".openswap")
         .join("taker")
         .join("wallets")
         .join("taker-example");
@@ -50,8 +50,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Setup bitcoind in regtest mode
     // NOTE: This example uses regtest for demonstration. In production,
     // you should run your own bitcoind node. See the bitcoind documentation
-    // at https://github.com/citadel-tech/coinswap/blob/master/docs/bitcoind.md
-    let data_dir = std::env::temp_dir().join("coinswap_taker_example");
+    // at https://github.com/citadel-foss/openswap/blob/master/docs/bitcoind.md
+    let data_dir = std::env::temp_dir().join("openswap_taker_example");
     std::fs::create_dir_all(&data_dir)?;
 
     println!("Starting Bitcoin Core in regtest mode...");
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let taker = Taker::init(config).unwrap();
 
     // Swap the two lines above for these to drive the same wallet through an electrs server instead of bitcoind RPC.
-    //     use coinswap::wallet::ElectrumConfig;
+    //     use openswap::wallet::ElectrumConfig;
     //     let electrum_config = ElectrumConfig {
     //         url: "tcp://127.0.0.1:60401".to_string(),
     //     };
@@ -162,7 +162,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap();
 
             // Sync wallet to see the new funds
-            wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+            wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
             let updated_balances = wallet.get_balances().unwrap();
             println!("Wallet funded successfully!");
@@ -213,8 +213,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Coinswap setup
-    println!("\nCoinswap setup:");
+    // OpenSwap setup
+    println!("\nOpenSwap setup:");
 
     let swap_params = SwapParams {
         protocol: ProtocolVersion::Legacy,
@@ -233,17 +233,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Protocol: {:?}", swap_params.protocol);
 
     // In production, you would call:
-    //   let summary = taker.prepare_coinswap(swap_params).unwrap();
-    //   let report = taker.start_coinswap(&summary.swap_id).unwrap();
+    //   let summary = taker.prepare_swap(swap_params).unwrap();
+    //   let report = taker.start_swap(&summary.swap_id).unwrap();
 
-    println!("\nCoinswap call commented out for this example.");
+    println!("\nOpenSwap call commented out for this example.");
     println!("\nIn production, you would call:");
-    println!("  let summary = taker.prepare_coinswap(swap_params).unwrap();");
-    println!("  let report = taker.start_coinswap(&summary.swap_id).unwrap();");
+    println!("  let summary = taker.prepare_swap(swap_params).unwrap();");
+    println!("  let report = taker.start_swap(&summary.swap_id).unwrap();");
     println!("\nThis would:");
     println!("- Connect to the tracker server to find makers");
     println!("- Negotiate with {} makers", swap_params.maker_count);
-    println!("- Execute the coinswap protocol");
+    println!("- Execute the openswap protocol");
     println!("- Return the final transaction details");
 
     println!("\nExample completed.");

--- a/examples/wallet_basic.rs
+++ b/examples/wallet_basic.rs
@@ -21,18 +21,18 @@ use bitcoind::{
     bitcoincore_rpc::{Auth, RpcApi},
     BitcoinD,
 };
-use coinswap::{
+use openswap::{
     utill::MIN_FEE_RATE,
     wallet::{AddressType, AnyBlockchain, CoreRPC, CoreRpcConfig, Destination, Wallet},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Coinswap Wallet Basic Example ===");
+    println!("=== OpenSwap Wallet Basic Example ===");
 
     // Clean up any existing wallet files to ensure fresh start
     let wallet_path = std::env::home_dir()
         .unwrap_or_else(std::env::temp_dir)
-        .join(".coinswap")
+        .join(".openswap")
         .join("taker")
         .join("wallets")
         .join("wallet-example");
@@ -45,8 +45,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Setup bitcoind in regtest mode
     // NOTE: This example uses regtest for demonstration. In production,
     // you should run your own bitcoind node. See the bitcoind documentation
-    // at https://github.com/citadel-tech/coinswap/blob/master/docs/bitcoind.md
-    let data_dir = std::env::temp_dir().join("coinswap_wallet_example");
+    // at https://github.com/citadel-foss/openswap/blob/master/docs/bitcoind.md
+    let data_dir = std::env::temp_dir().join("openswap_wallet_example");
     std::fs::create_dir_all(&data_dir)?;
 
     println!("Starting Bitcoin Core in regtest mode...");
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut wallet = Wallet::init(&wallet_path, backend, None).unwrap();
 
     // Swap the two lines above for these to drive the same wallet through an electrs server instead of bitcoind RPC.
-    //     use coinswap::wallet::{Electrum, ElectrumConfig};
+    //     use openswap::wallet::{Electrum, ElectrumConfig};
     //     let electrum_config = ElectrumConfig {
     //         url: "tcp://127.0.0.1:60401".to_string(),
     //     };
@@ -101,7 +101,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Wallet initialized successfully!");
 
     // Sync wallet first
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     println!("Wallet synced with blockchain");
 
     // Fund the wallet for demonstration
@@ -128,7 +128,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     // Sync wallet to see the new funds
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     println!("Wallet funded with {} BTC", fund_amount.to_btc());
 
     // Check balances and explain what each type means

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -1,7 +1,7 @@
 use std::{fs, net::TcpStream, path::PathBuf, time::Duration};
 
 use clap::Parser;
-use coinswap::{
+use openswap::{
     maker::{AuthenticatedRpcRequest, MakerError, RpcMsgReq, RpcMsgResp},
     utill::{get_maker_dir, read_message, send_message, MIN_FEE_RATE},
 };
@@ -10,9 +10,9 @@ use coinswap::{
 ///
 /// The app works as an RPC client for makerd, useful to access the server, retrieve information, and manage server operations.
 ///
-/// For more detailed usage information, please refer: <https://github.com/citadel-tech/coinswap/blob/master/docs/maker-cli.md>
+/// For more detailed usage information, please refer: <https://github.com/citadel-foss/openswap/blob/master/docs/maker-cli.md>
 ///
-/// This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-tech/coinswap/issues>
+/// This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-foss/openswap/issues>
 #[derive(Parser, Debug)]
 #[command(version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]

--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -1,6 +1,6 @@
 use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
-use coinswap::{
+use openswap::{
     lock_debug,
     maker::{bind_port_retry, start_server, MakerError, MakerServer, MakerServerConfig},
     utill::{parse_proxy_auth, print_new_wallet_seed, setup_maker_logger},
@@ -8,7 +8,7 @@ use coinswap::{
 };
 use std::{path::PathBuf, sync::Arc};
 
-/// Coinswap Maker Server
+/// OpenSwap Maker Server
 ///
 /// The server requires a Bitcoin Core RPC connection running in Testnet4. It requires some starting balance, around 50,000 sats for Fidelity + Swap Liquidity (suggested 50,000 sats).
 /// So topup with at least 0.001 BTC to start all the node processses. Suggested [faucet here]<https://mempool.space/testnet4/faucet>
@@ -18,14 +18,14 @@ use std::{path::PathBuf, sync::Arc};
 ///
 /// The server is operated with the maker-cli app, for all basic wallet related operations.
 ///
-/// For more detailed usage information, please refer the [Maker Doc]<https://github.com/citadel-tech/coinswap/blob/master/docs/makerd.md>
+/// For more detailed usage information, please refer the [Maker Doc]<https://github.com/citadel-foss/openswap/blob/master/docs/makerd.md>
 ///
-/// This is early beta, and there are known and unknown bugs. Please report issues in the [Project Issue Board]<https://github.com/citadel-tech/coinswap/issues>
+/// This is early beta, and there are known and unknown bugs. Please report issues in the [Project Issue Board]<https://github.com/citadel-foss/openswap/issues>
 #[derive(Parser, Debug)]
 #[clap(version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
 struct Cli {
-    /// Optional DNS data directory. Default value: "~/.coinswap/maker"
+    /// Optional DNS data directory. Default value: "~/.openswap/maker"
     #[clap(long, short = 'd')]
     data_directory: Option<PathBuf>,
     /// Bitcoin Core RPC network address.
@@ -81,7 +81,7 @@ fn main() -> Result<(), MakerError> {
 
     let data_dir = match args.data_directory {
         Some(dir) => dir,
-        None => coinswap::utill::get_maker_dir()?,
+        None => openswap::utill::get_maker_dir()?,
     };
 
     // Load static settings from config file (auto-creates defaults if missing)

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -1,7 +1,7 @@
 use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
-use coinswap::{
+use openswap::{
     lock_debug,
     protocol::ProtocolVersion,
     taker::{
@@ -15,22 +15,22 @@ use log::LevelFilter;
 use serde_json::{json, to_string_pretty};
 use std::{path::PathBuf, str::FromStr};
 
-/// A simple command line app to operate as coinswap client.
+/// A simple command line app to operate as openswap client.
 ///
-/// The app works as a regular Bitcoin wallet with the added capability to perform coinswaps.
+/// The app works as a regular Bitcoin wallet with the added capability to perform openswaps.
 /// It can talk to either a Bitcoin Core node (over RPC + ZMQ — the default) or an
 /// Electrum-protocol server (via `--electrum`). Both paths support the full swap flow
 /// and the `restore` subcommand. It currently only runs on Testnet4.
 /// Suggested faucet for getting Signet coins (tor browser required): <http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/>
 ///
-/// For more detailed usage information, please refer: <https://github.com/citadel-tech/coinswap/blob/master/docs/taker.md>
+/// For more detailed usage information, please refer: <https://github.com/citadel-foss/openswap/blob/master/docs/taker.md>
 ///
-/// This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-tech/coinswap/issues>
+/// This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-foss/openswap/issues>
 #[derive(Parser, Debug)]
 #[clap(version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
 struct Cli {
-    /// Optional data directory. Default value: "~/.coinswap/taker"
+    /// Optional data directory. Default value: "~/.openswap/taker"
     #[clap(long, short = 'd')]
     data_directory: Option<PathBuf>,
 
@@ -138,8 +138,8 @@ enum Commands {
         #[clap(long, short = 'm')]
         address: String,
     },
-    /// Initiate the coinswap process
-    Coinswap {
+    /// Initiate the openswap process
+    OpenSwap {
         /// Sets the Maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy.
         /// Adding more makers in the swap will incur more swap fees.
         #[clap(long, short = 'm', default_value = "2")]
@@ -322,7 +322,7 @@ fn main() -> Result<(), TakerError> {
                 | Commands::FetchOffers
                 | Commands::Backup { .. }
                 | Commands::Restore { .. }
-                | Commands::Coinswap { .. }
+                | Commands::OpenSwap { .. }
         ),
         args.data_directory.clone(), // default path handled inside the function.
     );
@@ -334,7 +334,7 @@ fn main() -> Result<(), TakerError> {
 
     let data_dir = match args.data_directory.clone() {
         Some(dir) => dir,
-        None => coinswap::utill::get_taker_dir()?,
+        None => openswap::utill::get_taker_dir()?,
     };
     // Static settings live in the file (auto-created with defaults if missing).
     // Read it here, before the backend bakes the proxy address in, so a
@@ -344,14 +344,14 @@ fn main() -> Result<(), TakerError> {
     // Build the unified taker config (also used by the Restore branch).
     // `--electrum` selects the Electrum backend; otherwise Bitcoin Core.
     let backend = match args.electrum_url.as_ref() {
-        Some(url) => coinswap::wallet::BackendConfig::Electrum(coinswap::wallet::ElectrumConfig {
+        Some(url) => openswap::wallet::BackendConfig::Electrum(openswap::wallet::ElectrumConfig {
             url: url.clone(),
             socks5: args
                 .electrum_tor
                 .then(|| format!("127.0.0.1:{}", file_config.socks_port)),
             ..Default::default()
         }),
-        None => coinswap::wallet::BackendConfig::CoreRpc(CoreRpcConfig {
+        None => openswap::wallet::BackendConfig::CoreRpc(CoreRpcConfig {
             url: args.rpc.clone(),
             auth: Auth::UserPass(args.auth.0.clone(), args.auth.1.clone()),
             wallet_name: wallet_name.clone(),
@@ -363,7 +363,7 @@ fn main() -> Result<(), TakerError> {
     };
 
     if let Commands::Restore { ref backup_file } = args.command {
-        coinswap::taker::Taker::restore_wallet(
+        openswap::taker::Taker::restore_wallet(
             args.data_directory,
             Some(wallet_name), // Use the actual translated wallet name here.
             backend,
@@ -404,7 +404,7 @@ fn main() -> Result<(), TakerError> {
     // Sync wallet after initialization
     lock_debug!(taker.get_wallet().write())
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)?;
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)?;
 
     match &args.command {
         Commands::ListUtxo => {
@@ -469,7 +469,7 @@ fn main() -> Result<(), TakerError> {
             let manually_selected_outpoints = {
                 let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
                 Some(
-                    coinswap::utill::interactive_select(wallet.list_all_utxo_spend_info(), amount)?
+                    openswap::utill::interactive_select(wallet.list_all_utxo_spend_info(), amount)?
                         .iter()
                         .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
                         .collect::<Vec<_>>(),
@@ -541,7 +541,7 @@ fn main() -> Result<(), TakerError> {
                 println!("No maker with address {address} in offerbook");
             }
         }
-        Commands::Coinswap {
+        Commands::OpenSwap {
             makers,
             amount,
             tx_count,
@@ -558,7 +558,7 @@ fn main() -> Result<(), TakerError> {
                 let target_amount = Amount::from_sat(*amount);
                 let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
                 Some(
-                    coinswap::utill::interactive_select(
+                    openswap::utill::interactive_select(
                         wallet.list_all_utxo_spend_info(),
                         target_amount,
                     )?
@@ -589,7 +589,7 @@ fn main() -> Result<(), TakerError> {
             }
 
             // Phase 1: Prepare — discover makers, negotiate, get fee summary.
-            let summary = taker.prepare_coinswap(swap_params)?;
+            let summary = taker.prepare_swap(swap_params)?;
 
             println!("\n========== Swap Summary ==========");
             println!("Swap ID:   {}", summary.swap_id);
@@ -622,7 +622,7 @@ fn main() -> Result<(), TakerError> {
                     payment.taker_funding_fee_estimate
                 );
                 println!(
-                    "Total coinswap cost: {}",
+                    "Total openswap cost: {}",
                     summary.send_amount + payment.taker_funding_fee_estimate
                 );
             } else {
@@ -649,7 +649,7 @@ fn main() -> Result<(), TakerError> {
                 }
             }
 
-            taker.start_coinswap(&summary.swap_id)?;
+            taker.start_swap(&summary.swap_id)?;
         }
         Commands::Recover => {
             taker.recover_active_swap()?;
@@ -663,7 +663,7 @@ fn main() -> Result<(), TakerError> {
             unreachable!()
         }
         Commands::VerifyDeniability { swap_id } => match taker.verify_deniability(swap_id) {
-            Ok(true) => println!("Proof valid: swap participated in a completed coinswap"),
+            Ok(true) => println!("Proof valid: swap participated in a completed openswap"),
             Ok(false) => println!("Proof invalid or not found for this swap ID"),
             Err(e) => println!("Error: {e}"),
         },

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -1,6 +1,7 @@
 use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::Auth;
 use clap::Parser;
+use log::LevelFilter;
 use openswap::{
     lock_debug,
     protocol::ProtocolVersion,
@@ -11,7 +12,6 @@ use openswap::{
     utill::{parse_proxy_auth, print_new_wallet_seed, setup_taker_logger, UTXO},
     wallet::{AddressType, CoreRpcConfig, Wallet},
 };
-use log::LevelFilter;
 use serde_json::{json, to_string_pretty};
 use std::{path::PathBuf, str::FromStr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ pub extern crate bitcoind;
 pub mod error;
 pub mod fee_estimation;
 pub mod maker;
-pub mod nostr;
-pub mod nostr_coinswap;
 pub mod protocol;
 pub mod security;
 pub mod taker;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -18,7 +18,7 @@ use bitcoin::{bip32::ChainCode, Amount, Network, OutPoint, PublicKey, Transactio
 
 use crate::{
     lock_debug,
-    nostr_coinswap::NOSTR_RELAYS,
+    maker::nostr::NOSTR_RELAYS,
     protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
     taker::api::REFUND_LOCKTIME_STEP,
     utill::{get_maker_dir, parse_field, parse_toml, MIN_FEE_RATE},
@@ -184,7 +184,7 @@ impl Default for MakerServerConfig {
 impl MakerServerConfig {
     /// Load configuration from a TOML file at the given path.
     ///
-    /// If `config_path` is `None`, defaults to `~/.coinswap/maker/config.toml`.
+    /// If `config_path` is `None`, defaults to `~/.openswap/maker/config.toml`.
     /// If the file doesn't exist or is empty, a default config file is created.
     /// Fields missing from the file fall back to defaults.
     pub fn new(config_path: Option<&Path>) -> Result<Self, WalletError> {
@@ -1705,7 +1705,7 @@ impl MakerTrait for MakerServer {
         Ok(hashvalue)
     }
 
-    fn initialize_coinswap(
+    fn initialize_openswap(
         &self,
         send_amount: Amount,
         next_multisig_pubkeys: &[PublicKey],
@@ -1716,7 +1716,7 @@ impl MakerTrait for MakerServer {
         excluded_outpoints: Option<Vec<OutPoint>>,
     ) -> Result<(Vec<Transaction>, Vec<OutgoingSwapCoin>, Amount), MakerError> {
         log::info!(
-            "[{}] Initializing coinswap: amount={} sats, {} pubkeys",
+            "[{}] Initializing openswap: amount={} sats, {} pubkeys",
             self.config.network_port,
             send_amount.to_sat(),
             next_multisig_pubkeys.len()
@@ -1725,9 +1725,9 @@ impl MakerTrait for MakerServer {
         let mut wallet = lock_debug!(self.wallet.write())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
-        let (coinswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = next_multisig_pubkeys
+        let (openswap_addresses, my_multisig_privkeys): (Vec<_>, Vec<_>) = next_multisig_pubkeys
             .iter()
-            .map(|other_key| wallet.create_and_import_coinswap_address(other_key))
+            .map(|other_key| wallet.create_and_import_swap_address(other_key))
             .collect::<Result<Vec<_>, _>>()
             .map_err(MakerError::Wallet)?
             .into_iter()
@@ -1736,7 +1736,7 @@ impl MakerTrait for MakerServer {
         let create_funding_txes_result = wallet
             .create_funding_txes(
                 send_amount,
-                &coinswap_addresses,
+                &openswap_addresses,
                 contract_feerate,
                 None,
                 excluded_outpoints,

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -366,9 +366,9 @@ pub trait Maker: Send + Sync {
         message: &crate::protocol::legacy_messages::ProofOfFunding,
     ) -> Result<crate::protocol::Hash160, MakerError>;
 
-    /// Initialize outgoing coinswap.
+    /// Initialize outgoing openswap.
     #[allow(clippy::too_many_arguments)]
-    fn initialize_coinswap(
+    fn initialize_openswap(
         &self,
         send_amount: Amount,
         next_multisig_pubkeys: &[PublicKey],

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -222,7 +222,7 @@ fn process_proof_of_funding<M: Maker>(
         "[CONTRACT_STATE] Role: Maker | Protocol: Legacy | SwapID: {} | ProofFundingTxs: {} | NextHopKeys: {} | RefundLocktime: {} | Status: verified",
         pof.id,
         pof.confirmed_funding_txes.len(),
-        pof.next_coinswap_info.len(),
+        pof.next_openswap_info.len(),
         pof.refund_locktime
     );
 
@@ -318,7 +318,7 @@ fn process_proof_of_funding<M: Maker>(
     // success reports match what was really earned.
     state.service_fee_sats = swap_fee.to_sat();
     let mining_fee =
-        Amount::from_sat(estimate_funding_tx_fee_sats() * pof.next_coinswap_info.len() as u64);
+        Amount::from_sat(estimate_funding_tx_fee_sats() * pof.next_openswap_info.len() as u64);
     let outgoing_amount = incoming_amount
         .checked_sub(swap_fee)
         .and_then(|amt| amt.checked_sub(mining_fee))
@@ -349,22 +349,22 @@ fn process_proof_of_funding<M: Maker>(
     maker.sync_and_save_wallet()?;
 
     let next_multisig_pubkeys: Vec<PublicKey> = pof
-        .next_coinswap_info
+        .next_openswap_info
         .iter()
         .map(|info| info.next_multisig_pubkey)
         .collect();
     let next_hashlock_pubkeys: Vec<PublicKey> = pof
-        .next_coinswap_info
+        .next_openswap_info
         .iter()
         .map(|info| info.next_hashlock_pubkey)
         .collect();
     let next_multisig_nonces: Vec<SecretKey> = pof
-        .next_coinswap_info
+        .next_openswap_info
         .iter()
         .map(|info| info.next_multisig_nonce)
         .collect();
     let next_hashlock_nonces: Vec<SecretKey> = pof
-        .next_coinswap_info
+        .next_openswap_info
         .iter()
         .map(|info| info.next_hashlock_nonce)
         .collect();
@@ -379,7 +379,7 @@ fn process_proof_of_funding<M: Maker>(
         );
     }
 
-    let (funding_txes, mut outgoing_swapcoins, _mining_fees) = maker.initialize_coinswap(
+    let (funding_txes, mut outgoing_swapcoins, _mining_fees) = maker.initialize_openswap(
         outgoing_amount,
         &next_multisig_pubkeys,
         &next_hashlock_pubkeys,

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -1,4 +1,4 @@
-//! The Coinswap Maker.
+//! The OpenSwap Maker.
 //!
 //! A Maker server that acts as a swap service provider.
 //! It can be run in an unix/mac system with local access to Bitcoin Core RPC.
@@ -20,6 +20,7 @@ mod taproot_verification;
 
 pub mod api;
 pub mod handlers;
+pub mod nostr;
 pub mod server;
 pub mod swap_tracker;
 

--- a/src/maker/nostr.rs
+++ b/src/maker/nostr.rs
@@ -3,7 +3,7 @@
 //! This module provides a minimal interface for publishing Maker-related
 //! events over the Nostr protocol. It is primarily used to broadcast
 //! fidelity bond information and other coordination signals required
-//! by the Coinswap protocol.
+//! by the OpenSwap protocol.
 
 #[cfg(not(feature = "integration-test"))]
 use std::io;
@@ -36,15 +36,15 @@ use crate::{
 #[cfg(not(feature = "integration-test"))]
 const NOSTR_SOCKS_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// nostr url for coinswap
+/// nostr url for openswap
 #[cfg(not(feature = "integration-test"))]
 pub const NOSTR_RELAYS: &[&str] = &["wss://nos.lol", "wss://relay.damus.io"];
-/// nostr url for coinswap
+/// nostr url for openswap
 #[cfg(feature = "integration-test")]
 pub const NOSTR_RELAYS: &[&str] = &["ws://127.0.0.1:8000"];
 
-/// Returns the Coinswap Nostr event kind for the given Bitcoin network.
-pub fn coinswap_kind(network: Network) -> u16 {
+/// Returns the OpenSwap Nostr event kind for the given Bitcoin network.
+pub fn swap_kind(network: Network) -> u16 {
     match network {
         Network::Bitcoin => 37778,
         Network::Signet => 37779,
@@ -122,8 +122,8 @@ pub fn broadcast_bond_on_nostr(
     }
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
-    let kind = coinswap_kind(config.network);
-    // Coinswap kinds are in the NIP-33 parameterized-replaceable range (30000..39999),
+    let kind = swap_kind(config.network);
+    // OpenSwap kinds are in the NIP-33 parameterized-replaceable range (30000..39999),
     // so included a stable `d` tag to keep relay handling spec-compliant.
     let d_tag = format!("fidelity:{}", content);
 

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -151,7 +151,7 @@ impl Display for RpcMsgResp {
             Self::ListBonds(v) => write!(f, "{v}"),
             Self::VerifyDeniabilityResp(valid) => {
                 if *valid {
-                    write!(f, "Proof valid: swap participated in a completed coinswap")
+                    write!(f, "Proof valid: swap participated in a completed openswap")
                 } else {
                     write!(f, "Proof invalid or not found for this swap ID")
                 }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -1,4 +1,4 @@
-//! Coinswap Maker Server.
+//! OpenSwap Maker Server.
 
 use std::{
     io::ErrorKind,
@@ -15,7 +15,7 @@ use std::{
 use crate::maker::rpc::server::MakerRpc;
 use crate::{
     lock_debug,
-    nostr_coinswap::broadcast_bond_on_nostr,
+    maker::nostr::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
     utill::{HEART_BEAT_INTERVAL, MAX_RPC_MESSAGE_SIZE},
     wallet::{Blockchain, RecoveryReport, Wallet},

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -1,4 +1,4 @@
-//! Common Coinswap Protocol Messages and Top-Level Message Enums.
+//! Common OpenSwap Protocol Messages and Top-Level Message Enums.
 
 use bitcoin::{bip32::ChainCode, hashes::sha256d::Hash, Amount, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -13,8 +13,8 @@ use super::{
 };
 use crate::wallet::FidelityBond;
 
-/// Well-known virtual port for the CoinSwap protocol over Tor.
-pub const COINSWAP_PORT: u16 = 21;
+/// Well-known virtual port for the OpenSwap protocol over Tor.
+pub const OPENSWAP_PORT: u16 = 21;
 
 /// Hash preimage type used in HTLC contracts.
 pub type Preimage = [u8; 32];
@@ -30,7 +30,7 @@ pub struct FidelityProof {
     pub cert_sig: bitcoin::secp256k1::ecdsa::Signature,
 }
 
-/// Protocol version identifier for coinswap operations.
+/// Protocol version identifier for openswap operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum ProtocolVersion {
     /// Legacy ECDSA-based protocol with script-evaluated HTLCs.

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -1,6 +1,6 @@
-//! Definition of the Coinswap Contract Transaction.
+//! Definition of the OpenSwap Contract Transaction.
 //!
-//! This module includes most of the fundamental functions defining the coinswap protocol.
+//! This module includes most of the fundamental functions defining the openswap protocol.
 
 use std::convert::TryInto;
 
@@ -54,7 +54,7 @@ const PUBKEY2_OFFSET: usize = PUBKEY1_OFFSET + PUBKEY_LENGTH + 1;
 /// Calculate the coin swap fee based on various parameters.
 /// swap_amount in sats, refund_locktime in blocks.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn calculate_coinswap_fee(
+pub(crate) fn calculate_swap_fee(
     // Should we consider value in Amount?
     swap_amount: u64,
     refund_locktime: u16,
@@ -202,7 +202,7 @@ pub(crate) fn check_hashlock_has_pubkey(
     }
 }
 
-/// Create a contract redeem script for a coinswap transaction.
+/// Create a contract redeem script for a openswap transaction.
 #[rustfmt::skip]
 pub(crate) fn create_contract_redeemscript(
     pub_hashlock: &PublicKey,
@@ -384,7 +384,7 @@ pub(crate) fn read_pubkeys_from_multisig_redeemscript(
 /// Virtual size charged for a legacy contract transaction.
 pub(crate) const CONTRACT_TX_VSIZE: u64 = 150;
 
-/// Create a Contract Transaction for the "Sender" side of Coinswap.
+/// Create a Contract Transaction for the "Sender" side of OpenSwap.
 /// The Sender gets the coins back via timelock.
 /// Receiver gets the coins via hashlock.
 pub(crate) fn create_senders_contract_tx(
@@ -1071,7 +1071,7 @@ mod test {
     }
 
     #[test]
-    fn calculate_coinswap_fee_normal() {
+    fn calculate_swap_fee_normal() {
         // Test with typical values
         let base_fee_sat = calculate_fee_sats(150);
         let amt_rel_fee_pct = 2.5;
@@ -1081,7 +1081,7 @@ mod test {
 
         let expected_fee = 4800;
 
-        let calculated_fee = calculate_coinswap_fee(
+        let calculated_fee = calculate_swap_fee(
             swap_amount,
             refund_locktime,
             base_fee_sat,
@@ -1093,19 +1093,19 @@ mod test {
 
         // Test with zero values
         assert_eq!(
-            calculate_coinswap_fee(swap_amount, refund_locktime, 0, 0.0, 0.0),
+            calculate_swap_fee(swap_amount, refund_locktime, 0, 0.0, 0.0),
             0
         );
 
         // Test with only the absolute fee being non-zero
         assert_eq!(
-            calculate_coinswap_fee(swap_amount, refund_locktime, base_fee_sat, 0.0, 0.0),
+            calculate_swap_fee(swap_amount, refund_locktime, base_fee_sat, 0.0, 0.0),
             300
         );
 
         // Test with only the relative fees being non-zero
         assert_eq!(
-            calculate_coinswap_fee(
+            calculate_swap_fee(
                 swap_amount,
                 refund_locktime,
                 0,
@@ -1262,7 +1262,7 @@ mod test {
 
         let funding_proof = ProofOfFunding {
             confirmed_funding_txes: vec![funding_info_1.clone()],
-            next_coinswap_info: vec![NextHopInfo {
+            next_openswap_info: vec![NextHopInfo {
                 next_hashlock_pubkey: pub_1,
                 next_multisig_pubkey: pub_2,
                 next_multisig_nonce: SecretKey::new(&mut thread_rng()),
@@ -1293,7 +1293,7 @@ mod test {
 
         let funding_proof = ProofOfFunding {
             confirmed_funding_txes: vec![funding_info_1, funding_info_2],
-            next_coinswap_info: vec![NextHopInfo {
+            next_openswap_info: vec![NextHopInfo {
                 next_hashlock_pubkey: pub_1,
                 next_multisig_pubkey: pub_2,
                 next_multisig_nonce: SecretKey::new(&mut thread_rng()),

--- a/src/protocol/legacy_messages.rs
+++ b/src/protocol/legacy_messages.rs
@@ -63,7 +63,7 @@ pub struct FundingTxInfo {
     pub hashlock_nonce: SecretKey,
 }
 
-/// Public key information for the next hop of a coinswap.
+/// Public key information for the next hop of a openswap.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NextHopInfo {
     /// Multisig pubkey for the next hop (derived from tweakable_point + nonce).
@@ -84,7 +84,7 @@ pub struct ProofOfFunding {
     /// Confirmed funding transactions with merkle proofs.
     pub confirmed_funding_txes: Vec<FundingTxInfo>,
     /// Information about the next hop (pubkeys for outgoing swap).
-    pub next_coinswap_info: Vec<NextHopInfo>,
+    pub next_openswap_info: Vec<NextHopInfo>,
     /// Refund locktime in blocks.
     pub refund_locktime: u16,
     /// Fee rate for contract transactions.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -30,7 +30,7 @@ use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 
 use crate::{
     lock_debug,
-    nostr_coinswap::NOSTR_RELAYS,
+    maker::nostr::NOSTR_RELAYS,
     protocol::{
         common_messages::{
             GetOffer, MakerToTakerMessage, Offer, PrivateKeyHandover, ProtocolVersion, SwapDetails,
@@ -229,7 +229,7 @@ pub struct SwapParams {
     pub preferred_makers: Option<Vec<String>>,
     /// (optional) PaySwap: settle the final incoming swapcoin to this
     /// third-party address. When set, `send_amount` is the exact amount the
-    /// receiver gets; the gross route amount is solved during `prepare_coinswap`.
+    /// receiver gets; the gross route amount is solved during `prepare_swap`.
     pub payment_address: Option<bitcoin::Address<bitcoin::address::NetworkUnchecked>>,
 }
 
@@ -305,7 +305,7 @@ pub struct MakerFeeInfo {
 /// Summary returned after the prepare phase, before the user commits funds.
 #[derive(Debug, Clone)]
 pub struct SwapSummary {
-    /// Unique swap ID (use this to call `start_coinswap`).
+    /// Unique swap ID (use this to call `start_swap`).
     pub swap_id: String,
     /// Protocol version.
     pub protocol: ProtocolVersion,
@@ -848,13 +848,13 @@ impl Taker {
         }
     }
 
-    /// Prepare a coinswap: discover makers, negotiate, and return a summary.
+    /// Prepare a openswap: discover makers, negotiate, and return a summary.
     ///
     /// No funds are committed. The caller reviews the summary and then calls
-    /// `start_coinswap` with the returned `swap_id` to execute.
-    pub fn prepare_coinswap(&mut self, params: SwapParams) -> Result<SwapSummary, TakerError> {
+    /// `start_swap` with the returned `swap_id` to execute.
+    pub fn prepare_swap(&mut self, params: SwapParams) -> Result<SwapSummary, TakerError> {
         log::info!(
-            "Preparing coinswap: amount={}, makers={}, protocol={:?}",
+            "Preparing openswap: amount={}, makers={}, protocol={:?}",
             params.send_amount,
             params.maker_count,
             params.protocol
@@ -888,7 +888,7 @@ impl Taker {
         OsRng.fill_bytes(&mut preimage);
 
         let swap_id = Hash160::hash(&preimage)[0..8].to_lower_hex_string();
-        log::info!("Preparing coinswap with id: {}", swap_id);
+        log::info!("Preparing openswap with id: {}", swap_id);
 
         let maker_count = params.maker_count;
 
@@ -1011,12 +1011,12 @@ impl Taker {
         Ok(summary)
     }
 
-    /// Execute a prepared coinswap. Call after reviewing the `SwapSummary`
-    /// from `prepare_coinswap`.
+    /// Execute a prepared openswap. Call after reviewing the `SwapSummary`
+    /// from `prepare_swap`.
     ///
     /// Commits funds on-chain: creates funding transactions, exchanges
     /// contracts with makers, finalizes, and sweeps.
-    pub fn start_coinswap(&mut self, swap_id: &str) -> Result<TakerReport, TakerError> {
+    pub fn start_swap(&mut self, swap_id: &str) -> Result<TakerReport, TakerError> {
         let swap_start_time = Instant::now();
 
         // Verify the swap_id matches the prepared swap.
@@ -1037,7 +1037,7 @@ impl Taker {
 
         let initial_utxos = self.read_wallet()?.list_all_utxo();
 
-        log::info!("Starting coinswap execution for id: {}", swap_id);
+        log::info!("Starting openswap execution for id: {}", swap_id);
 
         // Taproot has no breach case: its contract output cannot be spent
         // mid-swap — key-path needs both keys, the hashlock needs the
@@ -1287,7 +1287,7 @@ impl Taker {
             Some(&swept),
         )?;
 
-        log::info!("Coinswap completed successfully: {:?}", report);
+        log::info!("OpenSwap completed successfully: {:?}", report);
         Ok(report)
     }
 
@@ -2047,12 +2047,12 @@ impl Taker {
                 TakerError::General(format!("Failed to connect to {}: {}", address, e))
             })?,
             ConnectionType::Tor => {
-                use crate::protocol::common_messages::COINSWAP_PORT;
+                use crate::protocol::common_messages::OPENSWAP_PORT;
 
                 socks5_connect(
                     self.config.socks_port,
                     address,
-                    COINSWAP_PORT,
+                    OPENSWAP_PORT,
                     None,
                     timeout,
                 )

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -38,8 +38,8 @@ impl TakerConfig {
     ///
     /// For reference of default config checkout `./taker.toml` in repo folder.
     ///
-    /// Default data-dir for linux: `~/.coinswap/taker`
-    /// Default config locations: `~/.coinswap/taker/config.toml`.
+    /// Default data-dir for linux: `~/.openswap/taker`
+    /// Default config locations: `~/.openswap/taker/config.toml`.
     pub fn new(config_path: Option<&Path>) -> io::Result<Self> {
         let default_config_path = get_taker_dir()?.join("config.toml");
 

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -54,7 +54,7 @@ impl Taker {
         let secp = Secp256k1::new();
         let mut swapcoins = Vec::new();
         let mut contract_data = Vec::new();
-        let mut coinswap_addresses = Vec::new();
+        let mut openswap_addresses = Vec::new();
 
         for (multisig_pubkey, hashlock_pubkey) in
             multisig_pubkeys.iter().zip(hashlock_pubkeys.iter())
@@ -77,7 +77,7 @@ impl Taker {
                 &locktime,
             );
 
-            coinswap_addresses.push(bitcoin::Address::p2wsh(&multisig_redeemscript, network));
+            openswap_addresses.push(bitcoin::Address::p2wsh(&multisig_redeemscript, network));
             contract_data.push((
                 my_multisig_privkey,
                 *multisig_pubkey,
@@ -88,7 +88,7 @@ impl Taker {
 
         let funding_result = wallet.create_funding_txes(
             send_amount,
-            &coinswap_addresses,
+            &openswap_addresses,
             MIN_FEE_RATE,
             manually_selected_outpoints,
             None,
@@ -132,7 +132,7 @@ impl Taker {
         Ok(swapcoins)
     }
 
-    /// Execute the multi-hop Legacy coinswap flow.
+    /// Execute the multi-hop Legacy openswap flow.
     pub(crate) fn exchange_legacy(&mut self) -> Result<(), TakerError> {
         log::info!("Starting multi-hop Legacy swap with ProofOfFunding flow");
 
@@ -1155,7 +1155,7 @@ impl Taker {
             }
         }
 
-        let next_coinswap_info: Vec<NextHopInfo> = next_multisig_pubkeys
+        let next_openswap_info: Vec<NextHopInfo> = next_multisig_pubkeys
             .iter()
             .zip(next_hashlock_pubkeys.iter())
             .zip(next_multisig_nonces.iter())
@@ -1176,7 +1176,7 @@ impl Taker {
         let pof = ProofOfFunding {
             id: swap_id.to_string(),
             confirmed_funding_txes,
-            next_coinswap_info,
+            next_openswap_info,
             refund_locktime,
             contract_feerate: MIN_FEE_RATE,
         };

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -1,8 +1,8 @@
-//! Defines a Coinswap Taker Client.
+//! Defines a OpenSwap Taker Client.
 //!
 //! This also contains the entire swap workflow as major decision makings are involved for the Taker. Makers are
 //! simple request-response servers. The Taker handles all the necessary communications between one or many makers to route the swap across various makers. Description of
-//! protocol workflow is described in the [protocol between takers and makers](https://github.com/citadel-tech/Coinswap-Protocol-Specification/blob/main/v1/3_protocol-flow.md)
+//! protocol workflow is described in the [protocol between takers and makers](https://github.com/citadel-foss/OpenSwap-Protocol-Specification/blob/main/v1/3_protocol-flow.md)
 
 mod config;
 pub mod error;

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -1185,13 +1185,13 @@ impl MakerAddress {
         };
         #[cfg(not(feature = "integration-test"))]
         let mut socket = {
-            use crate::protocol::common_messages::COINSWAP_PORT;
+            use crate::protocol::common_messages::OPENSWAP_PORT;
 
             // Production: self.0 is a .onion hostname, connect via the Tor proxy
             socks5_connect(
                 socks_port,
                 &self.0,
-                COINSWAP_PORT,
+                OPENSWAP_PORT,
                 None,
                 Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC),
             )?

--- a/src/taker/payment.rs
+++ b/src/taker/payment.rs
@@ -141,7 +141,7 @@ fn solve_route_gross_sats(
 impl Taker {
     /// Validate the receiver address network and per-output dust floor.
     /// Returns the checked address, or `None` for regular swaps. Runs at the
-    /// top of `prepare_coinswap`, before any swap state exists; the checked
+    /// top of `prepare_swap`, before any swap state exists; the checked
     /// address then feeds [`Self::payment_prepare_route`].
     pub(crate) fn payment_validate_params(
         &self,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -104,9 +104,9 @@ fn get_home_dir() -> io::Result<PathBuf> {
     }
 }
 
-/// Get the default data directory. `~/.coinswap`.
+/// Get the default data directory. `~/.openswap`.
 fn get_data_dir() -> io::Result<PathBuf> {
-    Ok(get_home_dir()?.join(".coinswap"))
+    Ok(get_home_dir()?.join(".openswap"))
 }
 
 /// Get the Maker Directory
@@ -252,7 +252,7 @@ pub fn setup_maker_logger(filter: LevelFilter, data_dir: Option<PathBuf>) {
 
         let config = config
             .logger(Logger::builder().build("bitcoincore_rpc", LevelFilter::Off))
-            .logger(maker_logger.build("coinswap::maker", filter))
+            .logger(maker_logger.build("openswap::maker", filter))
             .build(Root::builder().appender("stdout").build(filter))
             .unwrap();
 
@@ -267,7 +267,7 @@ pub fn setup_maker_logger(filter: LevelFilter, data_dir: Option<PathBuf>) {
 /// Takes log level to set the desired logging verbosity
 pub fn setup_logger(filter: LevelFilter, data_dir: Option<PathBuf>) {
     Once::new().call_once(|| {
-        // env::set_var("RUST_LOG", "coinswap=info");
+        // env::set_var("RUST_LOG", "openswap=info");
         setup_taker_logger(filter, true, data_dir.as_ref().map(|d| d.join("taker")));
         setup_maker_logger(filter, data_dir.as_ref().map(|d| d.join("maker")));
     });
@@ -852,7 +852,7 @@ pub fn print_new_wallet_seed(mnemonic: &SecretMnemonic) -> io::Result<()> {
 
 /// Publish `local_port` as an ephemeral Tor onion service via `ADD_ONION`.
 ///
-/// The service listens on [`COINSWAP_PORT`](crate::protocol::common_messages::COINSWAP_PORT)
+/// The service listens on [`OPENSWAP_PORT`](crate::protocol::common_messages::OPENSWAP_PORT)
 /// and forwards to `127.0.0.1:local_port`. Pass `"NEW:ED25519-V3"` as
 /// `private_key_data` for a fresh key, or `"ED25519-V3:<base64>"` to reuse one.
 /// When `service_id_data` is set, that service is removed first.
@@ -868,7 +868,7 @@ pub fn get_ephemeral_address(
     private_key_data: &str,
     service_id_data: Option<&str>,
 ) -> Result<String, TorError> {
-    use crate::protocol::common_messages::COINSWAP_PORT;
+    use crate::protocol::common_messages::OPENSWAP_PORT;
     use std::io::BufRead;
     let mut stream = TcpStream::connect(format!("127.0.0.1:{control_port}"))?;
     let mut reader = BufReader::new(stream.try_clone()?);
@@ -882,7 +882,7 @@ pub fn get_ephemeral_address(
     }
 
     let add_onion_command = format!(
-        "ADD_ONION {private_key_data} Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n"
+        "ADD_ONION {private_key_data} Flags=Detach Port={OPENSWAP_PORT},127.0.0.1:{local_port}\r\n"
     );
 
     stream.write_all(add_onion_command.as_bytes())?;

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -243,7 +243,7 @@ pub enum UTXOSpendInfo {
 }
 
 impl UTXOSpendInfo {
-    /// Estimates Witness Size for different types of UTXOs in the context of Coinswap
+    /// Estimates Witness Size for different types of UTXOs in the context of OpenSwap
     pub fn estimate_witness_size(&self) -> usize {
         const P2WPKH_WITNESS_SIZE: usize = 107; // 1 + 72 (sig) + 33 (pubkey) + 1 (count)
         const P2TR_WITNESS_SIZE: usize = 66; // 1 (witness items) + 1 (Signature length) + 64 (Schnorr sig)
@@ -2651,7 +2651,7 @@ impl Wallet {
         }
     }
 
-    pub(crate) fn create_and_import_coinswap_address(
+    pub(crate) fn create_and_import_swap_address(
         &mut self,
         other_pubkey: &PublicKey,
     ) -> Result<(Address, SecretKey), WalletError> {

--- a/src/wallet/deniability.rs
+++ b/src/wallet/deniability.rs
@@ -133,7 +133,7 @@ impl std::error::Error for DeniabilityProofError {}
 /// SHA256 message signed to assert control of a swap contract outpoint.
 fn proof_message(protocol: ProtocolVersion, outpoint: OutPoint) -> secp256k1::Message {
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(b"coinswap-deniability-proof-v1");
+    bytes.extend_from_slice(b"openswap-deniability-proof-v1");
     bytes.extend_from_slice(format!("{protocol:?}").as_bytes());
     bytes.extend_from_slice(outpoint.to_string().as_bytes());
     secp256k1::Message::from_digest_slice(sha256::Hash::hash(&bytes).as_byte_array())

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -33,7 +33,7 @@ pub use super::report::{
 ///
 /// # Parameters
 ///
-/// - `data_dir`: Target directory, defaults to `~/.coinswap/taker`
+/// - `data_dir`: Target directory, defaults to `~/.openswap/taker`
 /// - `wallet_file_name`: Restored wallet filename, defaults to name from backup if empty
 /// - `backup_file_path`: Path to the JSON file containing the wallet backup (encrypted or plain)
 /// - `password`: Required if the backup is encrypted. Supplying a non-empty password

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -26,14 +26,14 @@ impl Wallet {
     /// Returns Ok(None) if there was no error but the wallet was unable to create funding txes
     pub fn create_funding_txes(
         &mut self,
-        coinswap_amount: Amount,
+        openswap_amount: Amount,
         destinations: &[Address],
         fee_rate: f64,
         manually_selected_outpoints: Option<Vec<OutPoint>>,
         excluded_outpoints: Option<Vec<OutPoint>>,
     ) -> Result<CreateFundingTxesResult, WalletError> {
         let ret = self.create_funding_txes_random_amounts(
-            coinswap_amount,
+            openswap_amount,
             destinations,
             fee_rate,
             manually_selected_outpoints,
@@ -46,14 +46,14 @@ impl Wallet {
 
         ret
 
-        // let ret = self.create_funding_txes_utxo_max_sends(coinswap_amount, destinations, fee_rate);
+        // let ret = self.create_funding_txes_utxo_max_sends(openswap_amount, destinations, fee_rate);
         // if ret.is_ok() {
         //     log::info!(target: "wallet", "created funding txes with fully-spending utxos");
         //     return ret;
         // }
 
         // let ret =
-        //     self.create_funding_txes_use_biggest_utxos(coinswap_amount, destinations, fee_rate);
+        //     self.create_funding_txes_use_biggest_utxos(openswap_amount, destinations, fee_rate);
         // if ret.is_ok() {
         //     log::info!(target: "wallet", "created funding txes with using the biggest utxos");
         //     return ret;
@@ -109,7 +109,7 @@ impl Wallet {
 
         //this calculation works like this:
         //o = [a, b, c, ...]             | list of output values
-        //t = coinswap amount            | total desired value
+        //t = openswap amount            | total desired value
         //a' <-- a + (t - (a+b+c+...))   | assign new first output value
         //a' <-- a + (t -a-b-c-...)      | rearrange
         //a' <-- t - b - c -...          |
@@ -131,16 +131,16 @@ impl Wallet {
     }
 
     // This function creates funding transactions with random amounts
-    // The total `coinswap_amount` is randomly distributed among number of destinations.
+    // The total `openswap_amount` is randomly distributed among number of destinations.
     fn create_funding_txes_random_amounts(
         &mut self,
-        coinswap_amount: Amount,
+        openswap_amount: Amount,
         destinations: &[Address],
         fee_rate: f64,
         manually_selected_outpoints: Option<Vec<OutPoint>>,
         excluded_outpoints: Option<Vec<OutPoint>>,
     ) -> Result<CreateFundingTxesResult, WalletError> {
-        let output_values = Wallet::generate_amount_fractions(destinations.len(), coinswap_amount)?;
+        let output_values = Wallet::generate_amount_fractions(destinations.len(), openswap_amount)?;
 
         // Flow of Lock Step 1. Unlock all unspent UTXOs
         self.unlock_all_utxos();
@@ -224,7 +224,7 @@ impl Wallet {
             log::debug!(
                 "[FUNDING_STATE] Source: wallet::funding::create_funding_txes_random_amounts | Wallet: {} | Amount: {} | Destinations: {} | FundingTxs: {} | MinerFee: {} | ManualUtxos: {} | ExcludedUtxos: {}",
                 self.get_name(),
-                coinswap_amount.to_sat(),
+                openswap_amount.to_sat(),
                 destinations.len(),
                 funding.funding_txes.len(),
                 funding.total_miner_fee,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1,4 +1,4 @@
-//! The Coinswap Wallet (unsecured). Used by both the Taker and Maker.
+//! The OpenSwap Wallet (unsecured). Used by both the Taker and Maker.
 
 mod api;
 mod backup;

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-//! Per-wallet swap report files for coinswap participants.
+//! Per-wallet swap report files for openswap participants.
 //!
 //! Reports are appended to the swap report file next to the wallet that
 //! participated in the swap:
@@ -832,7 +832,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let dir = std::env::temp_dir().join(format!(
-            "coinswap_report_{test_name}_{}_{}",
+            "openswap_report_{test_name}_{}_{}",
             std::process::id(),
             nonce
         ));

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -1215,7 +1215,7 @@ impl OutgoingSwapCoin {
 
 /// Watch-only view of a swap between two other parties.
 ///
-/// Used by the taker to monitor coinswaps between two makers.
+/// Used by the taker to monitor openswaps between two makers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WatchOnlySwapCoin {
     /// Protocol version for this swap coin.

--- a/src/watch_tower/mod.rs
+++ b/src/watch_tower/mod.rs
@@ -1,5 +1,6 @@
-//! Watch tower implementation for coinswap.
+//! Watch tower implementation for openswap.
 
+pub mod nostr;
 pub mod registry_storage;
 pub mod service;
 pub mod utils;

--- a/src/watch_tower/nostr.rs
+++ b/src/watch_tower/nostr.rs
@@ -1,7 +1,7 @@
 //! Nostr discovery module.
 //!
 //! Handles the discovery of Maker fidelity bonds via Nostr relays. It creates persistent
-//! subscriptions to network-specific CoinSwap events, validates incoming fidelity
+//! subscriptions to network-specific OpenSwap events, validates incoming fidelity
 //! announcements against the Bitcoin blockchain, and stores verified bonds in the registry.
 
 use std::{
@@ -25,7 +25,7 @@ use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
     lock_debug,
-    nostr_coinswap::{coinswap_kind, connect_nostr_websocket, EXPIRATION_SECS},
+    maker::nostr::{swap_kind, connect_nostr_websocket, EXPIRATION_SECS},
     wallet::{AnyBlockchain, Blockchain},
     watch_tower::{
         registry_storage::FileRegistry,
@@ -50,7 +50,7 @@ pub fn run_discovery(
     relays: &[String],
     nostr_tor_config: (u16, String),
 ) -> Result<(), WatcherError> {
-    let kind = Kind::Custom(coinswap_kind(network));
+    let kind = Kind::Custom(swap_kind(network));
     log::info!(
         "Starting market discovery via Nostr | network={} | kind={} | relays={:?}",
         network,

--- a/src/watch_tower/nostr.rs
+++ b/src/watch_tower/nostr.rs
@@ -25,7 +25,7 @@ use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
     lock_debug,
-    maker::nostr::{swap_kind, connect_nostr_websocket, EXPIRATION_SECS},
+    maker::nostr::{connect_nostr_websocket, swap_kind, EXPIRATION_SECS},
     wallet::{AnyBlockchain, Blockchain},
     watch_tower::{
         registry_storage::FileRegistry,

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -17,10 +17,10 @@ use bitcoin::{consensus::deserialize, Block, Network, OutPoint, ScriptBuf, Trans
 use crossbeam_channel::Sender as CbSender;
 
 use crate::{
-    nostr,
     utill::HEART_BEAT_INTERVAL,
     wallet::{blockchain::WatchEvent, AnyBlockchain, Blockchain},
     watch_tower::{
+        nostr,
         registry_storage::FileRegistry,
         utils::{process_block, process_transaction},
         watcher_error::WatcherError,

--- a/tests/integration/abort1.rs
+++ b/tests/integration/abort1.rs
@@ -5,11 +5,11 @@
 //! If the Taker doesn't return, the Makers broadcast the contract transactions and reclaim
 //! their funds via timelock.
 //!
-//! The Taker after coming live again will see unfinished coinswaps in its wallet.
+//! The Taker after coming live again will see unfinished openswaps in its wallet.
 //! It can reclaim funds via broadcasting contract transactions and claiming via timelock.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -80,14 +80,14 @@ fn taker_abort_1_legacy_corerpc() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     verify_maker_pre_swap_balances(&makers);
 
-    // Initiate Coinswap
-    info!("Initiating coinswap protocol");
+    // Initiate OpenSwap
+    info!("Initiating openswap protocol");
 
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
@@ -103,9 +103,9 @@ fn taker_abort_1_legacy_corerpc() {
 
     // Prepare should succeed; execution should fail with DropAfterFundsBroadcast
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to DropAfterFundsBroadcast behavior"
@@ -125,7 +125,7 @@ fn taker_abort_1_legacy_corerpc() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -163,7 +163,7 @@ fn taker_abort_1_legacy_corerpc() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -217,7 +217,7 @@ fn taker_abort_1_legacy_corerpc() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
 
@@ -330,7 +330,7 @@ fn maker_recovers_swap_past_refund_deadline() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -341,10 +341,10 @@ fn maker_recovers_swap_past_refund_deadline() {
         .with_tx_count(1)
         .with_required_confirms(1);
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Legacy prepare_coinswap should succeed");
+        .prepare_swap(swap_params)
+        .expect("Legacy prepare_swap should succeed");
     assert!(
-        taker.start_coinswap(&summary.swap_id).is_err(),
+        taker.start_swap(&summary.swap_id).is_err(),
         "The swap must fail once the maker gives up on it"
     );
 

--- a/tests/integration/abort2_case1.rs
+++ b/tests/integration/abort2_case1.rs
@@ -5,7 +5,7 @@
 //! The swap should succeed.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -75,13 +75,13 @@ fn maker_abort2_case1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -90,10 +90,10 @@ fn maker_abort2_case1() {
 
     // Prepare and execute the swap — taker should retry with the spare maker
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare openswap");
     taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect("Swap should succeed with spare maker");
 
     // Sync wallets and verify results
@@ -101,7 +101,7 @@ fn maker_abort2_case1() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     generate_blocks(bitcoind, 1);
@@ -111,7 +111,7 @@ fn maker_abort2_case1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 

--- a/tests/integration/abort2_case2.rs
+++ b/tests/integration/abort2_case2.rs
@@ -5,7 +5,7 @@
 //! The swap should succeed.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -75,13 +75,13 @@ fn maker_abort2_case2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -90,10 +90,10 @@ fn maker_abort2_case2() {
 
     // Prepare and execute the swap — taker should retry with the spare maker
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare openswap");
     taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect("Swap should succeed with spare maker");
 
     // Sync wallets and verify results
@@ -101,7 +101,7 @@ fn maker_abort2_case2() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     generate_blocks(bitcoind, 1);
@@ -111,7 +111,7 @@ fn maker_abort2_case2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 

--- a/tests/integration/abort2_case3.rs
+++ b/tests/integration/abort2_case3.rs
@@ -6,7 +6,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtProofOfFunding) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at ProofOfFunding.
 //! 4. Taker detects the failure and triggers recovery.
@@ -14,7 +14,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -85,7 +85,7 @@ fn maker_abort2_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -99,7 +99,7 @@ fn maker_abort2_case3() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -108,9 +108,9 @@ fn maker_abort2_case3() {
 
     // Prepare should succeed; execution should fail because Maker2 drops at ProofOfFunding
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at ProofOfFunding"
@@ -130,7 +130,7 @@ fn maker_abort2_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -169,7 +169,7 @@ fn maker_abort2_case3() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -223,7 +223,7 @@ fn maker_abort2_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/abort3_case1.rs
+++ b/tests/integration/abort3_case1.rs
@@ -6,7 +6,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtContractSigsForRecvrAndSender) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at RespContractSigsForRecvrAndSender.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -14,7 +14,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -89,7 +89,7 @@ fn maker_abort3_case1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -103,7 +103,7 @@ fn maker_abort3_case1() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -112,9 +112,9 @@ fn maker_abort3_case1() {
 
     // Prepare should succeed; execution should fail because Maker2 drops
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at RespContractSigsForRecvrAndSender"
@@ -134,7 +134,7 @@ fn maker_abort3_case1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -173,7 +173,7 @@ fn maker_abort3_case1() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -227,7 +227,7 @@ fn maker_abort3_case1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/abort3_case2.rs
+++ b/tests/integration/abort3_case2.rs
@@ -6,7 +6,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtContractSigsForRecvr) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at ReqContractSigsForRecvr.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -14,7 +14,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -89,7 +89,7 @@ fn maker_abort3_case2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -103,7 +103,7 @@ fn maker_abort3_case2() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -112,9 +112,9 @@ fn maker_abort3_case2() {
 
     // Prepare should succeed; execution should fail because Maker2 drops
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at ReqContractSigsForRecvr"
@@ -134,7 +134,7 @@ fn maker_abort3_case2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -173,7 +173,7 @@ fn maker_abort3_case2() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -227,7 +227,7 @@ fn maker_abort3_case2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let expected_regular = [14500865u64, 14503103][i];

--- a/tests/integration/abort3_case3.rs
+++ b/tests/integration/abort3_case3.rs
@@ -6,7 +6,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtHashPreimage) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at hash preimage handover.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -14,7 +14,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -86,7 +86,7 @@ fn maker_abort3_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -100,7 +100,7 @@ fn maker_abort3_case3() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -109,9 +109,9 @@ fn maker_abort3_case3() {
 
     // Prepare should succeed; execution should fail because Maker2 drops
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at hash preimage handover"
@@ -131,7 +131,7 @@ fn maker_abort3_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -170,7 +170,7 @@ fn maker_abort3_case3() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -224,7 +224,7 @@ fn maker_abort3_case3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let expected_regular = [14500865u64, 14503103][i];

--- a/tests/integration/concurrent_takers.rs
+++ b/tests/integration/concurrent_takers.rs
@@ -1,4 +1,4 @@
-//! Integration test for concurrent taker coinswap with limited maker liquidity.
+//! Integration test for concurrent taker openswap with limited maker liquidity.
 //!
 //! Setup: 2 takers with Normal behavior, 2 makers with Normal behavior.
 //! Both takers run swaps concurrently via `thread::scope`, once per protocol.
@@ -7,7 +7,7 @@
 //! This exercises the UTXO reservation mechanism that prevents double-spend.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -124,7 +124,7 @@ fn concurrent_takers(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -164,20 +164,20 @@ fn concurrent_takers(
         let r2 = &result2;
 
         s.spawn(move || {
-            info!("Taker 1 starting concurrent {:?} coinswap", protocol);
+            info!("Taker 1 starting concurrent {:?} openswap", protocol);
             let swap_params = SwapParams::new(protocol, Amount::from_sat(500000), 2)
                 .with_tx_count(3)
                 .with_required_confirms(1);
 
-            match taker1.prepare_coinswap(swap_params) {
-                Ok(summary) => match taker1.start_coinswap(&summary.swap_id) {
+            match taker1.prepare_swap(swap_params) {
+                Ok(summary) => match taker1.start_swap(&summary.swap_id) {
                     Ok(report) => {
-                        info!("Taker 1 {:?} coinswap completed successfully!", protocol);
+                        info!("Taker 1 {:?} openswap completed successfully!", protocol);
                         info!("Taker 1 swap report: {:?}", report);
                         r1.store(RESULT_SUCCESS, Relaxed);
                     }
                     Err(e) => {
-                        warn!("Taker 1 {:?} coinswap failed: {:?}", protocol, e);
+                        warn!("Taker 1 {:?} openswap failed: {:?}", protocol, e);
                         r1.store(RESULT_FAILED, Relaxed);
                     }
                 },
@@ -192,20 +192,20 @@ fn concurrent_takers(
         thread::sleep(Duration::from_secs(3));
 
         s.spawn(move || {
-            info!("Taker 2 starting concurrent {:?} coinswap", protocol);
+            info!("Taker 2 starting concurrent {:?} openswap", protocol);
             let swap_params = SwapParams::new(protocol, Amount::from_sat(900000), 2)
                 .with_tx_count(3)
                 .with_required_confirms(1);
 
-            match taker2.prepare_coinswap(swap_params) {
-                Ok(summary) => match taker2.start_coinswap(&summary.swap_id) {
+            match taker2.prepare_swap(swap_params) {
+                Ok(summary) => match taker2.start_swap(&summary.swap_id) {
                     Ok(report) => {
-                        info!("Taker 2 {:?} coinswap completed successfully!", protocol);
+                        info!("Taker 2 {:?} openswap completed successfully!", protocol);
                         info!("Taker 2 swap report: {:?}", report);
                         r2.store(RESULT_SUCCESS, Relaxed);
                     }
                     Err(e) => {
-                        warn!("Taker 2 {:?} coinswap failed: {:?}", protocol, e);
+                        warn!("Taker 2 {:?} openswap failed: {:?}", protocol, e);
                         r2.store(RESULT_FAILED, Relaxed);
                     }
                 },
@@ -217,7 +217,7 @@ fn concurrent_takers(
         });
     });
 
-    info!("All concurrent {:?} coinswaps processed.", protocol);
+    info!("All concurrent {:?} openswaps processed.", protocol);
 
     let r1 = result1.load(Relaxed);
     let r2 = result2.load(Relaxed);
@@ -244,7 +244,7 @@ fn concurrent_takers(
         "Both takers should have completed (success or failure)"
     );
 
-    log::info!("All coinswaps processed. Transactions complete.");
+    log::info!("All openswaps processed. Transactions complete.");
 
     // Sync all wallets
     for taker in takers.iter() {
@@ -252,7 +252,7 @@ fn concurrent_takers(
             .get_wallet()
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -260,7 +260,7 @@ fn concurrent_takers(
 
     for maker in makers.iter() {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     // ---- Verify balances ----

--- a/tests/integration/electrum_abort1.rs
+++ b/tests/integration/electrum_abort1.rs
@@ -14,11 +14,11 @@
 //! If the Taker doesn't return, the Makers broadcast the contract transactions and reclaim
 //! their funds via timelock.
 //!
-//! The Taker after coming live again will see unfinished coinswaps in its wallet.
+//! The Taker after coming live again will see unfinished openswaps in its wallet.
 //! It can reclaim funds via broadcasting contract transactions and claiming via timelock.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -123,14 +123,14 @@ pub(crate) fn run_abort1<B: TestBackend>(protocol: ProtocolVersion, expected: &E
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     verify_maker_pre_swap_balances(&makers);
 
-    // Initiate Coinswap
-    info!("Initiating coinswap protocol");
+    // Initiate OpenSwap
+    info!("Initiating openswap protocol");
 
     let swap_params = SwapParams::new(protocol, Amount::from_sat(500000), 2)
         .with_tx_count(3)
@@ -146,14 +146,14 @@ pub(crate) fn run_abort1<B: TestBackend>(protocol: ProtocolVersion, expected: &E
 
     // Prepare should succeed; execution should fail with DropAfterFundsBroadcast
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     let swap_error = swap_result.expect_err("Swap should fail due to test behavior");
     assert!(
         matches!(
             &swap_error,
-            coinswap::taker::error::TakerError::General(message)
+            openswap::taker::error::TakerError::General(message)
                 if message == "Test: dropped after contract exchange"
         ),
         "Swap failed before the injected abort: {:?}",
@@ -173,7 +173,7 @@ pub(crate) fn run_abort1<B: TestBackend>(protocol: ProtocolVersion, expected: &E
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -214,7 +214,7 @@ pub(crate) fn run_abort1<B: TestBackend>(protocol: ProtocolVersion, expected: &E
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -268,7 +268,7 @@ pub(crate) fn run_abort1<B: TestBackend>(protocol: ProtocolVersion, expected: &E
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
 
@@ -386,7 +386,7 @@ fn electrum_sweeps_after_breach() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -400,10 +400,10 @@ fn electrum_sweeps_after_breach() {
 
     let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
 
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail once the last maker closes"
@@ -423,7 +423,7 @@ fn electrum_sweeps_after_breach() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
     let swapcoins_left = taker
@@ -514,7 +514,7 @@ fn electrum_discards_only_on_confirmed_spend() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -526,10 +526,10 @@ fn electrum_discards_only_on_confirmed_spend() {
 
     let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
 
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail once the last maker closes"

--- a/tests/integration/electrum_list_transactions.rs
+++ b/tests/integration/electrum_list_transactions.rs
@@ -9,7 +9,7 @@ use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::{
     json::GetTransactionResultDetailCategory as Category, RpcApi as _,
 };
-use coinswap::{taker::TakerBehavior, utill::MIN_FEE_RATE, wallet::AddressType};
+use openswap::{taker::TakerBehavior, utill::MIN_FEE_RATE, wallet::AddressType};
 use log::info;
 
 use super::test_framework::*;
@@ -72,7 +72,7 @@ fn test_electrum_list_transactions() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     let txs = taker

--- a/tests/integration/electrum_list_transactions.rs
+++ b/tests/integration/electrum_list_transactions.rs
@@ -9,8 +9,8 @@ use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::{
     json::GetTransactionResultDetailCategory as Category, RpcApi as _,
 };
-use openswap::{taker::TakerBehavior, utill::MIN_FEE_RATE, wallet::AddressType};
 use log::info;
+use openswap::{taker::TakerBehavior, utill::MIN_FEE_RATE, wallet::AddressType};
 
 use super::test_framework::*;
 

--- a/tests/integration/electrum_swap.rs
+++ b/tests/integration/electrum_swap.rs
@@ -6,13 +6,13 @@
 
 use super::test_framework::*;
 use bitcoin::Amount;
+use log::info;
 use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
     wallet::AddressType,
 };
-use log::info;
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
 /// Exact post-swap balances for one protocol run. Legacy and taproot spend

--- a/tests/integration/electrum_swap.rs
+++ b/tests/integration/electrum_swap.rs
@@ -1,12 +1,12 @@
-//! Electrum-only coinswap tests.
+//! Electrum-only openswap tests.
 //!
 //! - The watch-tower uses `ElectrumNotifier` + `electrum_chain_name`/`electrum_block_count` instead of ZMQ + Bitcoin Core REST.
 //! - The offer-sync and Nostr discovery use `electrum_block_count`/`electrum_get_raw_tx`.
-//!   Bitcoind is still spawned because it is the source of regtest funds and mines blocks, but the coinswap code itself talks only to electrs.
+//!   Bitcoind is still spawned because it is the source of regtest funds and mines blocks, but the openswap code itself talks only to electrs.
 
 use super::test_framework::*;
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -44,10 +44,10 @@ const LEGACY_EXPECTED: ExpectedBalances = ExpectedBalances {
     maker_earnings: [451, 414],
 };
 
-/// Run an Electrum-only coinswap with the given protocol version and assert the
+/// Run an Electrum-only openswap with the given protocol version and assert the
 /// exact post-swap taker / maker balances.
 fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
-    info!("Running Test: Electrum Coinswap Procedure ({protocol:?})");
+    info!("Running Test: Electrum OpenSwap Procedure ({protocol:?})");
     let makers_config_map = vec![(6102, Some(19051)), (16102, Some(19052))];
     let taker_behavior = vec![TakerBehavior::Normal];
     let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
@@ -85,7 +85,7 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
@@ -95,8 +95,8 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
     generate_blocks(bitcoind, 1);
     // The taker's pre-swap sync must see the funding blocks, not a stale index.
     test_framework.wait_for_electrs_tip();
-    let summary = taker.prepare_coinswap(swap_params).unwrap();
-    taker.start_coinswap(&summary.swap_id).unwrap();
+    let summary = taker.prepare_swap(swap_params).unwrap();
+    taker.start_swap(&summary.swap_id).unwrap();
     // electrs indexes asynchronously; let it reach the tip before the
     // post-swap syncs so the asserted balances aren't computed from a
     // stale index.
@@ -105,7 +105,7 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     generate_blocks(bitcoind, 1);
     test_framework.wait_for_electrs_tip();
@@ -114,7 +114,7 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
@@ -202,7 +202,7 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
             "Maker {i} earnings mismatch"
         );
     }
-    info!("Electrum-only coinswap test ({protocol:?}) completed successfully!");
+    info!("Electrum-only openswap test ({protocol:?}) completed successfully!");
     drop(takers);
     makers
         .iter()
@@ -213,11 +213,11 @@ fn run_electrum_swap(protocol: ProtocolVersion, expected: &ExpectedBalances) {
 }
 
 #[test]
-fn test_taproot_coinswap_electrum() {
+fn test_taproot_openswap_electrum() {
     run_electrum_swap(ProtocolVersion::Taproot, &TAPROOT_EXPECTED);
 }
 
 #[test]
-fn test_legacy_coinswap_electrum() {
+fn test_legacy_openswap_electrum() {
     run_electrum_swap(ProtocolVersion::Legacy, &LEGACY_EXPECTED);
 }

--- a/tests/integration/electrum_tor.rs
+++ b/tests/integration/electrum_tor.rs
@@ -17,17 +17,17 @@
 //!
 //! An ephemeral onion service must upload its descriptor to the HSDir ring and
 //! the client must fetch it back, so these **cannot work offline**. They are
-//! `#[ignore]`d and additionally require `COINSWAP_TOR_IT=1`; without that
+//! `#[ignore]`d and additionally require `OPENSWAP_TOR_IT=1`; without that
 //! variable they skip, but with it set and Tor unreachable they deliberately
 //! panic — a misconfigured Tor must not pass silently. Run them with:
 //!
 //! ```text
-//! COINSWAP_TOR_IT=1 cargo test --features integration-test electrum_tor \
+//! OPENSWAP_TOR_IT=1 cargo test --features integration-test electrum_tor \
 //!     -- --ignored --test-threads=1 --nocapture
 //! ```
 //!
 //! `tor` must be listening on `TOR_CONTROL_PORT` / `TOR_SOCKS_PORT` and be fully
-//! bootstrapped. Set `COINSWAP_TOR_PASSWORD` if the control port needs one.
+//! bootstrapped. Set `OPENSWAP_TOR_PASSWORD` if the control port needs one.
 //!
 //! Ignored does not mean dead: no hermetic suite can reach the Tor network, so
 //! these stay opt-in by design. They are the only coverage of the watchtower
@@ -37,7 +37,7 @@
 //! test process. That is deliberate — the CI job's tor is ephemeral and drops
 //! them on restart.
 
-use coinswap::protocol::common_messages::ProtocolVersion;
+use openswap::protocol::common_messages::ProtocolVersion;
 
 use super::{
     electrum_abort1::{run_abort1, LEGACY_EXPECTED, TAPROOT_EXPECTED},
@@ -49,7 +49,7 @@ use log::warn;
 
 /// Taproot abort1 over Tor: the widest watchtower path in the suite.
 #[test]
-#[ignore = "requires a bootstrapped tor and COINSWAP_TOR_IT=1"]
+#[ignore = "requires a bootstrapped tor and OPENSWAP_TOR_IT=1"]
 fn tor_abort1_taproot() {
     if !tor_it_enabled() {
         return;
@@ -60,7 +60,7 @@ fn tor_abort1_taproot() {
 
 /// Legacy abort1 over Tor. Same cascade, different contract shape.
 #[test]
-#[ignore = "requires a bootstrapped tor and COINSWAP_TOR_IT=1"]
+#[ignore = "requires a bootstrapped tor and OPENSWAP_TOR_IT=1"]
 fn tor_abort1_legacy() {
     if !tor_it_enabled() {
         return;
@@ -71,7 +71,7 @@ fn tor_abort1_legacy() {
 
 /// Malicious contract broadcast over Tor, exercising the taker's breach detector.
 #[test]
-#[ignore = "requires a bootstrapped tor and COINSWAP_TOR_IT=1"]
+#[ignore = "requires a bootstrapped tor and OPENSWAP_TOR_IT=1"]
 fn tor_malice2() {
     if !tor_it_enabled() {
         return;

--- a/tests/integration/electrum_transport.rs
+++ b/tests/integration/electrum_transport.rs
@@ -19,7 +19,7 @@ use std::{
 
 use bitcoin::hashes::Hash;
 use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD};
-use coinswap::wallet::{Blockchain, Electrum, ElectrumConfig, WalletError};
+use openswap::wallet::{Blockchain, Electrum, ElectrumConfig, WalletError};
 
 use super::test_framework::{
     generate_blocks, init_bitcoind, init_electrsd, send_to_address, wait_for_electrs_tip,
@@ -133,7 +133,7 @@ struct Setup {
 }
 
 fn setup(name: &str) -> Setup {
-    let root_dir = std::env::temp_dir().join(format!("coinswap-transport-{}", std::process::id()));
+    let root_dir = std::env::temp_dir().join(format!("openswap-transport-{}", std::process::id()));
     let temp_dir = root_dir.join(name);
     std::fs::create_dir_all(&temp_dir).unwrap();
 

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -14,7 +14,7 @@
 
 use bitcoin::{absolute::LockTime, Amount};
 use bitcoind::bitcoincore_rpc::{Auth, RpcApi};
-use coinswap::{
+use openswap::{
     maker::start_server,
     taker::TakerBehavior,
     utill::MIN_FEE_RATE,
@@ -33,7 +33,7 @@ fn test_mempool_only_spend_reads_as_spent() {
     // Its own bitcoind: nothing mines in the background, so the spend cannot
     // confirm while the assertions run.
     let temp_dir =
-        std::env::temp_dir().join(format!("coinswap-mempool-spend-{}", std::process::id()));
+        std::env::temp_dir().join(format!("openswap-mempool-spend-{}", std::process::id()));
     std::fs::create_dir_all(&temp_dir).unwrap();
     // Ask the OS for the zmq port rather than guessing one in a range.
     let zmq_port = std::net::TcpListener::bind("127.0.0.1:0")
@@ -238,7 +238,7 @@ fn test_fidelity_creation() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let wallet_read = maker.wallet.read().unwrap();
 
@@ -310,7 +310,7 @@ fn test_fidelity_creation() {
         move || {
             let mut maker_write_wallet = maker.wallet.write().unwrap();
             maker_write_wallet
-                .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+                .sync_and_save(&openswap::utill::NO_SHUTDOWN)
                 .unwrap();
         }
     });
@@ -404,7 +404,7 @@ fn test_fidelity_spending() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Make fidelity bond expire
@@ -416,7 +416,7 @@ fn test_fidelity_spending() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Assert UTXO shows up in list and track the specific fidelity UTXO
@@ -528,7 +528,7 @@ fn test_fidelity_spending() {
                     .wallet
                     .write()
                     .unwrap()
-                    .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+                    .sync_and_save(&openswap::utill::NO_SHUTDOWN)
                     .unwrap();
                 log::info!("Regular transaction #{} completed successfully", i + 1);
             }
@@ -563,7 +563,7 @@ fn test_fidelity_spending() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify the specific UTXO is now consumed and bond is spent
@@ -635,7 +635,7 @@ fn test_fidelity_spending() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     {

--- a/tests/integration/fidelity_renewal.rs
+++ b/tests/integration/fidelity_renewal.rs
@@ -5,7 +5,7 @@
 
 use bitcoin::Amount;
 use bitcoind::bitcoincore_rpc::RpcApi;
-use coinswap::{maker::start_server, taker::TakerBehavior, wallet::AddressType};
+use openswap::{maker::start_server, taker::TakerBehavior, wallet::AddressType};
 
 use super::test_framework::*;
 
@@ -48,7 +48,7 @@ fn test_fidelity_auto_renewal() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let wallet_read = maker.wallet.read().unwrap();
 
@@ -126,7 +126,7 @@ fn test_fidelity_auto_renewal() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let wallet_read = maker.wallet.read().unwrap();
 

--- a/tests/integration/fidelity_timelock_violation.rs
+++ b/tests/integration/fidelity_timelock_violation.rs
@@ -5,7 +5,7 @@
 //! unacceptable block count, the Maker thus results an error saying "Invalid fidelity timelock".
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior, MakerError, MakerServer, MakerServerConfig},
     protocol::common_messages::ProtocolVersion,
     taker::{error::TakerError, SwapParams, TakerBehavior},
@@ -71,10 +71,10 @@ fn fidelity_limit_violation() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
-    info!("Initiating coinswap (Will fail due to invalid fidelity timelock)");
+    info!("Initiating openswap (Will fail due to invalid fidelity timelock)");
 
     // Swap params - small amount for faster testing
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 1)
@@ -83,14 +83,14 @@ fn fidelity_limit_violation() {
 
     // Prepare the swap - it will fail
     let err = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect_err("Swap should have failed due to NotEnoughMakersInOfferBook");
     assert!(
         matches!(err, TakerError::NotEnoughMakersInOfferBook),
         "Expected NotEnoughMakersInOfferBook, got: {:?}",
         err
     );
-    info!("Coinswap failed as expected: {err:?}");
+    info!("OpenSwap failed as expected: {err:?}");
 
     info!("Shutting down maker to simulate restart with corrupted config");
     maker.shutdown.store(true, Relaxed);

--- a/tests/integration/legacy_hashlock_recovery.rs
+++ b/tests/integration/legacy_hashlock_recovery.rs
@@ -11,7 +11,7 @@
 //! Legacy arm in `legacy_handlers.rs` was added alongside this test.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -93,9 +93,9 @@ fn test_legacy_hashlock_recovery() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing after sweep"

--- a/tests/integration/legacy_reboot_recovery.rs
+++ b/tests/integration/legacy_reboot_recovery.rs
@@ -4,7 +4,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtHashPreimage) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Maker2 broadcasts its funding transaction and persists unfinished swapcoins.
 //! 3. Maker2 closes at hash preimage / private key handover.
 //! 4. Maker2 is restarted before idle recovery can write a tracker record.
@@ -12,7 +12,7 @@
 //!    it cannot find a matching tracker record.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior, MakerServer},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -90,9 +90,9 @@ fn test_legacy_maker_reboot_recovery_preserves_funded_swapcoins() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at hash preimage handover"

--- a/tests/integration/maker_cli.rs
+++ b/tests/integration/maker_cli.rs
@@ -9,7 +9,7 @@
 //! something real to report.
 
 use bitcoin::{Address, Amount};
-use coinswap::{
+use openswap::{
     maker::{start_server, AuthenticatedRpcRequest, MakerBehavior, RpcMsgReq, RpcMsgResp},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -111,11 +111,11 @@ fn test_maker_rpc_server() {
         .with_required_confirms(1);
     generate_blocks(bitcoind, 1);
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
     taker
-        .start_coinswap(&summary.swap_id)
-        .expect("Coinswap should complete successfully");
+        .start_swap(&summary.swap_id)
+        .expect("OpenSwap should complete successfully");
     let swap_id = summary.swap_id.clone();
     info!("Swap {} completed, querying maker RPC", swap_id);
 

--- a/tests/integration/malice1.rs
+++ b/tests/integration/malice1.rs
@@ -1,14 +1,14 @@
 //! Malice test 1: Taker broadcasts contract transactions maliciously after full setup.
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Full setup completes (funding broadcast, contract sigs exchanged).
 //! 3. Taker broadcasts outgoing contract txs maliciously (BroadcastContractAfterFullSetup).
 //! 4. Swap fails. Makers detect the broadcast contracts and recover via timelock.
 //! 5. After recovery, verify: makers recovered funds (contract == 0, small fee loss).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -84,14 +84,14 @@ fn test_malice1_taker_broadcast_contract() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
     log::info!("Starting malice1 test...");
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -100,9 +100,9 @@ fn test_malice1_taker_broadcast_contract() {
 
     // Prepare should succeed; execution should fail with BroadcastContractAfterFullSetup
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to BroadcastContractAfterFullSetup behavior"
@@ -122,7 +122,7 @@ fn test_malice1_taker_broadcast_contract() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -186,7 +186,7 @@ fn test_malice1_taker_broadcast_contract() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance

--- a/tests/integration/malice2.rs
+++ b/tests/integration/malice2.rs
@@ -1,7 +1,7 @@
 //! Malice test 2: Maker broadcasts contract transactions maliciously after setup.
 //!
 //! Scenario:
-//! 1. Taker initiates a Legacy coinswap with 2 makers.
+//! 1. Taker initiates a Legacy openswap with 2 makers.
 //! 2. Maker[1] (second maker) broadcasts its outgoing contract txs after setup
 //!    and closes the connection (BroadcastContractAfterSetup behavior).
 //! 3. Taker detects the failure and triggers recovery (recover_active_swap).
@@ -17,7 +17,7 @@
 //! broadcasts then dies.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -105,7 +105,7 @@ fn run_malice2_with_taker_behavior<B: TestBackend>(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -118,7 +118,7 @@ fn run_malice2_with_taker_behavior<B: TestBackend>(
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(1)
         .with_required_confirms(1);
@@ -127,9 +127,9 @@ fn run_malice2_with_taker_behavior<B: TestBackend>(
 
     // Prepare should succeed; execution should fail because maker broadcasts contracts
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to maker BroadcastContractAfterSetup behavior"
@@ -155,7 +155,7 @@ fn run_malice2_with_taker_behavior<B: TestBackend>(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -208,7 +208,7 @@ fn run_malice2_with_taker_behavior<B: TestBackend>(
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance

--- a/tests/integration/mixed_protocol_concurrent_swaps.rs
+++ b/tests/integration/mixed_protocol_concurrent_swaps.rs
@@ -6,7 +6,7 @@
 //! maker-wide setting.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -70,7 +70,7 @@ fn test_concurrent_legacy_and_taproot_swaps() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     let maker_original_balances = verify_maker_pre_swap_balances(&makers);
@@ -95,8 +95,8 @@ fn test_concurrent_legacy_and_taproot_swaps() {
                 .with_tx_count(3)
                 .with_required_confirms(1);
             let result = legacy_taker
-                .prepare_coinswap(params)
-                .and_then(|summary| legacy_taker.start_coinswap(&summary.swap_id));
+                .prepare_swap(params)
+                .and_then(|summary| legacy_taker.start_swap(&summary.swap_id));
 
             match result {
                 Ok(report) => {
@@ -117,8 +117,8 @@ fn test_concurrent_legacy_and_taproot_swaps() {
                 .with_tx_count(3)
                 .with_required_confirms(1);
             let result = taproot_taker
-                .prepare_coinswap(params)
-                .and_then(|summary| taproot_taker.start_coinswap(&summary.swap_id));
+                .prepare_swap(params)
+                .and_then(|summary| taproot_taker.start_swap(&summary.swap_id));
 
             match result {
                 Ok(report) => {
@@ -152,7 +152,7 @@ fn test_concurrent_legacy_and_taproot_swaps() {
             .get_wallet()
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
 
@@ -213,7 +213,7 @@ fn test_concurrent_legacy_and_taproot_swaps() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let balances = maker.wallet.read().unwrap().get_balances().unwrap();
 

--- a/tests/integration/multi_confirm_swap.rs
+++ b/tests/integration/multi_confirm_swap.rs
@@ -9,7 +9,7 @@
 //! `taproot_swap.rs`) even though the keepalive message is shared.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -104,13 +104,13 @@ fn run_multi_confirm_swap(protocol: ProtocolVersion, makers_config_map: Vec<(u16
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare openswap");
     taker
-        .start_coinswap(&summary.swap_id)
-        .expect("Coinswap should complete successfully despite the longer funding wait");
+        .start_swap(&summary.swap_id)
+        .expect("OpenSwap should complete successfully despite the longer funding wait");
 
-    info!("Coinswap completed with required_confirms = {REQUIRED_CONFIRMS}");
+    info!("OpenSwap completed with required_confirms = {REQUIRED_CONFIRMS}");
 
     makers
         .iter()

--- a/tests/integration/multi_taker.rs
+++ b/tests/integration/multi_taker.rs
@@ -1,11 +1,11 @@
-//! Integration test for multi-taker concurrent coinswap.
+//! Integration test for multi-taker concurrent openswap.
 //!
 //! Setup: 2 takers with Normal behavior, 2 makers with Normal behavior.
 //! Protocol: Legacy (ECDSA), AddressType::P2TR.
 //! Both takers run swaps sequentially through the same pair of makers.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -18,9 +18,9 @@ use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
 #[test]
-fn test_multi_taker_coinswap() {
+fn test_multi_taker_openswap() {
     // ---- Setup ----
-    warn!("Running Test: Multi-Taker Coinswap with Legacy (ECDSA) Protocol");
+    warn!("Running Test: Multi-Taker OpenSwap with Legacy (ECDSA) Protocol");
 
     let makers_config_map = vec![(7602, Some(20601)), (17602, Some(20602))];
     let taker_behavior = vec![TakerBehavior::Normal, TakerBehavior::Normal];
@@ -85,7 +85,7 @@ fn test_multi_taker_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -102,18 +102,18 @@ fn test_multi_taker_coinswap() {
 
     let taker1 = &mut takers[0];
     let summary1 = taker1
-        .prepare_coinswap(swap_params1)
-        .expect("Failed to prepare Legacy coinswap for Taker 1");
+        .prepare_swap(swap_params1)
+        .expect("Failed to prepare Legacy openswap for Taker 1");
     log::info!("Taker 1 swap summary: {:?}", summary1);
 
-    match taker1.start_coinswap(&summary1.swap_id) {
+    match taker1.start_swap(&summary1.swap_id) {
         Ok(report) => {
-            log::info!("Taker 1 coinswap (Legacy) completed successfully!");
+            log::info!("Taker 1 openswap (Legacy) completed successfully!");
             log::info!("Taker 1 swap report: {:?}", report);
         }
         Err(e) => {
-            log::error!("Taker 1 coinswap (Legacy) failed: {:?}", e);
-            panic!("Taker 1 coinswap (Legacy) failed: {:?}", e);
+            log::error!("Taker 1 openswap (Legacy) failed: {:?}", e);
+            panic!("Taker 1 openswap (Legacy) failed: {:?}", e);
         }
     }
 
@@ -126,7 +126,7 @@ fn test_multi_taker_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -139,22 +139,22 @@ fn test_multi_taker_coinswap() {
 
     let taker2 = &mut takers[1];
     let summary2 = taker2
-        .prepare_coinswap(swap_params2)
-        .expect("Failed to prepare Legacy coinswap for Taker 2");
+        .prepare_swap(swap_params2)
+        .expect("Failed to prepare Legacy openswap for Taker 2");
     log::info!("Taker 2 swap summary: {:?}", summary2);
 
-    match taker2.start_coinswap(&summary2.swap_id) {
+    match taker2.start_swap(&summary2.swap_id) {
         Ok(report) => {
-            log::info!("Taker 2 coinswap (Legacy) completed successfully!");
+            log::info!("Taker 2 openswap (Legacy) completed successfully!");
             log::info!("Taker 2 swap report: {:?}", report);
         }
         Err(e) => {
-            log::error!("Taker 2 coinswap (Legacy) failed: {:?}", e);
-            panic!("Taker 2 coinswap (Legacy) failed: {:?}", e);
+            log::error!("Taker 2 openswap (Legacy) failed: {:?}", e);
+            panic!("Taker 2 openswap (Legacy) failed: {:?}", e);
         }
     }
 
-    log::info!("All coinswaps processed successfully. Transactions complete.");
+    log::info!("All openswaps processed successfully. Transactions complete.");
 
     // Sync all wallets
     for taker in takers.iter() {
@@ -162,7 +162,7 @@ fn test_multi_taker_coinswap() {
             .get_wallet()
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -170,7 +170,7 @@ fn test_multi_taker_coinswap() {
 
     for maker in makers.iter() {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     // ---- Verify Taker 1 ----

--- a/tests/integration/offerbook_restart.rs
+++ b/tests/integration/offerbook_restart.rs
@@ -16,7 +16,7 @@
 //!    the relay. A corrupted offerbook.json must be reset and rewritten.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     taker::{Taker, TakerBehavior},
     wallet::AddressType,

--- a/tests/integration/offerbook_sync_race.rs
+++ b/tests/integration/offerbook_sync_race.rs
@@ -1,7 +1,7 @@
 //! Stress and race-oriented tests for offerbook sync behavior (taker path).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     taker::{MakerProtocol, MakerState, TakerBehavior},
     wallet::AddressType,
@@ -16,7 +16,7 @@ use super::test_framework::*;
 
 const STAGED_MAKER_SETUP_TIMEOUT_SECS: u64 = 180;
 
-fn good_maker_count(taker: &coinswap::taker::Taker) -> usize {
+fn good_maker_count(taker: &openswap::taker::Taker) -> usize {
     taker
         .fetch_offers()
         .unwrap()

--- a/tests/integration/offerbook_sync_race.rs
+++ b/tests/integration/offerbook_sync_race.rs
@@ -1,12 +1,12 @@
 //! Stress and race-oriented tests for offerbook sync behavior (taker path).
 
 use bitcoin::Amount;
+use log::warn;
 use openswap::{
     maker::{start_server, MakerBehavior},
     taker::{MakerProtocol, MakerState, TakerBehavior},
     wallet::AddressType,
 };
-use log::warn;
 use std::{
     sync::{atomic::Ordering::Relaxed, Arc},
     thread,

--- a/tests/integration/payswap.rs
+++ b/tests/integration/payswap.rs
@@ -1,4 +1,4 @@
-//! PaySwap integration tests: settling a coinswap to a third-party receiver
+//! PaySwap integration tests: settling a openswap to a third-party receiver
 //! for an exact amount.
 //!
 //! The receiver is the regtest node's wallet — a genuine third party whose
@@ -8,7 +8,7 @@
 //! swapcoins (`tx_count > 1`).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -73,7 +73,7 @@ fn test_taproot_payswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     verify_maker_pre_swap_balances(&makers);
@@ -92,7 +92,7 @@ fn test_taproot_payswap() {
     let mainnet_address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
         .parse()
         .unwrap();
-    let wrong_network_result = taker.prepare_coinswap(
+    let wrong_network_result = taker.prepare_swap(
         SwapParams::new(ProtocolVersion::Taproot, payment_amount, 2)
             .with_tx_count(3)
             .with_required_confirms(1)
@@ -115,7 +115,7 @@ fn test_taproot_payswap() {
         .with_payment_address(receiver_address.as_unchecked().clone());
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Failed to prepare Taproot payment swap");
 
     let quote = summary
@@ -140,7 +140,7 @@ fn test_taproot_payswap() {
     );
 
     let report = taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect("Taproot payment swap should complete successfully");
 
     // ---- Verify the exact payment ----
@@ -182,7 +182,7 @@ fn test_taproot_payswap() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
     info!(
@@ -281,7 +281,7 @@ fn test_legacy_payswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     verify_maker_pre_swap_balances(&makers);
@@ -301,7 +301,7 @@ fn test_legacy_payswap() {
         .with_payment_address(receiver_address.as_unchecked().clone());
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Failed to prepare Legacy payment swap");
     let quote = summary
         .payment
@@ -320,7 +320,7 @@ fn test_legacy_payswap() {
     );
 
     let report = taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect("Legacy payment swap should complete successfully");
 
     // ---- Verify the exact payment ----
@@ -360,7 +360,7 @@ fn test_legacy_payswap() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();
     assert_eq!(
@@ -442,7 +442,7 @@ fn test_payswap_negotiation_guards_abort_before_funding() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -459,7 +459,7 @@ fn test_payswap_negotiation_guards_abort_before_funding() {
         .require_network(bitcoin::Network::Regtest)
         .unwrap();
     let negotiation_err = takers[0]
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, payment_amount, 1)
                 .with_required_confirms(1)
                 .with_preferred_makers(vec![failing_maker, spare_maker.clone()])
@@ -483,7 +483,7 @@ fn test_payswap_negotiation_guards_abort_before_funding() {
         .require_network(bitcoin::Network::Regtest)
         .unwrap();
     let repricing_err = takers[1]
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, payment_amount, 1)
                 .with_required_confirms(1)
                 .with_preferred_makers(vec![spare_maker])

--- a/tests/integration/reboot_recovery.rs
+++ b/tests/integration/reboot_recovery.rs
@@ -12,7 +12,7 @@
 //! merely because it cannot find a matching tracker record.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior, MakerServer},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, Taker, TakerBehavior},
@@ -96,7 +96,7 @@ fn run_reboot_recovery_with_watcher<B: TestBackend>(watcher_available: bool) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -107,9 +107,9 @@ fn run_reboot_recovery_with_watcher<B: TestBackend>(watcher_available: bool) {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at private key handover"
@@ -121,7 +121,7 @@ fn run_reboot_recovery_with_watcher<B: TestBackend>(watcher_available: bool) {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let before_outgoing = victim.wallet.read().unwrap().get_outgoing_swapcoins_count();
     let before_incoming = victim.wallet.read().unwrap().get_incoming_swapcoins_count();
@@ -323,7 +323,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -334,9 +334,9 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail because the taker crashes before finalization"
@@ -349,7 +349,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     assert!(
         taker
@@ -369,7 +369,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         assert!(
             maker.wallet.read().unwrap().get_incoming_swapcoins_count() > 0,
@@ -440,7 +440,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     assert_eq!(
         restarted
@@ -511,7 +511,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -532,7 +532,7 @@ pub(crate) fn run_restart_rebuilds_watches<B: TestBackend>(
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let taker_balances = restarted
         .get_wallet()

--- a/tests/integration/rejection.rs
+++ b/tests/integration/rejection.rs
@@ -15,7 +15,7 @@ use bitcoin::{
     Address, Amount, Network,
 };
 use bitcoind::bitcoincore_rpc::RpcApi;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior, MakerServer},
     protocol::common_messages::ProtocolVersion,
     taker::{error::TakerError, SwapParams, TakerBehavior},
@@ -111,7 +111,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
 
     // ---- 1. Below minimum, taker-side offerbook filter ----
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, below_min, 2)
                 .with_tx_count(1)
                 .with_required_confirms(1),
@@ -126,7 +126,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
 
     // ---- 2. Above maximum, taker-side offerbook filter ----
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, above_max, 2)
                 .with_tx_count(1)
                 .with_required_confirms(1),
@@ -141,7 +141,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
 
     // ---- 3. Below minimum, past the filter, caught at negotiation ----
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, below_min, 2)
                 .with_tx_count(1)
                 .with_required_confirms(1)
@@ -161,7 +161,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
 
     // ---- 4. Above maximum, past the filter, caught at negotiation ----
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, above_max, 2)
                 .with_tx_count(1)
                 .with_required_confirms(1)
@@ -182,12 +182,12 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
     // ---- 5. Taker aborts after maker selection, before negotiating ----
     taker.behavior = TakerBehavior::CloseEarly;
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
                 .with_tx_count(1)
                 .with_required_confirms(1),
         )
-        .expect_err("CloseEarly must abort prepare_coinswap");
+        .expect_err("CloseEarly must abort prepare_swap");
     info!("Taker closed early after maker selection: {:?}", err);
     taker.behavior = TakerBehavior::Normal;
 
@@ -196,7 +196,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
     // the amount only on the wire, so the maker guard is what must refuse.
     taker.behavior = TakerBehavior::ForgeBounds(below_min);
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
                 .with_tx_count(1)
                 .with_required_confirms(1)
@@ -208,7 +208,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
     // ---- 7. Forged above-maximum reaches the maker's own guard ----
     taker.behavior = TakerBehavior::ForgeBounds(above_max);
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
                 .with_tx_count(1)
                 .with_required_confirms(1)
@@ -222,7 +222,7 @@ fn test_maker_rejects_out_of_bounds_swap_details() {
     // error string it surfaces tells which arm the maker took for each.
     taker.behavior = TakerBehavior::ResendMutatedDetails;
     let err = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
                 .with_tx_count(1)
                 .with_required_confirms(1)
@@ -400,12 +400,12 @@ fn test_low_swap_liquidity() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     info!("Maker should be halted due to low swap liquidity");
 
-    info!("Initiating coinswap (Will fail due to maker not accepting any offer due to low swap liquidity)");
+    info!("Initiating openswap (Will fail due to maker not accepting any offer due to low swap liquidity)");
 
     // Swap params
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 1)
@@ -414,9 +414,9 @@ fn test_low_swap_liquidity() {
 
     // Attempt the swap - it will fail because maker has no liquidity
     let err = taker
-        .prepare_coinswap(swap_params.clone())
+        .prepare_swap(swap_params.clone())
         .expect_err("Swap should have failed due to insufficient maker liquidity");
-    info!("Coinswap failed as expected: {err:?}");
+    info!("OpenSwap failed as expected: {err:?}");
 
     info!("Adding sufficient funds to maker to perform a swap and avoid low swap liquidity");
     fund_makers(
@@ -441,16 +441,16 @@ fn test_low_swap_liquidity() {
         .with_required_confirms(1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed after funding");
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed after funding");
 
-    match taker.start_coinswap(&summary.swap_id) {
+    match taker.start_swap(&summary.swap_id) {
         Ok(_report) => {
-            log::info!("Coinswap completed successfully after re-funding!");
+            log::info!("OpenSwap completed successfully after re-funding!");
         }
         Err(e) => {
-            log::error!("Coinswap failed: {:?}", e);
-            panic!("Coinswap failed: {:?}", e);
+            log::error!("OpenSwap failed: {:?}", e);
+            panic!("OpenSwap failed: {:?}", e);
         }
     }
 
@@ -520,7 +520,7 @@ fn makers_reject_duplicate_funding_outpoints() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -531,10 +531,10 @@ fn makers_reject_duplicate_funding_outpoints() {
         .with_tx_count(3)
         .with_required_confirms(1);
     let taproot_summary = takers[0]
-        .prepare_coinswap(taproot_params)
-        .expect("Taproot prepare_coinswap should succeed");
+        .prepare_swap(taproot_params)
+        .expect("Taproot prepare_swap should succeed");
     assert!(
-        takers[0].start_coinswap(&taproot_summary.swap_id).is_err(),
+        takers[0].start_swap(&taproot_summary.swap_id).is_err(),
         "Taproot maker must reject a duplicated contract outpoint"
     );
 
@@ -606,7 +606,7 @@ fn run_legacy_proof_guard(port: u16, rpc: u16, behavior: TakerBehavior, expected
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -615,10 +615,10 @@ fn run_legacy_proof_guard(port: u16, rpc: u16, behavior: TakerBehavior, expected
         .with_tx_count(3)
         .with_required_confirms(1);
     let summary = taker
-        .prepare_coinswap(params)
-        .expect("prepare_coinswap should succeed");
+        .prepare_swap(params)
+        .expect("prepare_swap should succeed");
     assert!(
-        taker.start_coinswap(&summary.swap_id).is_err(),
+        taker.start_swap(&summary.swap_id).is_err(),
         "maker must reject the crafted ProofOfFunding"
     );
 
@@ -708,7 +708,7 @@ fn run_rejects_spent_funding_outpoint<B: TestBackend>(behavior: TakerBehavior) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -717,10 +717,10 @@ fn run_rejects_spent_funding_outpoint<B: TestBackend>(behavior: TakerBehavior) {
         .with_tx_count(3)
         .with_required_confirms(1);
     let summary = takers[0]
-        .prepare_coinswap(params)
-        .expect("Legacy prepare_coinswap should succeed");
+        .prepare_swap(params)
+        .expect("Legacy prepare_swap should succeed");
     assert!(
-        takers[0].start_coinswap(&summary.swap_id).is_err(),
+        takers[0].start_swap(&summary.swap_id).is_err(),
         "Legacy maker must reject an already spent funding outpoint"
     );
 
@@ -806,7 +806,7 @@ fn maker_errors_when_seen_funding_tx_is_evicted() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
     generate_blocks(bitcoind, 1);
@@ -815,7 +815,7 @@ fn maker_errors_when_seen_funding_tx_is_evicted() {
     // funding tx (which signals RBF) the moment the maker reports seeing it.
     let conflict_tx = {
         let mut wallet = taker.get_wallet().write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
         let coins = wallet.list_all_utxo_spend_info();
         let destination = wallet
             .get_next_internal_addresses(1, AddressType::P2TR)
@@ -834,8 +834,8 @@ fn maker_errors_when_seen_funding_tx_is_evicted() {
         .with_tx_count(1)
         .with_required_confirms(0);
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed");
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed");
 
     let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
 
@@ -843,7 +843,7 @@ fn maker_errors_when_seen_funding_tx_is_evicted() {
     // its confirmation wait until the conflict evicts the tx from the mempool.
     test_framework.set_block_gen_paused(true);
     let swap_result = thread::scope(|s| {
-        let swap_handle = s.spawn(|| taker.start_coinswap(&summary.swap_id));
+        let swap_handle = s.spawn(|| taker.start_swap(&summary.swap_id));
 
         wait_for_new_log(&log_path, "seen in mempool", Duration::from_secs(120));
         // Sent through bitcoind, not the taker's wallet, whose lock the swap
@@ -916,7 +916,7 @@ fn maker_rejects_proof_of_funding_with_missing_contract_cache() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -934,10 +934,10 @@ fn maker_rejects_proof_of_funding_with_missing_contract_cache() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed");
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed");
 
-    let result = taker.start_coinswap(&summary.swap_id);
+    let result = taker.start_swap(&summary.swap_id);
     assert!(
         result.is_err(),
         "maker must reject ProofOfFunding without a cached contract binding"
@@ -963,7 +963,7 @@ fn maker_rejects_proof_of_funding_with_missing_contract_cache() {
         .wallet
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
     let maker_spendable_after = makers[0]
         .wallet
@@ -1031,7 +1031,7 @@ fn test_taproot_maker_rejects_contract_amount_mismatch() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -1041,9 +1041,9 @@ fn test_taproot_maker_rejects_contract_amount_mismatch() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Taproot swap preparation should succeed before contract validation");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Taproot swap should fail when taker lies about contract amount"
@@ -1110,7 +1110,7 @@ fn test_legacy_taker_rejects_malformed_maker_funding_output() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -1120,12 +1120,12 @@ fn test_legacy_taker_rejects_malformed_maker_funding_output() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed");
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed");
 
     // The taker must reject before signing/finalizing; otherwise it can later
     // report success while the incoming sweep is unspendable.
-    let result = taker.start_coinswap(&summary.swap_id);
+    let result = taker.start_swap(&summary.swap_id);
     assert!(
         result.is_err(),
         "taker must reject malformed maker sender contract data"
@@ -1191,14 +1191,14 @@ fn test_legacy_taker_rejects_fee_skimming_maker() {
     wait_for_makers_setup(&makers, 120);
     generate_blocks(bitcoind, 1);
     let summary = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
                 .with_tx_count(3)
                 .with_required_confirms(1),
         )
         .expect("prepare Legacy swap");
     let error = taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect_err("reject fee skim");
     assert!(
         format!("{error:?}").contains("does not match expected"),
@@ -1270,13 +1270,13 @@ fn test_taproot_rejects_underfunded_maker_contract() {
         .with_tx_count(3)
         .with_required_confirms(1);
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("failed to prepare Taproot coinswap");
+        .prepare_swap(swap_params)
+        .expect("failed to prepare Taproot openswap");
 
     // The taker must reject during maker contract verification, before storing
     // an incoming swapcoin from the malicious contract data.
     let error = taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect_err("taker must reject maker contract data that claims more than the tx output");
     match error {
         TakerError::General(message) => {
@@ -1344,14 +1344,14 @@ fn test_taproot_rejection(behavior: MakerBehavior, expected_error: &str) {
     wait_for_makers_setup(&makers, 120);
     generate_blocks(bitcoind, 1);
     let summary = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(30_000), 1)
                 .with_tx_count(3)
                 .with_required_confirms(1),
         )
         .expect("prepare Taproot swap");
     let error = taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect_err("reject fee skim");
     assert!(
         format!("{error:?}").contains(expected_error),
@@ -1423,14 +1423,14 @@ fn test_maker_rejects_insufficient_liquidity_from_active_reservation() {
 
     let maker_addr = format!("127.0.0.1:{}", maker.config.network_port);
 
-    // Taker 0 admits a swap with the maker. prepare_coinswap only negotiates;
+    // Taker 0 admits a swap with the maker. prepare_swap only negotiates;
     // it does not fund, so the maker keeps an active reservation for the amount.
     let first = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(9_000_000), 1)
         .with_tx_count(1)
         .with_required_confirms(1)
         .with_preferred_makers(vec![maker_addr.clone()]);
     takers[0]
-        .prepare_coinswap(first)
+        .prepare_swap(first)
         .expect("first swap should be admitted and create a reservation");
 
     // Taker 1 asks for the same amount. The advertised max_size is still large
@@ -1440,7 +1440,7 @@ fn test_maker_rejects_insufficient_liquidity_from_active_reservation() {
         .with_required_confirms(1)
         .with_preferred_makers(vec![maker_addr]);
     let _err = takers[1]
-        .prepare_coinswap(second)
+        .prepare_swap(second)
         .expect_err("second swap should fail due to reserved liquidity");
 
     // The wire rejection is intentionally terse (AckSwapDetails::reject), so the

--- a/tests/integration/skip_funding_recovery.rs
+++ b/tests/integration/skip_funding_recovery.rs
@@ -5,7 +5,7 @@
 //! recovery is impossible since the funding is never on-chain).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -89,7 +89,7 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -103,7 +103,7 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Legacy)
+    // Swap params for openswap (Legacy)
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -112,9 +112,9 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
 
     // Prepare should succeed; execution should fail because Maker2 closes the connection
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 skipping funding broadcast"
@@ -145,7 +145,7 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -184,7 +184,7 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -229,7 +229,7 @@ fn run_legacy_timelock_only_recovery(stop_watcher: bool) {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];
@@ -348,7 +348,7 @@ fn test_taproot_timelock_only_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -362,7 +362,7 @@ fn test_taproot_timelock_only_recovery() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -371,9 +371,9 @@ fn test_taproot_timelock_only_recovery() {
 
     // Prepare should succeed; execution should fail because Maker2 closes the connection
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 skipping funding broadcast"
@@ -393,7 +393,7 @@ fn test_taproot_timelock_only_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -433,7 +433,7 @@ fn test_taproot_timelock_only_recovery() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -478,7 +478,7 @@ fn test_taproot_timelock_only_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/standard_swap.rs
+++ b/tests/integration/standard_swap.rs
@@ -1,9 +1,9 @@
-//! Standard coinswap test: normal swap between a Taker and 2 Makers.
-//! Nothing goes wrong and the coinswap completes successfully.
+//! Standard openswap test: normal swap between a Taker and 2 Makers.
+//! Nothing goes wrong and the openswap completes successfully.
 //! Also asserts a 3-hop request is rejected up front when only 2 makers exist.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{error::TakerError, SwapParams, TakerBehavior},
@@ -15,12 +15,12 @@ use super::test_framework::*;
 use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
-/// This test demonstrates a standard coinswap round between a Taker and 2 Makers. Nothing goes wrong
-/// and the coinswap completes successfully.
+/// This test demonstrates a standard openswap round between a Taker and 2 Makers. Nothing goes wrong
+/// and the openswap completes successfully.
 #[test]
-fn test_standard_coinswap() {
+fn test_standard_openswap() {
     // ---- Setup ----
-    warn!("Running Test: Standard Coinswap Procedure");
+    warn!("Running Test: Standard OpenSwap Procedure");
 
     let makers_config_map = vec![(6102, Some(19051)), (16102, Some(19052))];
     let taker_behavior = vec![TakerBehavior::Normal];
@@ -72,7 +72,7 @@ fn test_standard_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -84,16 +84,16 @@ fn test_standard_coinswap() {
         .with_tx_count(3)
         .with_required_confirms(1);
     let err = taker
-        .prepare_coinswap(too_many_hops)
-        .expect_err("prepare_coinswap must fail with only 2 makers for a 3-hop swap");
+        .prepare_swap(too_many_hops)
+        .expect_err("prepare_swap must fail with only 2 makers for a 3-hop swap");
     assert!(
         matches!(err, TakerError::NotEnoughMakersInOfferBook),
         "Expected NotEnoughMakersInOfferBook, got: {:?}",
         err
     );
 
-    // Initiate Coinswap
-    info!("Initiating coinswap protocol");
+    // Initiate OpenSwap
+    info!("Initiating openswap protocol");
 
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
         .with_tx_count(3)
@@ -102,20 +102,20 @@ fn test_standard_coinswap() {
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare openswap");
     taker
-        .start_coinswap(&summary.swap_id)
-        .expect("Coinswap should complete successfully");
+        .start_swap(&summary.swap_id)
+        .expect("OpenSwap should complete successfully");
 
-    info!("All coinswaps processed successfully. Transaction complete.");
+    info!("All openswaps processed successfully. Transaction complete.");
 
     // Sync wallets
     taker
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     generate_blocks(bitcoind, 1);
@@ -125,7 +125,7 @@ fn test_standard_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -176,7 +176,7 @@ fn test_standard_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let balances = maker.wallet.read().unwrap().get_balances().unwrap();
 
@@ -228,7 +228,7 @@ fn test_standard_coinswap() {
         );
     }
 
-    info!("Standard coinswap test completed successfully!");
+    info!("Standard openswap test completed successfully!");
 
     let temp_dir = makers[0]
         .data_dir

--- a/tests/integration/taker_cli.rs
+++ b/tests/integration/taker_cli.rs
@@ -25,7 +25,7 @@ impl TakerCli {
     /// Construct a new [`TakerCli`] struct that also includes initiating bitcoind.
     fn new() -> TakerCli {
         // Initiate the bitcoind backend — unique dir for parallel test safety.
-        let unique_id = format!("coinswap-cli-{}", bip39::rand::random::<u64>());
+        let unique_id = format!("openswap-cli-{}", bip39::rand::random::<u64>());
         let temp_dir = temp_dir().join(unique_id);
 
         // Remove if previously existing

--- a/tests/integration/taker_restart_recovery.rs
+++ b/tests/integration/taker_restart_recovery.rs
@@ -15,7 +15,7 @@
 //! 4. `recover_active_swap` must find the swap on disk and finish the job.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, Taker, TakerBehavior},
@@ -103,9 +103,9 @@ fn run_taker_restart_recovery(protocol: ProtocolVersion, last_maker: MakerBehavi
     generate_blocks(bitcoind, 1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail at the private key handover"

--- a/tests/integration/taproot_hashlock_recovery.rs
+++ b/tests/integration/taproot_hashlock_recovery.rs
@@ -3,7 +3,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAfterSweep) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection after completing its sweep.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -11,7 +11,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -83,7 +83,7 @@ fn test_taproot_hashlock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -97,7 +97,7 @@ fn test_taproot_hashlock_recovery() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -106,9 +106,9 @@ fn test_taproot_hashlock_recovery() {
 
     // Prepare should succeed; execution should fail because Maker2 drops after sweep
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing after sweep"
@@ -128,7 +128,7 @@ fn test_taproot_hashlock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -167,7 +167,7 @@ fn test_taproot_hashlock_recovery() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -220,7 +220,7 @@ fn test_taproot_hashlock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/taproot_maker_abort1.rs
+++ b/tests/integration/taproot_maker_abort1.rs
@@ -1,11 +1,11 @@
 //! Integration test: Taproot maker abort1 - Not enough makers.
 //!
 //! Only 1 maker is available, but the swap requires 2 makers (maker_count: 2).
-//! prepare_coinswap should FAIL because there are not enough makers.
+//! prepare_swap should FAIL because there are not enough makers.
 //! No recovery is needed - balances should remain unchanged.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -21,7 +21,7 @@ use std::{sync::atomic::Ordering::Relaxed, thread};
 ///
 /// Scenario:
 /// 1. Only 1 maker is available but swap requires 2 (maker_count: 2).
-/// 2. prepare_coinswap should fail because it cannot find enough makers.
+/// 2. prepare_swap should fail because it cannot find enough makers.
 /// 3. No funds are broadcast, so no recovery is needed.
 /// 4. Verify balances are unchanged.
 #[test]
@@ -80,7 +80,7 @@ fn test_taproot_maker_abort1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -94,11 +94,11 @@ fn test_taproot_maker_abort1() {
 
     generate_blocks(bitcoind, 1);
 
-    // prepare_coinswap should FAIL because only 1 maker is available for a 2-maker swap
-    let prepare_result = taker.prepare_coinswap(swap_params);
+    // prepare_swap should FAIL because only 1 maker is available for a 2-maker swap
+    let prepare_result = taker.prepare_swap(swap_params);
     assert!(
         prepare_result.is_err(),
-        "prepare_coinswap should fail because only 1 maker is available for a 2-maker swap"
+        "prepare_swap should fail because only 1 maker is available for a 2-maker swap"
     );
     info!(
         "Prepare failed as expected: {:?}",
@@ -110,7 +110,7 @@ fn test_taproot_maker_abort1() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();

--- a/tests/integration/taproot_maker_abort2.rs
+++ b/tests/integration/taproot_maker_abort2.rs
@@ -3,7 +3,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtPrivateKeyHandover) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at the private key handover phase.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -11,7 +11,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -86,7 +86,7 @@ fn test_taproot_maker_abort2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -100,7 +100,7 @@ fn test_taproot_maker_abort2() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -109,9 +109,9 @@ fn test_taproot_maker_abort2() {
 
     // Prepare should succeed; execution should fail because Maker2 drops at handover
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at private key handover"
@@ -131,7 +131,7 @@ fn test_taproot_maker_abort2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -170,7 +170,7 @@ fn test_taproot_maker_abort2() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -223,7 +223,7 @@ fn test_taproot_maker_abort2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/taproot_maker_abort3.rs
+++ b/tests/integration/taproot_maker_abort3.rs
@@ -6,7 +6,7 @@
 //! The swap should succeed.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -21,7 +21,7 @@ use std::{sync::atomic::Ordering::Relaxed, thread};
 /// Test: Maker drops after sending AckSwapDetails (Taproot). Taker finds spare maker.
 ///
 /// Scenario:
-/// 1. Taker initiates a Taproot coinswap requiring 2 makers, 3 are available.
+/// 1. Taker initiates a Taproot openswap requiring 2 makers, 3 are available.
 /// 2. maker[1] drops after sending AckSwapDetails (before funding broadcast).
 /// 3. Taker detects the failure and retries with the spare maker (maker[2]).
 /// 4. Swap completes successfully with maker[0] and maker[2].
@@ -85,13 +85,13 @@ fn test_taproot_maker_abort3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
 
-    // Swap params for coinswap (Taproot), requires 2 makers
+    // Swap params for openswap (Taproot), requires 2 makers
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -100,10 +100,10 @@ fn test_taproot_maker_abort3() {
 
     // Prepare and execute the swap -- taker should retry with the spare maker
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare Taproot coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare Taproot openswap");
     taker
-        .start_coinswap(&summary.swap_id)
+        .start_swap(&summary.swap_id)
         .expect("Swap should succeed with spare maker");
 
     // Sync wallets and verify results
@@ -111,7 +111,7 @@ fn test_taproot_maker_abort3() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     generate_blocks(bitcoind, 1);
@@ -121,7 +121,7 @@ fn test_taproot_maker_abort3() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 

--- a/tests/integration/taproot_maker_malice.rs
+++ b/tests/integration/taproot_maker_malice.rs
@@ -6,7 +6,7 @@
 //! stay locked on-chain while the taker never receives contract data.
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Maker[1] (second maker) broadcasts its contract tx after setup and
 //!    closes the connection (BroadcastContractAfterSetup behavior).
 //! 3. Taker detects the failure and triggers recovery (recover_active_swap).
@@ -14,7 +14,7 @@
 //! 5. Verify: taker and makers recovered funds (contract == 0, small fee loss).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -107,7 +107,7 @@ fn test_taproot_malice_maker_broadcast_contract() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(1)
         .with_required_confirms(1);
@@ -116,9 +116,9 @@ fn test_taproot_malice_maker_broadcast_contract() {
 
     // Prepare should succeed; execution should fail because maker broadcasts contracts
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to maker BroadcastContractAfterSetup behavior"

--- a/tests/integration/taproot_multi_maker.rs
+++ b/tests/integration/taproot_multi_maker.rs
@@ -1,11 +1,11 @@
-//! Integration test for multi-maker coinswap with Taproot protocol.
+//! Integration test for multi-maker openswap with Taproot protocol.
 //!
 //! Setup: 1 taker with Normal behavior, 4 makers with Normal behavior.
 //! Protocol: Taproot (MuSig2), AddressType::P2TR.
 //! The taker routes the swap through all 4 makers.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -18,9 +18,9 @@ use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
 #[test]
-fn test_taproot_multi_maker_coinswap() {
+fn test_taproot_multi_maker_openswap() {
     // ---- Setup ----
-    warn!("Running Test: Multi-Maker Coinswap with Taproot (MuSig2) Protocol - 4 Makers");
+    warn!("Running Test: Multi-Maker OpenSwap with Taproot (MuSig2) Protocol - 4 Makers");
 
     let makers_config_map = vec![
         (7802, Some(20801)),
@@ -78,14 +78,14 @@ fn test_taproot_multi_maker_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
     log::info!("Starting end-to-end swap test with Taproot protocol and 4 makers...");
 
-    // Swap params for coinswap (Taproot) with 4 makers
+    // Swap params for openswap (Taproot) with 4 makers
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 4)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -95,30 +95,30 @@ fn test_taproot_multi_maker_coinswap() {
 
     // Prepare the swap (negotiate with makers, get fee summary)
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare Taproot coinswap with 4 makers");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare Taproot openswap with 4 makers");
     log::info!("Swap summary: {:?}", summary);
 
     // Execute the swap
-    match taker.start_coinswap(&summary.swap_id) {
+    match taker.start_swap(&summary.swap_id) {
         Ok(report) => {
-            log::info!("Coinswap (Taproot, 4 makers) completed successfully!");
+            log::info!("OpenSwap (Taproot, 4 makers) completed successfully!");
             log::info!("Swap report: {:?}", report);
         }
         Err(e) => {
-            log::error!("Coinswap (Taproot, 4 makers) failed: {:?}", e);
-            panic!("Coinswap (Taproot, 4 makers) failed: {:?}", e);
+            log::error!("OpenSwap (Taproot, 4 makers) failed: {:?}", e);
+            panic!("OpenSwap (Taproot, 4 makers) failed: {:?}", e);
         }
     }
 
-    log::info!("All coinswaps processed successfully. Transaction complete.");
+    log::info!("All openswaps processed successfully. Transaction complete.");
 
     // Sync wallets and verify results
     taker
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Mine a block to confirm the sweep transactions
@@ -127,7 +127,7 @@ fn test_taproot_multi_maker_coinswap() {
     // Synchronize each maker's wallet
     for maker in makers.iter() {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     let taker_balances_after = taker.get_wallet().read().unwrap().get_balances().unwrap();

--- a/tests/integration/taproot_multi_taker.rs
+++ b/tests/integration/taproot_multi_taker.rs
@@ -1,11 +1,11 @@
-//! Integration test for multi-taker concurrent coinswap with Taproot protocol.
+//! Integration test for multi-taker concurrent openswap with Taproot protocol.
 //!
 //! Setup: 2 takers with Normal behavior, 2 makers with Normal behavior.
 //! Protocol: Taproot (MuSig2), AddressType::P2TR.
 //! Both takers run swaps sequentially through the same pair of makers.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -18,9 +18,9 @@ use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
 #[test]
-fn test_taproot_multi_taker_coinswap() {
+fn test_taproot_multi_taker_openswap() {
     // ---- Setup ----
-    warn!("Running Test: Multi-Taker Coinswap with Taproot (MuSig2) Protocol");
+    warn!("Running Test: Multi-Taker OpenSwap with Taproot (MuSig2) Protocol");
 
     let makers_config_map = vec![(7702, Some(20701)), (17702, Some(20702))];
     let taker_behavior = vec![TakerBehavior::Normal, TakerBehavior::Normal];
@@ -85,7 +85,7 @@ fn test_taproot_multi_taker_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -102,18 +102,18 @@ fn test_taproot_multi_taker_coinswap() {
 
     let taker1 = &mut takers[0];
     let summary1 = taker1
-        .prepare_coinswap(swap_params1)
-        .expect("Failed to prepare Taproot coinswap for Taker 1");
+        .prepare_swap(swap_params1)
+        .expect("Failed to prepare Taproot openswap for Taker 1");
     log::info!("Taker 1 swap summary: {:?}", summary1);
 
-    match taker1.start_coinswap(&summary1.swap_id) {
+    match taker1.start_swap(&summary1.swap_id) {
         Ok(report) => {
-            log::info!("Taker 1 coinswap (Taproot) completed successfully!");
+            log::info!("Taker 1 openswap (Taproot) completed successfully!");
             log::info!("Taker 1 swap report: {:?}", report);
         }
         Err(e) => {
-            log::error!("Taker 1 coinswap (Taproot) failed: {:?}", e);
-            panic!("Taker 1 coinswap (Taproot) failed: {:?}", e);
+            log::error!("Taker 1 openswap (Taproot) failed: {:?}", e);
+            panic!("Taker 1 openswap (Taproot) failed: {:?}", e);
         }
     }
 
@@ -126,7 +126,7 @@ fn test_taproot_multi_taker_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -139,22 +139,22 @@ fn test_taproot_multi_taker_coinswap() {
 
     let taker2 = &mut takers[1];
     let summary2 = taker2
-        .prepare_coinswap(swap_params2)
-        .expect("Failed to prepare Taproot coinswap for Taker 2");
+        .prepare_swap(swap_params2)
+        .expect("Failed to prepare Taproot openswap for Taker 2");
     log::info!("Taker 2 swap summary: {:?}", summary2);
 
-    match taker2.start_coinswap(&summary2.swap_id) {
+    match taker2.start_swap(&summary2.swap_id) {
         Ok(report) => {
-            log::info!("Taker 2 coinswap (Taproot) completed successfully!");
+            log::info!("Taker 2 openswap (Taproot) completed successfully!");
             log::info!("Taker 2 swap report: {:?}", report);
         }
         Err(e) => {
-            log::error!("Taker 2 coinswap (Taproot) failed: {:?}", e);
-            panic!("Taker 2 coinswap (Taproot) failed: {:?}", e);
+            log::error!("Taker 2 openswap (Taproot) failed: {:?}", e);
+            panic!("Taker 2 openswap (Taproot) failed: {:?}", e);
         }
     }
 
-    log::info!("All coinswaps processed successfully. Transactions complete.");
+    log::info!("All openswaps processed successfully. Transactions complete.");
 
     // Sync all wallets
     for taker in takers.iter() {
@@ -162,7 +162,7 @@ fn test_taproot_multi_taker_coinswap() {
             .get_wallet()
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -170,7 +170,7 @@ fn test_taproot_multi_taker_coinswap() {
 
     for maker in makers.iter() {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     // ---- Verify Taker 1 ----

--- a/tests/integration/taproot_swap.rs
+++ b/tests/integration/taproot_swap.rs
@@ -1,10 +1,10 @@
-//! Integration test for Taproot Coinswap implementation.
+//! Integration test for Taproot OpenSwap implementation.
 //!
-//! This test demonstrates a taproot-based coinswap between a Taker and 2 Makers using
+//! This test demonstrates a taproot-based openswap between a Taker and 2 Makers using
 //! the Taproot protocol with MuSig2 signatures.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -16,11 +16,11 @@ use super::test_framework::*;
 use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread};
 
-/// Test taproot coinswap
+/// Test taproot openswap
 #[test]
-fn test_taproot_coinswap() {
+fn test_taproot_openswap() {
     // ---- Setup ----
-    warn!("Running Test: Taproot Coinswap Basic Functionality");
+    warn!("Running Test: Taproot OpenSwap Basic Functionality");
 
     let makers_config_map = vec![(7102, Some(19061)), (17102, Some(19062))];
     let taker_behavior = vec![TakerBehavior::Normal];
@@ -72,14 +72,14 @@ fn test_taproot_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
     log::info!("Starting end-to-end taproot swap test...");
 
-    // Swap params for taproot coinswap
+    // Swap params for taproot openswap
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -89,19 +89,19 @@ fn test_taproot_coinswap() {
 
     // Prepare and execute the swap
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("Failed to prepare Taproot coinswap");
+        .prepare_swap(swap_params)
+        .expect("Failed to prepare Taproot openswap");
     taker
-        .start_coinswap(&summary.swap_id)
-        .expect("Taproot coinswap should complete successfully");
-    log::info!("Taproot coinswap completed successfully!");
+        .start_swap(&summary.swap_id)
+        .expect("Taproot openswap should complete successfully");
+    log::info!("Taproot openswap completed successfully!");
 
     // Sync wallets and verify results
     taker
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Mine a block to confirm the sweep transactions
@@ -112,7 +112,7 @@ fn test_taproot_coinswap() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 

--- a/tests/integration/taproot_taker_abort1.rs
+++ b/tests/integration/taproot_taker_abort1.rs
@@ -1,7 +1,7 @@
 //! Taproot taker abort test 1: Taker closes at AckSwapDetails response.
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Taker closes the connection immediately after receiving AckSwapDetails
 //!    from a maker (CloseAtAckResponse behavior).
 //! 3. This is an early abort -- no funding transactions are broadcast.
@@ -9,7 +9,7 @@
 //! 5. Verify: taker balance is approximately unchanged (no fund loss).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -81,14 +81,14 @@ fn test_taproot_taker_abort1() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
     let _maker_spendable_balance = verify_maker_pre_swap_balances(&makers);
     log::info!("Starting taproot taker abort1 test...");
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -97,7 +97,7 @@ fn test_taproot_taker_abort1() {
 
     // Prepare should fail at AckResponse — the taker closes the connection
     // right after receiving AckSwapDetails, before any funding is broadcast.
-    let prepare_result = taker.prepare_coinswap(swap_params.clone());
+    let prepare_result = taker.prepare_swap(swap_params.clone());
     assert!(
         prepare_result.is_err(),
         "Prepare should fail due to CloseAtAckResponse behavior"
@@ -132,7 +132,7 @@ fn test_taproot_taker_abort1() {
     // AckSwapDetails after storing a new reservation, and the taker only emits
     // the CloseAtAckResponse test error after receiving that ack — so hitting
     // that exact error proves the makers accepted the retry.
-    let retry_result = taker.prepare_coinswap(swap_params);
+    let retry_result = taker.prepare_swap(swap_params);
     let retry_err = format!(
         "{:?}",
         retry_result.expect_err("Retry should still abort at AckSwapDetails")
@@ -154,7 +154,7 @@ fn test_taproot_taker_abort1() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();

--- a/tests/integration/taproot_taker_abort2.rs
+++ b/tests/integration/taproot_taker_abort2.rs
@@ -1,7 +1,7 @@
 //! Taproot taker abort test 2: Taker closes at sender's contract exchange.
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Taker drops during the contract exchange phase, specifically when
 //!    sending the sender's contract data (CloseAtSendersContract behavior).
 //! 3. Funding transactions have been broadcast at this point.
@@ -9,7 +9,7 @@
 //! 5. Verify: all parties recovered funds (contract == 0, small fee loss).
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -85,7 +85,7 @@ fn test_taproot_taker_abort2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -98,7 +98,7 @@ fn test_taproot_taker_abort2() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -107,9 +107,9 @@ fn test_taproot_taker_abort2() {
 
     // Prepare should succeed; execution should fail at sender's contract exchange
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to CloseAtSendersContract behavior"
@@ -129,7 +129,7 @@ fn test_taproot_taker_abort2() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -181,7 +181,7 @@ fn test_taproot_taker_abort2() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance

--- a/tests/integration/taproot_taker_abort3.rs
+++ b/tests/integration/taproot_taker_abort3.rs
@@ -15,7 +15,7 @@
 //! Both cases force timelock recovery for every party and share one runner.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -123,7 +123,7 @@ fn run_taproot_taker_abort(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -142,9 +142,9 @@ fn run_taproot_taker_abort(
 
     // Prepare should succeed; execution should fail at the case's drop point.
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to {:?} behavior",
@@ -166,7 +166,7 @@ fn run_taproot_taker_abort(
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -227,7 +227,7 @@ fn run_taproot_taker_abort(
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     let taker_balances = taker.get_wallet().read().unwrap().get_balances().unwrap();

--- a/tests/integration/taproot_timelock_recovery.rs
+++ b/tests/integration/taproot_timelock_recovery.rs
@@ -3,7 +3,7 @@
 //! Route: Taker -> Maker1 (Normal) -> Maker2 (CloseAtContractSigsExchange) -> Taker
 //!
 //! Scenario:
-//! 1. Taker initiates a Taproot coinswap with 2 makers.
+//! 1. Taker initiates a Taproot openswap with 2 makers.
 //! 2. Funding transactions are broadcast and confirmed.
 //! 3. Maker2 drops the connection at the taproot contract sigs exchange phase.
 //! 4. Taker detects the failure and calls `recover_active_swap()`.
@@ -11,7 +11,7 @@
 //! 6. After blocks mature, verify: taker recovered funds (minus fees), no contract balance.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -86,7 +86,7 @@ fn test_taproot_timelock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
     }
 
@@ -100,7 +100,7 @@ fn test_taproot_timelock_recovery() {
         Duration::from_secs(10),
     );
 
-    // Swap params for coinswap (Taproot)
+    // Swap params for openswap (Taproot)
     let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
         .with_tx_count(3)
         .with_required_confirms(1);
@@ -109,9 +109,9 @@ fn test_taproot_timelock_recovery() {
 
     // Prepare should succeed; execution should fail because Maker2 drops at contract sigs exchange
     let summary = taker
-        .prepare_coinswap(swap_params)
+        .prepare_swap(swap_params)
         .expect("Prepare should succeed");
-    let swap_result = taker.start_coinswap(&summary.swap_id);
+    let swap_result = taker.start_swap(&summary.swap_id);
     assert!(
         swap_result.is_err(),
         "Swap should fail due to Maker2 closing at contract sigs exchange"
@@ -131,7 +131,7 @@ fn test_taproot_timelock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         info!(
@@ -170,7 +170,7 @@ fn test_taproot_timelock_recovery() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     // Verify taker balance
@@ -224,7 +224,7 @@ fn test_taproot_timelock_recovery() {
             .wallet
             .write()
             .unwrap()
-            .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
             .unwrap();
         let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
         let original = maker_spendable_balance[i];

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -1,4 +1,4 @@
-//! A Framework to write functional tests for the Coinswap Protocol.
+//! A Framework to write functional tests for the OpenSwap Protocol.
 //!
 //! This framework uses [bitcoind] to automatically spawn regtest node in the background.
 //!
@@ -35,9 +35,9 @@ use bitcoind::{
     BitcoinD,
 };
 
-use coinswap::{
+use openswap::{
     maker::{MakerBehavior, MakerServer, MakerServerConfig},
-    protocol::common_messages::{ProtocolVersion, COINSWAP_PORT},
+    protocol::common_messages::{ProtocolVersion, OPENSWAP_PORT},
     taker::{Taker, TakerBehavior, TakerInitConfig},
     utill::{check_tor_status, get_ephemeral_address, setup_logger},
     wallet::{
@@ -305,16 +305,16 @@ pub fn fund_taker(
 /// Poll a wallet, calling `sync_and_save`, until its `regular` balance reaches `expected_regular`
 /// or `timeout_secs` elapses. Returns the last observed balances either way.
 fn wait_for_balance(
-    wallet: &std::sync::Arc<std::sync::RwLock<coinswap::wallet::Wallet>>,
+    wallet: &std::sync::Arc<std::sync::RwLock<openswap::wallet::Wallet>>,
     expected_regular: Amount,
     timeout_secs: u64,
-) -> coinswap::wallet::Balances {
+) -> openswap::wallet::Balances {
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     let mut last;
     loop {
         {
             let mut w = wallet.write().unwrap();
-            w.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+            w.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
             last = w.get_balances().unwrap();
         }
         if last.regular >= expected_regular || Instant::now() >= deadline {
@@ -457,25 +457,25 @@ pub const TOR_CONTROL_PORT: u16 = 9051;
 /// Tor SOCKS port used by the Tor integration tests.
 pub const TOR_SOCKS_PORT: u16 = 9050;
 
-/// Control-port password for the Tor tests, from `COINSWAP_TOR_PASSWORD`
+/// Control-port password for the Tor tests, from `OPENSWAP_TOR_PASSWORD`
 /// (empty when unset, which matches a cookie-less `HashedControlPassword ""`).
 pub fn tor_password() -> String {
-    std::env::var("COINSWAP_TOR_PASSWORD").unwrap_or_default()
+    std::env::var("OPENSWAP_TOR_PASSWORD").unwrap_or_default()
 }
 
 /// True when the Tor integration tests should run.
 ///
-/// `COINSWAP_TOR_IT=1` means "I require Tor", so a missing daemon **panics**
+/// `OPENSWAP_TOR_IT=1` means "I require Tor", so a missing daemon **panics**
 /// rather than skipping. CI gates on these tests, and a silent skip would look
 /// exactly like a pass. Without the variable set they skip, for local runs.
 pub fn tor_it_enabled() -> bool {
-    if std::env::var("COINSWAP_TOR_IT").as_deref() != Ok("1") {
-        log::warn!("skipping Tor integration test: COINSWAP_TOR_IT=1 not set");
+    if std::env::var("OPENSWAP_TOR_IT").as_deref() != Ok("1") {
+        log::warn!("skipping Tor integration test: OPENSWAP_TOR_IT=1 not set");
         return false;
     }
     if let Err(e) = check_tor_status(TOR_CONTROL_PORT, &tor_password()) {
         panic!(
-            "COINSWAP_TOR_IT=1 but tor control port {} is unreachable: {:?}",
+            "OPENSWAP_TOR_IT=1 but tor control port {} is unreachable: {:?}",
             TOR_CONTROL_PORT, e
         );
     }
@@ -539,9 +539,9 @@ impl TestBackend for TorElectrumBackend {
         )
         .expect("ADD_ONION failed; call tor_it_enabled() before using this backend");
 
-        // The helper fixes the onion-side port to COINSWAP_PORT and maps it to
+        // The helper fixes the onion-side port to OPENSWAP_PORT and maps it to
         // electrsd's real local port.
-        let url = format!("tcp://{onion}:{COINSWAP_PORT}");
+        let url = format!("tcp://{onion}:{OPENSWAP_PORT}");
         log::info!("Tor electrum backend: {url} via socks 127.0.0.1:{TOR_SOCKS_PORT}");
 
         // `timeout` and `poll_interval_secs` are left at their derived proxied
@@ -682,7 +682,7 @@ impl TestFramework {
         maker_behaviors: Vec<MakerBehavior>,
     ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<MakerServer>>, JoinHandle<()>) {
         // Setup directory — use a unique suffix so tests can run in parallel
-        let unique_id = format!("coinswap-{}", rand::random::<u64>());
+        let unique_id = format!("openswap-{}", rand::random::<u64>());
         let temp_dir = env::temp_dir().join(unique_id);
         // Remove if previously existing
         if temp_dir.exists() {
@@ -993,7 +993,7 @@ impl Drop for TrackerLoggerHandle {
 /// ```
 #[allow(dead_code)]
 pub fn spawn_tracker_logger(data_dir: PathBuf, interval: Duration) -> TrackerLoggerHandle {
-    use coinswap::taker::swap_tracker::SwapTracker;
+    use openswap::taker::swap_tracker::SwapTracker;
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_clone = shutdown.clone();
@@ -1021,7 +1021,7 @@ pub fn spawn_tracker_logger(data_dir: PathBuf, interval: Duration) -> TrackerLog
 ///
 /// Each test gets its own relay on its own random port with an in-memory
 /// database, so concurrently running tests never share nostr state. The relay
-/// binary is located via the `COINSWAP_TEST_NOSTR_RELAY_BIN` env var, falling
+/// binary is located via the `OPENSWAP_TEST_NOSTR_RELAY_BIN` env var, falling
 /// back to `nostr-rs-relay` on `PATH`.
 fn spawn_nostr_relay(temp_dir: &Path, port: u16) -> Child {
     let data_dir = temp_dir.join("nostr-relay");
@@ -1037,7 +1037,7 @@ fn spawn_nostr_relay(temp_dir: &Path, port: u16) -> Child {
     std::fs::write(&config_path, config).unwrap();
 
     let bin =
-        env::var("COINSWAP_TEST_NOSTR_RELAY_BIN").unwrap_or_else(|_| "nostr-rs-relay".to_string());
+        env::var("OPENSWAP_TEST_NOSTR_RELAY_BIN").unwrap_or_else(|_| "nostr-rs-relay".to_string());
 
     Command::new(&bin)
         .arg("--config")
@@ -1047,7 +1047,7 @@ fn spawn_nostr_relay(temp_dir: &Path, port: u16) -> Child {
         .spawn()
         .unwrap_or_else(|e| {
             panic!(
-                "failed to spawn nostr relay binary '{}': {}. Install it with `cargo install nostr-rs-relay` or set COINSWAP_TEST_NOSTR_RELAY_BIN.",
+                "failed to spawn nostr relay binary '{}': {}. Install it with `cargo install nostr-rs-relay` or set OPENSWAP_TEST_NOSTR_RELAY_BIN.",
                 bin, e
             )
         })

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -35,6 +35,8 @@ use bitcoind::{
     BitcoinD,
 };
 
+use electrsd::ElectrsD;
+use log::info;
 use openswap::{
     maker::{MakerBehavior, MakerServer, MakerServerConfig},
     protocol::common_messages::{ProtocolVersion, OPENSWAP_PORT},
@@ -45,8 +47,6 @@ use openswap::{
         CoreRpcConfig, Electrum, ElectrumConfig,
     },
 };
-use electrsd::ElectrsD;
-use log::info;
 
 const BITCOIN_VERSION: &str = "28.1";
 

--- a/tests/integration/utxo_behavior.rs
+++ b/tests/integration/utxo_behavior.rs
@@ -5,6 +5,7 @@
 //! - Manual coin selection with regular/swap coin clause testing
 
 use bitcoin::{Amount, OutPoint};
+use log::{info, warn};
 use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
@@ -12,7 +13,6 @@ use openswap::{
     utill::MIN_FEE_RATE,
     wallet::{AddressType, WalletError},
 };
-use log::{info, warn};
 use std::{sync::atomic::Ordering::Relaxed, thread, time::Duration};
 
 use super::test_framework::*;

--- a/tests/integration/utxo_behavior.rs
+++ b/tests/integration/utxo_behavior.rs
@@ -5,7 +5,7 @@
 //! - Manual coin selection with regular/swap coin clause testing
 
 use bitcoin::{Amount, OutPoint};
-use coinswap::{
+use openswap::{
     maker::start_server,
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
@@ -109,7 +109,7 @@ fn test_address_grouping_behavior() {
     // Sync wallet to see all the UTXOs we just created
     {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     println!("\n=== Available UTXO Summary ===");
@@ -222,23 +222,23 @@ fn test_separated_utxo_coin_selection() {
     // Wait for both makers setup completion
     wait_for_makers_setup(&makers, 120);
 
-    // Perform coinswap to create swap coins
-    info!("Performing coinswap to create swap coins");
+    // Perform openswap to create swap coins
+    info!("Performing openswap to create swap coins");
     let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(35000000), 2)
         .with_tx_count(1)
         .with_required_confirms(1);
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed");
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed");
     taker
-        .start_coinswap(&summary.swap_id)
-        .expect("coinswap should succeed");
+        .start_swap(&summary.swap_id)
+        .expect("openswap should succeed");
 
     // Sync both maker wallets
     for maker in &makers {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     println!("=== Testing Separated UTXO Coin Selection ===");
@@ -346,7 +346,7 @@ fn test_separated_utxo_coin_selection() {
     // Sync wallet and retry
     {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
         let updated_balances = wallet.get_balances().unwrap();
 
         println!("Updated balances after funding:");
@@ -435,7 +435,7 @@ fn test_manual_coinselection() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     let all_utxos = taker.get_wallet().read().unwrap().list_all_utxo();
@@ -469,9 +469,9 @@ fn test_manual_coinselection() {
         .with_utxos(manually_selected_utxos.clone());
 
     let summary = taker
-        .prepare_coinswap(swap_params)
-        .expect("prepare_coinswap should succeed");
-    let _ = taker.start_coinswap(&summary.swap_id);
+        .prepare_swap(swap_params)
+        .expect("prepare_swap should succeed");
+    let _ = taker.start_swap(&summary.swap_id);
 
     // After Swap is done, wait for maker threads to conclude.
     makers
@@ -481,7 +481,7 @@ fn test_manual_coinselection() {
         .into_iter()
         .for_each(|thread| thread.join().unwrap());
 
-    info!("All coinswaps processed successfully. Transaction complete.");
+    info!("All openswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
 
@@ -490,12 +490,12 @@ fn test_manual_coinselection() {
         .get_wallet()
         .write()
         .unwrap()
-        .sync_and_save(&coinswap::utill::NO_SHUTDOWN)
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
         .unwrap();
 
     for maker in makers.iter() {
         let mut wallet = maker.wallet.write().unwrap();
-        wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+        wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
     }
 
     // Check that the originally manually selected UTXOs were spent
@@ -514,11 +514,11 @@ fn test_manual_coinselection() {
 
     assert!(
         manual_utxos_spent,
-        "Not all manually selected UTXOs were spent in the coinswap"
+        "Not all manually selected UTXOs were spent in the openswap"
     );
 
     println!(
-        "\nTest 1 : All {} originally selected UTXOs were used in the coinswap",
+        "\nTest 1 : All {} originally selected UTXOs were used in the openswap",
         manually_selected_utxos.len()
     );
 

--- a/tests/integration/wallet_backup.rs
+++ b/tests/integration/wallet_backup.rs
@@ -12,19 +12,19 @@ use bitcoind::{
 use electrsd::ElectrsD;
 use log::info;
 
-use coinswap::wallet::{
+use openswap::wallet::{
     AddressType, AnyBlockchain, BackendConfig, CoreRPC, CoreRpcConfig, Electrum, ElectrumConfig,
     Wallet, WalletBackup,
 };
 
-use coinswap::security::{load_sensitive_struct, KeyMaterial, SerdeJson};
+use openswap::security::{load_sensitive_struct, KeyMaterial, SerdeJson};
 
 use super::test_framework::{
     generate_blocks, init_bitcoind, init_electrsd, send_to_address, wait_for_electrs_tip,
 };
 
 fn setup(test_name: String) -> (PathBuf, CoreRpcConfig, PathBuf, BitcoinD, PathBuf, PathBuf) {
-    let root_dir = std::env::temp_dir().join(format!("coinswap-{}", rand::random::<u64>()));
+    let root_dir = std::env::temp_dir().join(format!("openswap-{}", rand::random::<u64>()));
     let temp_dir = root_dir.join("wallet-tests").join(test_name);
     let wallets_dir = temp_dir.join("");
 
@@ -109,7 +109,7 @@ fn plainwallet_plainbackup_plainrestore() {
     let addr = wallet.get_next_external_address(AddressType::P2TR).unwrap();
     send_and_mine(&mut bitcoind, &addr, 0.05, 1).unwrap();
 
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
     let (backup, _) =
         load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None).unwrap();
@@ -160,7 +160,7 @@ fn encwallet_encbackup_encrestore() {
     let addr = wallet.get_next_external_address(AddressType::P2TR).unwrap();
     send_and_mine(&mut bitcoind, &addr, 0.05, 1).unwrap();
 
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
     let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(
         &wallet_backup_file,
@@ -197,7 +197,7 @@ struct ElectrumSetup {
 }
 
 fn setup_electrum(test_name: &str) -> ElectrumSetup {
-    let root_dir = std::env::temp_dir().join(format!("coinswap-elec-{}", rand::random::<u64>()));
+    let root_dir = std::env::temp_dir().join(format!("openswap-elec-{}", rand::random::<u64>()));
     let temp_dir = root_dir.join("wallet-tests").join(test_name);
     let wallets_dir = temp_dir.join("");
     let original_wallet_name = "original-wallet".to_string();
@@ -253,7 +253,7 @@ fn plainwallet_plainbackup_plainrestore_electrum() {
     send_and_mine(&mut s.bitcoind, &addr, 0.05, 1).unwrap();
     wait_for_electrs_tip(&s.bitcoind, &s.electrsd, &s.electrum_cfg);
 
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
     let (backup, _) =
         load_sensitive_struct::<WalletBackup, SerdeJson>(&s.backup_file, None).unwrap();
@@ -298,7 +298,7 @@ fn encwallet_encbackup_encrestore_electrum() {
     send_and_mine(&mut s.bitcoind, &addr, 0.05, 1).unwrap();
     wait_for_electrs_tip(&s.bitcoind, &s.electrsd, &s.electrum_cfg);
 
-    wallet.sync_and_save(&coinswap::utill::NO_SHUTDOWN).unwrap();
+    wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
     let (backup, _) = load_sensitive_struct::<WalletBackup, SerdeJson>(
         &s.backup_file,

--- a/tests/integration/watchtower_liveness.rs
+++ b/tests/integration/watchtower_liveness.rs
@@ -1,7 +1,7 @@
 //! Maker admission must fail closed after its watcher thread exits.
 
 use bitcoin::Amount;
-use coinswap::{
+use openswap::{
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{error::TakerError, SwapParams, TakerBehavior},
@@ -52,7 +52,7 @@ fn maker_rejects_new_swaps_after_watcher_exit() {
     assert!(!maker.watch_service.is_alive());
 
     for protocol in [ProtocolVersion::Legacy, ProtocolVersion::Taproot] {
-        let result = taker.prepare_coinswap(
+        let result = taker.prepare_swap(
             SwapParams::new(protocol, Amount::from_sat(500_000), 1)
                 .with_tx_count(1)
                 .with_required_confirms(1),
@@ -114,14 +114,14 @@ fn taker_refuses_swap_before_funding_after_watcher_exit() {
     wait_for_makers_setup(&makers, 120);
 
     let summary = taker
-        .prepare_coinswap(
+        .prepare_swap(
             SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
                 .with_tx_count(1)
                 .with_required_confirms(1),
         )
         .unwrap();
     taker.behavior = TakerBehavior::StopWatcherBeforeSwap;
-    let error = taker.start_coinswap(&summary.swap_id).unwrap_err();
+    let error = taker.start_swap(&summary.swap_id).unwrap_err();
     assert!(format!("{error:?}").contains("watchtower is down"));
     assert_eq!(
         taker


### PR DESCRIPTION
## Summary

Rebrands the project from **Coinswap** to **OpenSwap**, following the project's move to the [citadel-foss](https://github.com/citadel-foss) org.

- Rename crate, identifiers, docs, docker, and CI from Coinswap to OpenSwap (`coinswap` → `openswap`, `Coinswap`/`CoinSwap` → `OpenSwap`, `COINSWAP` → `OPENSWAP`)
- Update all repository links: `citadel-tech/coinswap` → `citadel-foss/openswap`, plus `openswap-ffi`, `OpenSwap-Protocol-Specification`, `maker-dashboard`, `taker-app`, docs.rs, badges, deepwiki, codecov
- Rename `src/nostr_coinswap.rs` → `src/maker/nostr.rs` and the discovery module `src/nostr.rs` → `src/watch_tower/nostr.rs`, removing the inverted `watch_tower → taker` dependency (the discovery module's only caller and all of its types live in the watch tower)
- Rename swap activity APIs to drop the redundant protocol prefix:
  - `prepare_openswap` → `prepare_swap`
  - `start_openswap` → `start_swap`
  - `openswap_kind` → `swap_kind`
  - `calculate_openswap_fee` → `calculate_swap_fee`
  - `create_and_import_openswap_address` → `create_and_import_swap_address`

## Notes

- **Breaking change** for downstream consumers: crate name (`openswap`), data directory paths (e.g. `~/.openswap`), and the public taker API renames. A version bump and changelog entry are recommended before release.
- `OPENSWAP_PORT` kept as-is (protocol-level well-known Tor port, not swap activity).
- Verified: `cargo check --all-targets` passes with and without `integration-test`; renamed unit test `calculate_swap_fee_normal` passes.