### PR TITLE
fix: propagate watcher shutdown to Nostr discovery

### DIFF
--- a/src/watch_tower/nostr.rs
+++ b/src/watch_tower/nostr.rs
@@ -63,7 +63,7 @@ pub fn run_discovery(
 
     let connections = relays
         .iter()
-        .map(|_| blockchain.new_connection())
+        .map(|_| blockchain.new_connection_with_shutdown(shutdown.clone()))
         .collect::<Result<Vec<_>, _>>()?;
     let mut sessions = Vec::with_capacity(relays.len());
     for (relay, blockchain) in relays.iter().zip(connections) {

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -165,7 +165,10 @@ impl<R: Role> Watcher<R> {
             R::RUN_DISCOVERY
         );
 
-        let discovery_shutdown = Arc::new(AtomicBool::new(false));
+        // Discovery is part of the watcher lifetime. Sharing the owner flag
+        // lets taker shutdown interrupt relay processing immediately, even if
+        // the watcher event loop is still finishing its current backend call.
+        let discovery_shutdown = self.shutdown.clone();
         let registry = self.registry.clone();
         let nostr_relays = self.nostr_relays.clone();
         let nostr_tor_config = self.nostr_tor_config.clone();


### PR DESCRIPTION
## Summary
Fixes taker shutdown hanging after a successful swap by propagating the watcher shutdown flag to Nostr discovery and its per-relay backend connections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for blockchain connections and discovery processes.
  * Ensured related background operations stop consistently when the watcher shuts down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->