### PR TITLE
fix(maker): adopt unconfirmed fidelity bond on restart instead of creating a new one

### DIFF
--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -40,7 +40,7 @@ time_relative_fee_pct = 0.0001
 - `min_swap_amount`: Minimum swap amount (in satoshis).
 - `fidelity_amount`: Amount (in satoshis) locked as a fidelity bond to deter Sybil attacks.
 - `fidelity_timelock`: Lock duration in block heights for the fidelity bond.
-- `fidelity_feerate`: Fee rate (in sats/vB) for the fidelity bond transaction. Values below the minimum of 2.0 sats/vB are clamped to the minimum.
+- `fidelity_feerate`: Fee rate (in sats/vB) for the fidelity bond transaction. Defaults to 2.0; lower values are allowed, but anything below the relay minimum of 1.0 sats/vB is clamped to 1.0.
 - `connection_type`: Specifies the network mode; set to "TOR" in production for privacy, or "CLEARNET" during testing.
 - `base_fee`: A fixed fee charged by the Maker for providing its services (in satoshis).
 - `amount_relative_fee_pct`: A percentage fee based on the swap amount.

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -26,6 +26,7 @@ tor_auth_password = ""
 min_swap_amount = 10000
 fidelity_amount = 50000
 fidelity_timelock = 13104
+fidelity_feerate = 2.0
 connection_type = TOR
 base_fee = 500
 amount_relative_fee_pct = 0.0025
@@ -39,6 +40,7 @@ time_relative_fee_pct = 0.0001
 - `min_swap_amount`: Minimum swap amount (in satoshis).
 - `fidelity_amount`: Amount (in satoshis) locked as a fidelity bond to deter Sybil attacks.
 - `fidelity_timelock`: Lock duration in block heights for the fidelity bond.
+- `fidelity_feerate`: Fee rate (in sats/vB) for the fidelity bond transaction. Values below the minimum of 2.0 sats/vB are clamped to the minimum.
 - `connection_type`: Specifies the network mode; set to "TOR" in production for privacy, or "CLEARNET" during testing.
 - `base_fee`: A fixed fee charged by the Maker for providing its services (in satoshis).
 - `amount_relative_fee_pct`: A percentage fee based on the swap amount.

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -640,7 +640,7 @@ impl MakerServer {
     /// would be silently discarded by `get_highest_fidelity_index`, making
     /// the maker create a second bond and doubly lock funds. Finalizing it
     /// here prevents that.
-    fn finalize_pending_fidelity_bonds(&self, maker_address: &str) -> Result<(), MakerError> {
+    fn finalize_pending_fidelity_bonds(&self) -> Result<(), MakerError> {
         loop {
             let pending = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
@@ -660,23 +660,12 @@ impl MakerServer {
                 txid
             );
 
-            // Refresh the UTXO view first: if the bond tx was evicted while
-            // the maker was down, its inputs are spendable again.
-            lock_debug!(self.wallet.write())
+            // An evicted bond tx would never confirm; rebroadcast the stored
+            // raw transaction before waiting. Returns the original txid
+            // unchanged if the broadcast is still live.
+            let txid = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .sync_and_save(&self.shutdown)
-                .map_err(MakerError::Wallet)?;
-
-            // An evicted bond tx would never confirm; rebuild and rebroadcast
-            // it before waiting. Returns the original txid if it is still live.
-            let txid = lock_debug!(self.wallet.write())
-                .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .ensure_fidelity_bond_broadcast(
-                    index,
-                    Some(maker_address),
-                    MIN_FEE_RATE,
-                    AddressType::P2TR,
-                )
+                .ensure_fidelity_bond_broadcast(index)
                 .map_err(MakerError::Wallet)?;
 
             // Wait on a fresh backend connection so the wallet lock is not
@@ -717,7 +706,7 @@ impl MakerServer {
         // Adopt any bond that was broadcast but not yet confirmed (e.g. the
         // maker shut down while waiting for confirmation) before deciding
         // whether a new bond is needed.
-        self.finalize_pending_fidelity_bonds(maker_address)?;
+        self.finalize_pending_fidelity_bonds()?;
 
         let highest_index = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -640,7 +640,7 @@ impl MakerServer {
     /// would be silently discarded by `get_highest_fidelity_index`, making
     /// the maker create a second bond and doubly lock funds. Finalizing it
     /// here prevents that.
-    fn finalize_pending_fidelity_bonds(&self) -> Result<(), MakerError> {
+    fn finalize_pending_fidelity_bonds(&self, maker_address: &str) -> Result<(), MakerError> {
         loop {
             let pending = lock_debug!(self.wallet.read())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
@@ -660,10 +660,41 @@ impl MakerServer {
                 txid
             );
 
-            let conf_height = lock_debug!(self.wallet.read())
+            // Refresh the UTXO view first: if the bond tx was evicted while
+            // the maker was down, its inputs are spendable again.
+            lock_debug!(self.wallet.write())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                .wait_for_tx_confirmation(&[txid], 1, Some(&self.shutdown), None)
+                .sync_and_save(&self.shutdown)
                 .map_err(MakerError::Wallet)?;
+
+            // An evicted bond tx would never confirm; rebuild and rebroadcast
+            // it before waiting. Returns the original txid if it is still live.
+            let txid = lock_debug!(self.wallet.write())
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .ensure_fidelity_bond_broadcast(
+                    index,
+                    Some(maker_address),
+                    MIN_FEE_RATE,
+                    AddressType::P2TR,
+                )
+                .map_err(MakerError::Wallet)?;
+
+            // Wait on a fresh backend connection so the wallet lock is not
+            // held for the duration of the wait.
+            let chain = lock_debug!(self.wallet.read())
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .blockchain
+                .new_connection()
+                .map_err(MakerError::Wallet)?;
+            let conf_height = crate::wallet::wait_for_tx_confirmation(
+                &chain,
+                &[txid],
+                1,
+                crate::utill::TX_BROADCAST_TIMEOUT,
+                Some(&self.shutdown),
+                None,
+            )
+            .map_err(MakerError::Wallet)?;
 
             lock_debug!(self.wallet.write())
                 .map_err(|_| MakerError::General("Failed to lock wallet"))?
@@ -686,7 +717,7 @@ impl MakerServer {
         // Adopt any bond that was broadcast but not yet confirmed (e.g. the
         // maker shut down while waiting for confirmation) before deciding
         // whether a new bond is needed.
-        self.finalize_pending_fidelity_bonds()?;
+        self.finalize_pending_fidelity_bonds(maker_address)?;
 
         let highest_index = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -135,6 +135,9 @@ pub struct MakerServerConfig {
     pub fidelity_amount: u64,
     /// Fidelity bond timelock in blocks.
     pub fidelity_timelock: u32,
+    /// Fee rate in sats/vB for the fidelity bond transaction.
+    /// Never below `MIN_FEE_RATE`.
+    pub fidelity_feerate: f64,
     /// Bitcoin network.
     pub network: Network,
     /// Selected blockchain backend (Bitcoin Core or Electrum) and its settings.
@@ -167,6 +170,7 @@ impl Default for MakerServerConfig {
             supported_protocols: vec![ProtocolVersion::Legacy, ProtocolVersion::Taproot],
             fidelity_amount: 10_000,   // 0.0001 BTC
             fidelity_timelock: 15_000, // ~6 months (MAX_FIDELITY_TIMELOCK)
+            fidelity_feerate: MIN_FEE_RATE,
             network: Network::Regtest,
             backend: BackendConfig::CoreRpc(CoreRpcConfig::default()),
             // "maker" predates this branch; changing it would strand an upgrading
@@ -233,6 +237,21 @@ impl MakerServerConfig {
             });
         }
 
+        let fidelity_feerate = parse_field(
+            config_map.get("fidelity_feerate"),
+            default_config.fidelity_feerate,
+        );
+        let fidelity_feerate = if fidelity_feerate < MIN_FEE_RATE {
+            log::warn!(
+                "Configured fidelity_feerate {} is below the minimum {} sats/vB; using the minimum",
+                fidelity_feerate,
+                MIN_FEE_RATE
+            );
+            MIN_FEE_RATE
+        } else {
+            fidelity_feerate
+        };
+
         Ok(MakerServerConfig {
             network_port: parse_field(config_map.get("network_port"), default_config.network_port),
             rpc_port: parse_field(config_map.get("rpc_port"), default_config.rpc_port),
@@ -255,6 +274,7 @@ impl MakerServerConfig {
                 default_config.fidelity_amount,
             ),
             fidelity_timelock,
+            fidelity_feerate,
             control_port: parse_field(config_map.get("control_port"), default_config.control_port),
             socks_port: parse_field(config_map.get("socks_port"), default_config.socks_port),
             tor_auth_password: parse_field(
@@ -301,6 +321,8 @@ min_swap_amount = {}
 fidelity_amount = {}
 # Fidelity Bond timelock in blocks (must be between {} and {})
 fidelity_timelock = {}
+# Fee rate in sats/vB for the fidelity bond transaction (minimum {})
+fidelity_feerate = {}
 # A fixed base fee charged by the Maker for providing its services (in satoshis)
 base_fee = {}
 # A percentage fee based on the swap amount
@@ -320,6 +342,8 @@ required_confirms = {}
             MIN_FIDELITY_TIMELOCK,
             MAX_FIDELITY_TIMELOCK,
             self.fidelity_timelock,
+            MIN_FEE_RATE,
+            self.fidelity_feerate,
             self.base_fee,
             self.amount_relative_fee_pct,
             self.time_relative_fee_pct,
@@ -814,7 +838,7 @@ impl MakerServer {
                         amount,
                         locktime,
                         Some(maker_address),
-                        MIN_FEE_RATE,
+                        self.config.fidelity_feerate,
                         AddressType::P2TR,
                     );
 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -21,7 +21,7 @@ use crate::{
     maker::nostr::NOSTR_RELAYS,
     protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
     taker::api::REFUND_LOCKTIME_STEP,
-    utill::{get_maker_dir, parse_field, parse_toml, MIN_FEE_RATE},
+    utill::{get_maker_dir, parse_field, parse_toml, MIN_FEE_RATE, MIN_RELAY_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
         AddressType, AnyBlockchain, BackendConfig, Blockchain, CoreRpcConfig, FidelityError,
@@ -136,7 +136,8 @@ pub struct MakerServerConfig {
     /// Fidelity bond timelock in blocks.
     pub fidelity_timelock: u32,
     /// Fee rate in sats/vB for the fidelity bond transaction.
-    /// Never below `MIN_FEE_RATE`.
+    /// Defaults to `MIN_FEE_RATE`; may go lower, but never below
+    /// `MIN_RELAY_FEE_RATE`.
     pub fidelity_feerate: f64,
     /// Bitcoin network.
     pub network: Network,
@@ -241,15 +242,21 @@ impl MakerServerConfig {
             config_map.get("fidelity_feerate"),
             default_config.fidelity_feerate,
         );
-        let fidelity_feerate = if fidelity_feerate < MIN_FEE_RATE {
-            log::warn!(
-                "Configured fidelity_feerate {} is below the minimum {} sats/vB; using the minimum",
-                fidelity_feerate,
-                MIN_FEE_RATE
-            );
-            MIN_FEE_RATE
-        } else {
+        // The default is MIN_FEE_RATE, but an operator may go lower on
+        // purpose; the only hard floor is the relay minimum. Non-finite
+        // values (TOML allows `nan`/`inf`) bypass a `<` comparison, so they
+        // must be filtered out explicitly.
+        let fidelity_feerate = if fidelity_feerate.is_finite()
+            && fidelity_feerate >= MIN_RELAY_FEE_RATE
+        {
             fidelity_feerate
+        } else {
+            log::warn!(
+                "Invalid fidelity_feerate {}; must be finite and at least {} sats/vB; using the relay minimum",
+                fidelity_feerate,
+                MIN_RELAY_FEE_RATE
+            );
+            MIN_RELAY_FEE_RATE
         };
 
         Ok(MakerServerConfig {
@@ -321,7 +328,7 @@ min_swap_amount = {}
 fidelity_amount = {}
 # Fidelity Bond timelock in blocks (must be between {} and {})
 fidelity_timelock = {}
-# Fee rate in sats/vB for the fidelity bond transaction (minimum {})
+# Fee rate in sats/vB for the fidelity bond transaction (must be at least {})
 fidelity_feerate = {}
 # A fixed base fee charged by the Maker for providing its services (in satoshis)
 base_fee = {}
@@ -342,7 +349,7 @@ required_confirms = {}
             MIN_FIDELITY_TIMELOCK,
             MAX_FIDELITY_TIMELOCK,
             self.fidelity_timelock,
-            MIN_FEE_RATE,
+            MIN_RELAY_FEE_RATE,
             self.fidelity_feerate,
             self.base_fee,
             self.amount_relative_fee_pct,

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -630,9 +630,63 @@ impl MakerServer {
         !self.is_shutdown()
     }
 
+    /// Waits for live but unconfirmed fidelity bonds to confirm and records
+    /// their confirmation height. No-op if no such bond exists.
+    ///
+    /// A bond is registered with `conf_height: None` as soon as it is
+    /// broadcast, so a maker that shut down while waiting for confirmation
+    /// restarts with a pending bond in the wallet. Such a bond fails
+    /// valuation (`calculate_bond_value` needs the confirmation height) and
+    /// would be silently discarded by `get_highest_fidelity_index`, making
+    /// the maker create a second bond and doubly lock funds. Finalizing it
+    /// here prevents that.
+    fn finalize_pending_fidelity_bonds(&self) -> Result<(), MakerError> {
+        loop {
+            let pending = lock_debug!(self.wallet.read())
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .store
+                .fidelity_bond
+                .iter()
+                .find(|b| !b.is_spent && b.conf_height.is_none())
+                .map(|b| (b.bond_index, b.outpoint.txid));
+
+            let Some((index, txid)) = pending else {
+                return Ok(());
+            };
+
+            log::info!(
+                "[{}] Found unconfirmed fidelity bond {}, waiting for confirmation instead of creating a new one",
+                self.config.network_port,
+                txid
+            );
+
+            let conf_height = lock_debug!(self.wallet.read())
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .wait_for_tx_confirmation(&[txid], 1, Some(&self.shutdown), None)
+                .map_err(MakerError::Wallet)?;
+
+            lock_debug!(self.wallet.write())
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?
+                .update_fidelity_bond_conf_details(index, conf_height)
+                .map_err(MakerError::Wallet)?;
+
+            log::info!(
+                "[{}] Pending fidelity bond {} confirmed at height {}",
+                self.config.network_port,
+                txid,
+                conf_height
+            );
+        }
+    }
+
     /// Setup fidelity bond for this maker.
     pub fn setup_fidelity_bond(&self, maker_address: &str) -> Result<FidelityProof, MakerError> {
         use bitcoin::absolute::LockTime;
+
+        // Adopt any bond that was broadcast but not yet confirmed (e.g. the
+        // maker shut down while waiting for confirmation) before deciding
+        // whether a new bond is needed.
+        self.finalize_pending_fidelity_bonds()?;
 
         let highest_index = lock_debug!(self.wallet.read())
             .map_err(|_| MakerError::General("Failed to lock wallet"))?

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -1309,6 +1309,7 @@ mod tests {
             conf_height: Some(1000),
             is_spent: false,
             bond_index: 0,
+            tx: None,
         };
 
         let cert_hash = bond.generate_cert_hash(maker_addr, &pubkey);

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -88,6 +88,11 @@ pub const MIN_REQUIRED_CONFIRM: u32 = 1;
 /// This replaces the hardcoded MINER_FEE constant
 pub const MIN_FEE_RATE: f64 = 2.0;
 
+/// Absolute fee rate floor in sats/vb — Bitcoin Core's default
+/// `minrelaytxfee`. Configurable fee rates (e.g. the fidelity bond) may go
+/// below [`MIN_FEE_RATE`] but never below this, or transactions stop relaying.
+pub const MIN_RELAY_FEE_RATE: f64 = 1.0;
+
 /// Maximum size of a length-prefixed protocol or RPC message.
 /// 10 MiB limit
 pub const MAX_RPC_MESSAGE_SIZE: usize = 10 * 1024 * 1024;

--- a/src/wallet/blockchain/corerpc.rs
+++ b/src/wallet/blockchain/corerpc.rs
@@ -378,6 +378,16 @@ impl Blockchain for CoreRPC {
         Ok(self.rpc.get_raw_transaction_info(txid, block_hash)?)
     }
 
+    fn is_tx_unknown(&self, txid: &Txid) -> Result<bool, WalletError> {
+        match self.rpc.get_raw_transaction(txid, None) {
+            Ok(_) => Ok(false),
+            // -5 (RPC_INVALID_ADDRESS_OR_KEY): Core's "no such mempool or
+            // blockchain transaction" answer.
+            Err(CoreRpcError::JsonRpc(jsonrpc::Error::Rpc(ref e))) if e.code == -5 => Ok(true),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn get_tx_out(
         &self,
         txid: &Txid,

--- a/src/wallet/blockchain/electrum.rs
+++ b/src/wallet/blockchain/electrum.rs
@@ -920,6 +920,14 @@ impl Blockchain for Electrum {
         Ok(serde_json::from_value(stub)?)
     }
 
+    fn is_tx_unknown(&self, txid: &Txid) -> Result<bool, WalletError> {
+        match self.call(|c| c.transaction_get(txid)) {
+            Ok(_) => Ok(false),
+            Err(WalletError::Electrum(ref e)) if is_unknown_txid(e) => Ok(true),
+            Err(e) => Err(e),
+        }
+    }
+
     fn get_tx_out(
         &self,
         txid: &Txid,

--- a/src/wallet/blockchain/mod.rs
+++ b/src/wallet/blockchain/mod.rs
@@ -180,6 +180,12 @@ pub trait Blockchain: Send + Sync + 'static {
         txid: &Txid,
         block_hash: Option<&BlockHash>,
     ) -> Result<GetRawTransactionResult, WalletError>;
+    /// Whether the backend positively reports the transaction as unknown.
+    ///
+    /// `Ok(true)` only on an explicit "no such transaction" answer (Core's
+    /// `-5`, Electrum's unknown-txid protocol error). Any transport or server
+    /// failure is propagated, so a failed query is never read as absence.
+    fn is_tx_unknown(&self, txid: &Txid) -> Result<bool, WalletError>;
     /// Unspent output at `txid:vout`, following Core's `gettxout`.
     ///
     /// `include_mempool`:
@@ -484,6 +490,12 @@ impl Blockchain for AnyBlockchain {
         match self {
             AnyBlockchain::CoreRPC(b) => b.get_raw_transaction_info(txid, block_hash),
             AnyBlockchain::Electrum(b) => b.get_raw_transaction_info(txid, block_hash),
+        }
+    }
+    fn is_tx_unknown(&self, txid: &Txid) -> Result<bool, WalletError> {
+        match self {
+            AnyBlockchain::CoreRPC(b) => b.is_tx_unknown(txid),
+            AnyBlockchain::Electrum(b) => b.is_tx_unknown(txid),
         }
     }
     fn get_tx_out(

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -271,6 +271,12 @@ pub struct FidelityBond {
     /// The child index used in the HD derivation path `m/175'/2/<bond_index>`.
     /// Note: Fidelity bonds must only be appended to the store; they should never be removed or reordered.
     pub bond_index: u32,
+    /// The raw bond transaction, kept only until confirmation so an evicted
+    /// broadcast can be re-sent as-is. Rebroadcasting the identical bytes
+    /// reproduces the same txid, so no replacement spending different coins
+    /// can ever confirm alongside the original and double-lock funds.
+    #[serde(default)]
+    pub(crate) tx: Option<Transaction>,
 }
 
 impl FidelityBond {
@@ -538,6 +544,7 @@ impl Wallet {
                 conf_height: None,
                 is_spent: false,
                 bond_index: index,
+                tx: Some(tx),
             };
             self.store.fidelity_bond.push(bond);
             self.save_to_disk()?;
@@ -552,29 +559,20 @@ impl Wallet {
     /// If the original broadcast is still in the mempool or already confirmed,
     /// its txid is returned unchanged. Otherwise the transaction was evicted
     /// (e.g. while the maker was offline) and waiting for it would never
-    /// succeed: a new transaction paying the same fidelity address is built,
-    /// broadcast, and the stored bond's outpoint is updated to it.
-    pub fn ensure_fidelity_bond_broadcast(
-        &mut self,
-        index: u32,
-        maker_address: Option<&str>,
-        feerate: f64,
-        change_address_type: AddressType,
-    ) -> Result<Txid, WalletError> {
+    /// succeed: the raw transaction stored at creation is rebroadcast, which
+    /// reproduces the same txid, so the bond keeps its original outpoint and
+    /// no replacement spending different coins can double-lock funds.
+    pub fn ensure_fidelity_bond_broadcast(&self, index: u32) -> Result<Txid, WalletError> {
         let bond = self
             .store
             .fidelity_bond
             .get(index as usize)
-            .ok_or(FidelityError::BondDoesNotExist)?
-            .clone();
+            .ok_or(FidelityError::BondDoesNotExist)?;
 
-        // With txindex this also finds confirmed transactions, so only a
-        // genuinely missing transaction takes the rebroadcast path.
-        if self
-            .blockchain
-            .get_raw_transaction_info(&bond.outpoint.txid, None)
-            .is_ok()
-        {
+        // Only a proven "unknown transaction" answer means eviction; any
+        // other backend failure surfaces as an error instead of triggering
+        // a spurious rebroadcast.
+        if !self.blockchain.is_tx_unknown(&bond.outpoint.txid)? {
             return Ok(bond.outpoint.txid);
         }
 
@@ -583,49 +581,18 @@ impl Wallet {
             bond.outpoint.txid
         );
 
-        // The fidelity address is fully determined by the stored locktime and
-        // pubkey, so the replacement pays the exact same script; only the
-        // outpoint changes.
-        let fidelity_addr = Address::p2wsh(
-            fidelity_redeemscript(&bond.lock_time, &bond.pubkey).as_script(),
-            self.store.network,
-        );
-
-        let coins = self.coin_select(
-            bond.amount,
-            feerate,
-            infer_address_type(&fidelity_addr.script_pubkey()),
-            None,
-            None,
-        )?;
-
-        let op_return_data = match maker_address {
-            Some(onion) => Some(self.encode_fidelity_op_return(onion, bond.lock_time)?),
-            None => None,
-        };
-
-        let destination = Destination::Multi {
-            outputs: vec![(fidelity_addr, bond.amount)],
-            op_return_data,
-            change_address_type,
-        };
-
-        let tx = self.spend_coins(&coins, destination, feerate)?;
-        let txid = self.send_tx(&tx)?;
-
-        self.store
-            .fidelity_bond
-            .get_mut(index as usize)
-            .ok_or(FidelityError::BondDoesNotExist)?
-            .outpoint = OutPoint::new(txid, 0);
-        self.save_to_disk()?;
-
-        log::info!("Rebroadcast fidelity bond as {txid}");
+        let tx = bond.tx.as_ref().ok_or(WalletError::General(format!(
+            "fidelity bond at index {index} has no stored transaction to rebroadcast"
+        )))?;
+        let txid = self.send_tx(tx)?;
+        debug_assert_eq!(txid, bond.outpoint.txid);
 
         Ok(txid)
     }
 
     /// Update the confirmation height of a fidelity bond after it confirms.
+    /// Also drops the stored raw transaction, which is only kept as a
+    /// rebroadcast fallback until confirmation.
     pub fn update_fidelity_bond_conf_details(
         &mut self,
         index: u32,
@@ -638,6 +605,7 @@ impl Wallet {
             .ok_or(FidelityError::BondDoesNotExist)?;
 
         bond.conf_height = Some(conf_height);
+        bond.tx = None;
 
         Ok(())
     }
@@ -697,8 +665,13 @@ impl Wallet {
             &fidelity_privkey,
         );
 
+        let mut bond = bond.clone();
+        // The stored raw transaction is a local rebroadcast fallback, not part
+        // of the proof; keep it off the wire.
+        bond.tx = None;
+
         Ok(FidelityProof {
-            bond: bond.clone(),
+            bond,
             cert_hash,
             cert_sig,
         })

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -546,6 +546,85 @@ impl Wallet {
         Ok((index, txid))
     }
 
+    /// Ensure the funding transaction of the bond at `index` is visible to the
+    /// network, returning its txid.
+    ///
+    /// If the original broadcast is still in the mempool or already confirmed,
+    /// its txid is returned unchanged. Otherwise the transaction was evicted
+    /// (e.g. while the maker was offline) and waiting for it would never
+    /// succeed: a new transaction paying the same fidelity address is built,
+    /// broadcast, and the stored bond's outpoint is updated to it.
+    pub fn ensure_fidelity_bond_broadcast(
+        &mut self,
+        index: u32,
+        maker_address: Option<&str>,
+        feerate: f64,
+        change_address_type: AddressType,
+    ) -> Result<Txid, WalletError> {
+        let bond = self
+            .store
+            .fidelity_bond
+            .get(index as usize)
+            .ok_or(FidelityError::BondDoesNotExist)?
+            .clone();
+
+        // With txindex this also finds confirmed transactions, so only a
+        // genuinely missing transaction takes the rebroadcast path.
+        if self
+            .blockchain
+            .get_raw_transaction_info(&bond.outpoint.txid, None)
+            .is_ok()
+        {
+            return Ok(bond.outpoint.txid);
+        }
+
+        log::warn!(
+            "Fidelity bond tx {} is not visible to the backend (evicted from mempool?); rebroadcasting",
+            bond.outpoint.txid
+        );
+
+        // The fidelity address is fully determined by the stored locktime and
+        // pubkey, so the replacement pays the exact same script; only the
+        // outpoint changes.
+        let fidelity_addr = Address::p2wsh(
+            fidelity_redeemscript(&bond.lock_time, &bond.pubkey).as_script(),
+            self.store.network,
+        );
+
+        let coins = self.coin_select(
+            bond.amount,
+            feerate,
+            infer_address_type(&fidelity_addr.script_pubkey()),
+            None,
+            None,
+        )?;
+
+        let op_return_data = match maker_address {
+            Some(onion) => Some(self.encode_fidelity_op_return(onion, bond.lock_time)?),
+            None => None,
+        };
+
+        let destination = Destination::Multi {
+            outputs: vec![(fidelity_addr, bond.amount)],
+            op_return_data,
+            change_address_type,
+        };
+
+        let tx = self.spend_coins(&coins, destination, feerate)?;
+        let txid = self.send_tx(&tx)?;
+
+        self.store
+            .fidelity_bond
+            .get_mut(index as usize)
+            .ok_or(FidelityError::BondDoesNotExist)?
+            .outpoint = OutPoint::new(txid, 0);
+        self.save_to_disk()?;
+
+        log::info!("Rebroadcast fidelity bond as {txid}");
+
+        Ok(txid)
+    }
+
     /// Update the confirmation height of a fidelity bond after it confirms.
     pub fn update_fidelity_bond_conf_details(
         &mut self,

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -12,10 +12,10 @@
 //!   regular transactions: regular sends never select expired fidelity UTXOs, but redemption
 //!   and new bond creation can properly consume them.
 
-use bitcoin::{absolute::LockTime, Amount};
+use bitcoin::{absolute::LockTime, Amount, Txid};
 use bitcoind::bitcoincore_rpc::{Auth, RpcApi};
 use openswap::{
-    maker::start_server,
+    maker::{start_server, MakerServer},
     taker::TakerBehavior,
     utill::MIN_FEE_RATE,
     wallet::{AddressType, Blockchain, CoreRPC, CoreRpcConfig, Destination},
@@ -24,7 +24,11 @@ use openswap::{
 use super::test_framework::*;
 
 use log::info;
-use std::{sync::atomic::Ordering::Relaxed, thread, time::Duration};
+use std::{
+    sync::{atomic::Ordering::Relaxed, Arc},
+    thread,
+    time::Duration,
+};
 /// Pins the two backend answers the maker's funding check rests on: `None` sees a
 /// mempool-only spend, while `Some(false)` — the argument it used to pass — reports
 /// that output live on Core. Pins the backend, not the maker's call site.
@@ -650,4 +654,133 @@ fn test_fidelity_spending() {
     log::info!("SUCCESS: All fidelity spending behavior requirements verified!");
     test_framework.stop();
     block_generation_handle.join().unwrap();
+}
+
+/// Regression test for <https://github.com/citadel-foss/openswap/issues/990>
+///
+/// A maker stopped after broadcasting its fidelity bond but before it confirms
+/// restarts with a pending bond (`conf_height: None`) in the wallet. The
+/// restart must adopt that bond - wait for its confirmation and use it -
+/// instead of silently discarding it and creating a second bond, which would
+/// doubly lock funds.
+///
+/// The behaviour is pinned on exact log lines:
+/// - run 1 takes the create branch once and broadcasts the bond,
+/// - run 2 must log the adopt-a-pending-bond lines and take the
+///   existing-bond branch ("Highest bond at outpoint"),
+/// - across both runs "No active Fidelity Bonds found. Creating one." appears
+///   exactly once, and "Successfully created fidelity bond" never appears
+///   (it only logs when a new bond is created, which the restart must not do).
+#[test]
+fn test_unconfirmed_fidelity_bond_not_duplicated() {
+    // ---- Setup ----
+    let makers_config_map = vec![(8102, None)];
+    let taker_behavior = vec![TakerBehavior::Normal];
+
+    let (test_framework, _takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(makers_config_map, taker_behavior, vec![]);
+
+    log::info!("Running Test: Unconfirmed Fidelity Bond Survives Maker Restart");
+
+    let bitcoind = &test_framework.bitcoind;
+    let maker = makers.first().unwrap();
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+
+    fund_makers(&makers, bitcoind, 1, Amount::ONE_BTC, AddressType::P2TR);
+
+    // ----- Run 1: maker broadcasts a bond, then stops before it confirms -----
+
+    // Pause the background miner so the bond tx cannot confirm while run 1 is up.
+    test_framework.set_block_gen_paused(true);
+
+    let maker_clone = maker.clone();
+    let maker_thread = thread::spawn(move || {
+        // The shutdown below interrupts setup mid-wait and surfaces as an
+        // error; that partial run is the point of the test, so don't unwrap.
+        let _ = start_server(maker_clone);
+    });
+
+    wait_for_log(
+        &log_path,
+        "Fidelity bond broadcast, waiting for confirmation",
+        Duration::from_secs(120),
+    );
+
+    // Pin the preconditions: the bond tx is still unconfirmed on-chain ...
+    let bond_txid: Txid = std::fs::read_to_string(&log_path)
+        .unwrap()
+        .lines()
+        .find(|l| l.contains("Fidelity bond broadcast, waiting for confirmation"))
+        .unwrap()
+        .rsplit(": ")
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(
+        bitcoind.client.get_mempool_entry(&bond_txid).is_ok(),
+        "bond tx {} must still be unconfirmed for this test to mean anything",
+        bond_txid
+    );
+
+    // ... and the create branch ran exactly once.
+    assert_eq!(
+        std::fs::read_to_string(&log_path)
+            .unwrap()
+            .matches("No active Fidelity Bonds found. Creating one.")
+            .count(),
+        1,
+        "run 1 should have created exactly one bond candidate"
+    );
+
+    // Stop the maker while the bond is still unconfirmed.
+    maker.shutdown.store(true, Relaxed);
+    let _ = maker_thread.join();
+
+    // ----- Run 2: the restart must adopt the pending bond, not create a new one -----
+
+    // Resume mining so the restarted maker can wait out the confirmation.
+    test_framework.set_block_gen_paused(false);
+
+    let restarted = Arc::new(MakerServer::init(maker.config.clone()).unwrap());
+    let restarted_clone = restarted.clone();
+    let restarted_thread = thread::spawn(move || {
+        let _ = start_server(restarted_clone);
+    });
+
+    wait_for_makers_setup(std::slice::from_ref(&restarted), 120);
+
+    restarted.shutdown.store(true, Relaxed);
+    let _ = restarted_thread.join();
+
+    // ----- Assertions on the log of both runs -----
+    let log = std::fs::read_to_string(&log_path).unwrap();
+
+    assert!(
+        log.contains("waiting for confirmation instead of creating a new one"),
+        "restart must detect the pending bond and wait for it"
+    );
+    assert!(
+        log.contains("confirmed at height"),
+        "restart must record the pending bond's confirmation"
+    );
+    assert!(
+        log.contains("Highest bond at outpoint"),
+        "restart must take the existing-bond branch with the adopted bond"
+    );
+    assert_eq!(
+        log.matches("No active Fidelity Bonds found. Creating one.")
+            .count(),
+        1,
+        "restart must not take the create-new-bond branch (would doubly lock funds)"
+    );
+    assert!(
+        !log.contains("Successfully created fidelity bond"),
+        "restart must not create a second fidelity bond"
+    );
+
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+
+    log::info!("Unconfirmed fidelity bond restart test completed successfully");
 }

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -707,16 +707,22 @@ fn test_unconfirmed_fidelity_bond_not_duplicated() {
     );
 
     // Pin the preconditions: the bond tx is still unconfirmed on-chain ...
-    let bond_txid: Txid = std::fs::read_to_string(&log_path)
+    let broadcast_line = std::fs::read_to_string(&log_path)
         .unwrap()
         .lines()
         .find(|l| l.contains("Fidelity bond broadcast, waiting for confirmation"))
-        .unwrap()
+        .expect("run 1 must log the bond broadcast line")
+        .to_string();
+    let bond_txid: Txid = broadcast_line
         .rsplit(": ")
         .next()
-        .unwrap()
-        .parse()
-        .unwrap();
+        .and_then(|t| t.trim().parse().ok())
+        .unwrap_or_else(|| {
+            panic!(
+                "could not parse bond txid from log line: {}",
+                broadcast_line
+            )
+        });
     assert!(
         bitcoind.client.get_mempool_entry(&bond_txid).is_ok(),
         "bond tx {} must still be unconfirmed for this test to mean anything",
@@ -749,6 +755,25 @@ fn test_unconfirmed_fidelity_bond_not_duplicated() {
     });
 
     wait_for_makers_setup(std::slice::from_ref(&restarted), 120);
+
+    // State assertions: the restart must hold exactly one bond, and it must be
+    // the one broadcast in run 1. `get_highest_fidelity_index` succeeding means
+    // the bond's confirmation was recorded (valuation requires it).
+    {
+        let wallet_read = restarted.wallet.read().unwrap();
+        let bonds = wallet_read.get_fidelity_bonds();
+        assert_eq!(bonds.len(), 1, "restart must not create a second bond");
+        assert_eq!(
+            bonds[0].outpoint().txid,
+            bond_txid,
+            "restart must adopt the bond broadcast in run 1"
+        );
+        assert_eq!(
+            wallet_read.get_highest_fidelity_index().unwrap(),
+            Some(0),
+            "adopted bond must be valuated, i.e. its confirmation was recorded"
+        );
+    }
 
     restarted.shutdown.store(true, Relaxed);
     let _ = restarted_thread.join();


### PR DESCRIPTION
## Problem

Closes #990.

A fidelity bond is registered in the wallet with `conf_height: None` as soon as it is broadcast (`Wallet::create_fidelity`). If the maker stops before the bond confirms, the next `setup_fidelity_bond` run can't value it: `calculate_bond_value` errors with `BondDoesNotExist` for `conf_height: None`, `get_highest_fidelity_index` silently drops the bond (`Fidelity valuation failed for index 0`), and the maker takes the "No active Fidelity Bonds found. Creating one." branch — broadcasting a **second** bond while the first tx is still in the mempool and will confirm. Funds end up doubly locked.

## Fix

`setup_fidelity_bond` now calls a new `finalize_pending_fidelity_bonds` before deciding whether a bond exists: it finds any live bond with `conf_height: None`, waits for it via `wait_for_tx_confirmation` (bounded by the existing timeouts and the shutdown flag), and records the confirmation height with `update_fidelity_bond_conf_details`. The existing-bond path then adopts the bond normally. The loop handles multiple pending bonds, which can exist if the bug already struck. No-op when there is no pending bond, so the normal startup/renewal flows are unchanged.

## Test

New regression test `fidelity::test_unconfirmed_fidelity_bond_not_duplicated`:

- **Run 1**: pauses the background miner, starts the maker via the top-level `start_server`, waits for the `Fidelity bond broadcast, waiting for confirmation` log, asserts the tx is still unconfirmed in the mempool, then shuts the maker down mid-wait — the exact scenario from the issue.
- **Run 2**: resumes mining, restarts from disk (`MakerServer::init` + `start_server`) and waits for setup.
- **Assertions pin the behavior on exact log lines**: the adopt-a-pending-bond lines appear (`waiting for confirmation instead of creating a new one`, `confirmed at height`, `Highest bond at outpoint`), `No active Fidelity Bonds found. Creating one.` appears exactly once across both runs, and `Successfully created fidelity bond` never appears (it only logs when a new bond is created).

Verified on regtest: the new test passes (~31s); pre-commit checks (rustfmt, clippy `-D warnings`, cargo-hack feature combos, 141 unit tests) all pass.

## Known limitation

If the pending tx was evicted from the mempool while the maker was offline, the wait fails via the existing `TX_CONFIRMATION_TIMEOUT` rather than hanging; rebroadcasting the original tx is not handled (the raw tx isn't stored) and would be a separate enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable fidelity bond transaction fee rates, defaulting to 2.0 sats/vB and enforcing a 1.0 sats/vB relay minimum.
  * Fidelity bond recovery now detects, rebroadcasts, and tracks pending transactions after restarts.

* **Bug Fixes**
  * Prevented duplicate fidelity bonds when an existing bond is awaiting confirmation.
  * Improved recovery when transactions are temporarily missing or confirmations are interrupted.

* **Documentation**
  * Documented the fidelity bond fee-rate configuration and relay minimum.

* **Tests**
  * Added coverage for restart recovery and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->