### PR TITLE
docs: update makerd, maker-cli and taker docs to current CLI state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ secp256k1 = { version = "0.32.0-beta.2", features = ["rand", "global-context"] }
 minreq = { version = "2.12.0", features = ["https"] }
 pbkdf2 = { version = "0.12", features = ["simple"] }
 aes-gcm = "0.10.3"
+zeroize = { version = "1", features = ["derive"] }
+tempfile = "3"
 sha2 = "0.10.9"
 rust-coinselect = "0.1.7"
 crossterm = "0.29.0"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The apps provide the full suite of OpenSwap operations at "near production" qual
 
 Check the [demo doc](./docs/demo.md) for quick setup guides.
 
+For how wallet keys and passphrases are protected — at-rest encryption, in-memory key sealing, and the exact threat model — see [wallet security](./docs/wallet-security.md).
+
 > [!NOTE]
 > These apps should be considered as "examples", rather than products. We encourage all Bitcoin wallet developers to take a look at our [examples](https://github.com/citadel-foss/openswap/tree/master/examples), [ffis](), and [apis](https://github.com/citadel-foss/openswap/blob/master/src/taker/api.rs), to build their own apps, or integrate OpenSwap within their existing apps. App ecosystem diversity is crucial for decentralization.
 

--- a/docs/maker-cli.md
+++ b/docs/maker-cli.md
@@ -30,73 +30,54 @@ This will display a detailed guide about the app and its capabilities.
 #### **Output:**
 
 ```bash
-openswap 0.1.0
-Developers at Citadel FOSS
 A simple command line app to operate the makerd server.
 
-The app works as an RPC client for makerd, useful to access the server, retrieve information, and
-manage server operations.
+The app works as an RPC client for makerd, useful to access the server, retrieve information, and manage server operations.
 
-For more detailed usage information, please refer:
-https://github.com/citadel-foss/openswap/blob/master/docs/maker-cli.md
+For more detailed usage information, please refer: <https://github.com/citadel-foss/openswap/blob/master/docs/maker-cli.md>
 
-This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-foss/openswap/issues
+This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-foss/openswap/issues>
 
-USAGE:
-    maker-cli [OPTIONS] <SUBCOMMAND>
+Usage: maker-cli [OPTIONS] <COMMAND>
 
-OPTIONS:
-    -h, --help
-            Print help information
+Commands:
+  send-ping           Sends a ping to makerd. Will return a pong
+  list-utxo           Lists all utxos in the wallet. Including fidelity bonds
+  list-utxo-swap      Lists utxos received from incoming swaps
+  list-utxo-contract  Lists HTLC contract utxos
+  list-utxo-fidelity  Lists fidelity bond utxos
+  get-balances        Get total wallet balances of different categories. regular: All single signature regular wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract: All live contract transaction balance locked in timelocks. If you see value in this field, you have unfinished or malfinished swaps. You can claim them back with the recover command. fidelity: All coins locked in fidelity bonds. spendable: Spendable amount in wallet (regular + swap balance)
+  get-new-address     Gets a new bitcoin receiving address
+  send-to-address     Send Bitcoin to an external address and return the txid
+  show-tor-address    Show the server tor address
+  show-data-dir       Show the data directory path
+  stop                Shutdown the makerd server
+  show-fidelity       Show all the fidelity bonds, current and previous, with an (index, {bond_proof, is_spent}) tuple
+  sync-wallet         Sync the Maker wallet with the current blockchain state
+  verify-deniability  Verify the deniability proof for a specific swap
+  help                Print this message or the help of the given subcommand(s)
 
-    -p, --rpc-port <RPC_PORT>
-            Sets the rpc-port of Makerd
+Options:
+  -p, --rpc-port <RPC_PORT>
+          Sets the rpc-port of Makerd
+          
+          [default: 127.0.0.1:6103]
 
-            [default: 127.0.0.1:6103]
+  -d, --data-directory <DATA_DIRECTORY>
+          Maker data directory used to read the RPC authentication cookie
 
-    -V, --version
-            Print version information
+  -h, --help
+          Print help (see a summary with '-h')
 
-SUBCOMMANDS:
-    get-balances
-            Get total wallet balances of different categories. regular: All single signature regular
-            wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract:
-            All live contract transaction balance locked in timelocks. If you see value in this
-            field, you have unfinished or malfinished swaps. You can claim them back with the
-            recover command. fidelity: All coins locked in fidelity bonds. spendable: Spendable
-            amount in wallet (regular + swap balance)
-    get-new-address
-            Gets a new bitcoin receiving address
-    help
-            Print this message or the help of the given subcommand(s)
-    list-utxo
-            Lists all utxos in the wallet. Including fidelity bonds
-    list-utxo-contract
-            Lists HTLC contract utxos
-    list-utxo-fidelity
-            Lists fidelity bond utxos
-    list-utxo-swap
-            Lists utxos received from incoming swaps
-    send-ping
-            Sends a ping to makerd. Will return a pong
-    send-to-address
-            Send Bitcoin to an external address and return the txid
-    show-data-dir
-            Show the data directory path
-    show-fidelity
-            Show all the fidelity bonds, current and previous, with an (index, {bond_proof,is_spent}) tuple
-    show-tor-address
-            Show the server tor address
-    stop
-            Shutdown the makerd server
-    sync-wallet
-            Sync the maker wallet with the current blockchain state
+  -V, --version
+          Print version
 ```
 
-### Key Points About the `rpc-port` Argument
+### Key Points About the Arguments
 
-- The `rpc-port` option specifies the RPC port that `makerd` listens on. By default, this is set to **`6103`**.
+- The `rpc-port` option specifies the RPC port that `makerd` listens on. By default, this is set to **`127.0.0.1:6103`**.
+
+- The `-d` or `--data-directory` option points `maker-cli` at the maker's data directory. It defaults to `~/.openswap/maker` and is used to read the **`rpc_cookie`** file that `makerd` writes on startup — every RPC request is authenticated with this token. If you started `makerd` with a custom `--data-directory`, pass the same directory to `maker-cli`.
 
 - #### If you're using the **default configuration**:
 
@@ -110,8 +91,6 @@ SUBCOMMANDS:
 ```
 
 ## For this tutorial, we'll assume the default configuration is being used. Output examples will reflect this setup.
-
-Here's a simplified and easier-to-read version of your content:
 
 ---
 
@@ -186,24 +165,24 @@ $ ./maker-cli show-fidelity
 ```json
 [
   {
-    "amount": 50000,
-    "bond_value": 0,
     "index": 0,
     "outpoint": "6c06a925066b0cf8adb400e53001b20587729407bce7dcb95dcacd038950b0e4:0",
-    "status": "Live"
+    "amount": 10000,
+    "status": "Live",
+    "bond_value": 904
   }
 ]
 ```
 
 This shows our maker's fidelity bond in a clean JSON format:
 
-- **amount**: The amount locked in the fidelity bond (50,000 sats in this example)
-- **bond_value**: The calculated bond value (0 indicates a newly created bond)
 - **index**: The bond index (0 for the first/current bond)
 - **outpoint**: The transaction output point (txid:vout) where the bond is locked
-- **status**: Current status of the bond ("Live" means active and unexpired)
+- **amount**: The amount locked in the fidelity bond (10,000 sats by default)
+- **status**: Current status of the bond ("Live" means active and unspent, "Redeemed" means it has been spent after expiry)
+- **bond_value**: The calculated bond value (only shown for live bonds)
 
-> **Note:** Currently, a maker can have only one active (unexpired) fidelity bond at a time. Once a bond expires and is redeemed, a new fidelity bond can be created.
+> **Note:** Currently, a maker can have only one active (unexpired) fidelity bond at a time. `makerd` automatically creates a new bond once the previous one expires and is redeemed.
 
 ---
 
@@ -221,14 +200,14 @@ $ ./maker-cli list-utxo-fidelity
 [
   {
     "addr": "tb1qttutr6nuum6e5neyddukxrzvnx87eksteu9vzx6xfmrfc30cppqspa6ut2",
-    "amount": 50000,
+    "amount": 10000,
     "confirmations": 1,
     "utxo_type": "fidelity-bond"
   }
 ]
 ```
 
-This lists fidelity bond UTXOs. Since only one live fidelity bond is allowed at a time, this shows a single UTXO of `50,000 sats`. Note that the `txid` and `vout` match the `outpoint` from the `show-fidelity` command, confirming this is the same fidelity bond UTXO.
+This lists fidelity bond UTXOs. Since only one live fidelity bond is allowed at a time, this shows a single UTXO of `10,000 sats`. Note that the `txid` and `vout` match the `outpoint` from the `show-fidelity` command, confirming this is the same fidelity bond UTXO.
 
 ---
 
@@ -245,9 +224,9 @@ $ ./maker-cli get-balances
 ```json
 {
   "contract": 0,
-  "fidelity": 50000,
-  "regular": 1000000,
-  "spendable": 1000000,
+  "fidelity": 10000,
+  "regular": 989000,
+  "spendable": 989000,
   "swap": 0
 }
 ```
@@ -296,10 +275,10 @@ Both categories show zero balances as confirmed by our `get-balances` output:
 $ ./maker-cli get-balances
 {
   "contract": 0,
-  "fidelity": 50000,
-  "regular": 1000000,
-  "spendable": 1000000,
-  "swap": 0,
+  "fidelity": 10000,
+  "regular": 989000,
+  "spendable": 989000,
+  "swap": 0
 }
 ```
 
@@ -315,27 +294,15 @@ $ ./maker-cli list-utxo
 [
   {
     "addr": "tb1qttutr6nuum6e5neyddukxrzvnx87eksteu9vzx6xfmrfc30cppqspa6ut2",
-    "amount": 50000,
+    "amount": 10000,
     "confirmations": 1,
     "utxo_type": "fidelity-bond"
   },
   {
     "addr": "tb1qu332pjytwdu0z73f5xzftkk06hpgdyvjvef9kn",
-    "amount": 80741,
+    "amount": 989000,
     "confirmations": 1,
     "utxo_type": "regular"
-  },
-  {
-    "addr": "tb1qzelepmza0c0gkkvm3aaerr95qjq8eysmkcw76z",
-    "amount": 9540,
-    "confirmations": 1,
-    "utxo_type": "regular"
-  },
-  {
-    "addr": "tb1qrjefrm0puwnl2exjpl73devd7czjqd8rl37wze",
-    "amount": 19124,
-    "confirmations": 1,
-    "utxo_type": "swept-incoming-swap"
   }
 ]
 ```
@@ -347,13 +314,13 @@ This lists all UTXOs in the wallet, including fidelity bonds. We created a fundi
 
 ### Breakdown:
 
-- Initially, we funded the wallet with `0.01 BTC`.
-- `50,000 sats` were used for the fidelity bond.
-- `1,000 sats` were used as the mining fee for the fidelity transaction.
+- Initially, we funded the wallet with `0.01 BTC` (1,000,000 sats).
+- `10,000 sats` were locked in the fidelity bond.
+- `1,000 sats` were paid as the mining fee for the fidelity transaction (at the default `fidelity_feerate` of 2 sats/vB).
 
 The remaining balance after these transactions is:
 
-**949,000 sats** = **1,000,000 sats** (total funding) - **50,000 sats** (for the fidelity bond) - **1,000 sats** (mining fees).
+**989,000 sats** = **1,000,000 sats** (total funding) - **10,000 sats** (for the fidelity bond) - **1,000 sats** (mining fees).
 
 We can verify this balance by running the `get-balances` command, which shows the total wallet balances of different categories:
 
@@ -361,9 +328,9 @@ We can verify this balance by running the `get-balances` command, which shows th
 $ ./maker-cli get-balances
 {
   "contract": 0,
-    "fidelity": 50000,
-    "regular": 949000,
-    "spendable": 949000
+  "fidelity": 10000,
+  "regular": 989000,
+  "spendable": 989000,
   "swap": 0
 }
 ```
@@ -399,27 +366,26 @@ The `send-to-address` command allows us to send Bitcoin to an external address. 
 ```bash
 $ ./maker-cli send-to-address --help
 
-Send Bitcoin to an external address and returns the txid
+Send Bitcoin to an external address and return the txid
 
-USAGE:
-    maker-cli send-to-address --address <ADDRESS> --amount <AMOUNT> --fee <FEE>
+Usage: maker-cli send-to-address [OPTIONS] --address <ADDRESS> --amount <AMOUNT>
 
-OPTIONS:
-    -a, --amount <AMOUNT>      Amount to send in sats
-    -f, --fee <FEE>            Total fee to be paid in sats
-    -h, --help                 Print help information
-    -t, --address <ADDRESS>    Recipient's address
+Options:
+  -t, --address <ADDRESS>  Recipient's address
+  -a, --amount <AMOUNT>    Amount to send in sats
+  -f, --feerate <FEERATE>  Feerate in sats/vByte. Defaults to 2 sats/vByte
+  -h, --help               Print help
 ```
 
 > **Note:**  
-> The command currently requires the `fee` parameter to specify the total mining fee for the transaction instead of using `fee_rate`. This is because the functionality to calculate the fee using a `fee_rate` for transactions that have not been created yet has not been implemented. This process will be improved in the next release.
+> The transaction fee is specified as a fee rate in sats/vByte via the `--feerate` option. If omitted, it defaults to 2 sats/vByte.
 
-Let's now send `10,000 sats` to the derived address, with a mining fee of `1,000 sats`:
+Let's now send `10,000 sats` to the derived address, with a fee rate of 2 sats/vByte:
 
 ```bash
-$ ./maker-cli send-to-address --amount 10000 --address <derived address> --fee 1000
+$ ./maker-cli send-to-address --amount 10000 --address <derived address> --feerate 2
 
-<tx hex>
+<txid>
 ```
 
 This command will create a transaction, send `10,000 sats` from the maker's wallet to the derived address, broadcast the transaction to the network, and return the transaction ID in hex format.
@@ -436,8 +402,8 @@ success
 This syncs the maker wallet with the current blockchain state. On `makerd`, we will see:
 
 ```bash
-INFO openswap::maker::rpc::server - Starting wallet sync.
-INFO openswap::maker::rpc::server - Wallet sync success.
+INFO openswap::maker::rpc::server - Initializing wallet sync
+INFO openswap::maker::rpc::server - Completed wallet sync
 ```
 
 ### Checking Wallet Balances and UTXOs:
@@ -454,7 +420,7 @@ $ ./maker-cli list-utxo-fidelity
 [
   {
     "addr": "tb1qttutr6nuum6e5neyddukxrzvnx87eksteu9vzx6xfmrfc30cppqspa6ut2",
-    "amount": 50000,
+    "amount": 10000,
     "confirmations": 1,
     "utxo_type": "fidelity-bond"
   }
@@ -463,15 +429,15 @@ $ ./maker-cli list-utxo-fidelity
 $ ./maker-cli get-balances
 
 {
-    "regular": 949000,
+    "regular": 978500,
     "swap": 0,
     "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
+    "fidelity": 10000,
+    "spendable": 978500
 }
 ```
 
-> **NOTE**: Fidelity UTXOs are not used for spending purposes. We can only spend these UTXOs by using the `redeem_fidelity` command after the fidelity bond expires. This is why the UTXO list and balance remain unchanged.
+> **NOTE**: Fidelity UTXOs are not used for spending purposes. These UTXOs can only be spent after the fidelity bond expires, which `makerd` handles automatically during bond renewal. This is why the UTXO list and balance remain unchanged.
 
 ---
 
@@ -483,11 +449,11 @@ $ ./maker-cli list-utxo-swap
 
 $ ./maker-cli get-balances
 {
-    "regular": 949000,
+    "regular": 978500,
     "swap": 0,
     "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
+    "fidelity": 10000,
+    "spendable": 978500
 }
 ```
 
@@ -501,11 +467,11 @@ $ ./maker-cli list-utxo-contract
 
 $ ./maker-cli get-balances
 {
-    "regular": 949000,
+    "regular": 978500,
     "swap": 0,
     "contract": 0,
-    "fidelity": 50000,
-    "spendable": 949000
+    "fidelity": 10000,
+    "spendable": 978500
 }
 ```
 
@@ -519,39 +485,43 @@ $ ./maker-cli list-utxo
 [
   {
     "addr": "tb1qttutr6nuum6e5neyddukxrzvnx87eksteu9vzx6xfmrfc30cppqspa6ut2",
-    "amount": 50000,
+    "amount": 10000,
     "confirmations": 1,
     "utxo_type": "fidelity-bond"
   },
   {
     "addr": "tb1qu332pjytwdu0z73f5xzftkk06hpgdyvjvef9kn",
-    "amount": 80741,
+    "amount": 978500,
     "confirmations": 1,
     "utxo_type": "regular"
-  },
-  {
-    "addr": "tb1qzelepmza0c0gkkvm3aaerr95qjq8eysmkcw76z",
-    "amount": 9540,
-    "confirmations": 1,
-    "utxo_type": "regular"
-  },
-  {
-    "addr": "tb1qrjefrm0puwnl2exjpl73devd7czjqd8rl37wze",
-    "amount": 19124,
-    "confirmations": 1,
-    "utxo_type": "swept-incoming-swap"
   }
 ]
 
 $ ./maker-cli get-balances
 {
-    "regular": 938000,
+    "regular": 978500,
     "swap": 0,
     "contract": 0,
-    "fidelity": 50000,
-    "spendable": 938000
+    "fidelity": 10000,
+    "spendable": 978500
 }
 ```
+
+After sending `10,000 sats` with a ~`500 sats` mining fee, the spendable balance dropped from `989,000` to `978,500` sats, and the change was consolidated back into the regular wallet UTXO.
+
+---
+
+### VerifyDeniability
+
+After a completed swap, you can verify the deniability proof for a specific swap ID:
+
+```bash
+$ ./maker-cli verify-deniability --swap-id <swap_id>
+
+Proof valid: swap participated in a completed openswap
+```
+
+If the proof is missing or doesn't check out, the command prints `Proof invalid or not found for this swap ID`.
 
 ---
 
@@ -568,18 +538,13 @@ Shutdown Initiated
 This shuts down the makerd server. Once you run this command, the maker server initiates a shutdown, and we'll see the following logs indicating the shutdown process:
 
 ```bash
- INFO openswap::maker::server - [6102] Maker is shutting down.
- INFO openswap::maker::api - Joining 4 threads
- INFO openswap::maker::api - [6102] Thread RPC Thread joined
- INFO openswap::maker::api - [6102] Thread Contract Watcher Thread joined
- INFO openswap::maker::api - [6102] Thread Idle Client Checker Thread joined
- INFO openswap::maker::api - [6102] Thread Bitcoin Core Connection Checker Thread joined
- INFO openswap::maker::api - Successfully joined 4 threads
- INFO openswap::maker::server - Shutdown wallet sync initiated.
- INFO openswap::maker::server - Shutdown wallet syncing completed.
- INFO openswap::maker::server - Wallet file saved to disk.
- INFO openswap::maker::server - Maker Server is shut down successfully
+ INFO openswap::maker::server - [6102] Server shutting down...
+ INFO openswap::maker::server - shutdown_phase_start pid=... component=maker:6102 phase=wallet_save
+ INFO openswap::maker::server - shutdown_phase_done pid=... component=maker:6102 phase=wallet_save outcome=ok
+ INFO openswap::maker::server - [6102] Server shutdown complete
 ```
+
+On shutdown, `makerd` also removes the `rpc_cookie` file from the data directory.
 
 ---
 

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -18,38 +18,54 @@ Maker stores all its data in a directory located by default at `$HOME/.openswap/
 ### **1. Default Maker Configuration (`~/.openswap/maker/config.toml`):**
 
 ```toml
+# Maker Configuration File
+
+# Network port for client connections
 network_port = 6102
+# RPC port for maker-cli operations
 rpc_port = 6103
+# Socks port for Tor proxy
 socks_port = 9050
+# Control port for Tor interface
 control_port = 9051
+# Authentication password for Tor interface
 tor_auth_password = ""
+# Minimum amount in satoshis that can be swapped
 min_swap_amount = 10000
-fidelity_amount = 50000
-fidelity_timelock = 13104
+# Fidelity Bond amount in satoshis
+fidelity_amount = 10000
+# Fidelity Bond timelock in blocks (must be between 12960 and 25920)
+fidelity_timelock = 15000
+# Fee rate in sats/vB for the fidelity bond transaction (must be at least 1.0)
 fidelity_feerate = 2.0
-connection_type = TOR
+# A fixed base fee charged by the Maker for providing its services (in satoshis)
 base_fee = 500
+# A percentage fee based on the swap amount
 amount_relative_fee_pct = 0.0025
+# A percentage fee based on the swap duration
 time_relative_fee_pct = 0.0001
+# Required confirmations for funding transactions
+required_confirms = 1
 ```
 - `network_port`: TCP port where the Maker listens for incoming OpenSwap protocol messages.
 - `rpc_port`: The port through which `makerd` listens for RPC commands from `maker-cli`.
 - `socks_port`: The Tor Socks Port.  Check the [tor doc](tor.md) for more details.
 - `control_port`: The Tor Control Port. Check the [tor doc](tor.md) for more details.
 - `tor_auth_password`: Optional password for Tor control authentication; empty by default.
-- `min_swap_amount`: Minimum swap amount (in satoshis).
-- `fidelity_amount`: Amount (in satoshis) locked as a fidelity bond to deter Sybil attacks.
-- `fidelity_timelock`: Lock duration in block heights for the fidelity bond.
+- `min_swap_amount`: Minimum swap amount (in satoshis). Values below the protocol minimum of 10,000 sats are rejected at startup.
+- `fidelity_amount`: Amount (in satoshis) locked as a fidelity bond to deter Sybil attacks. Defaults to 10,000 sats.
+- `fidelity_timelock`: Lock duration in block heights for the fidelity bond. Defaults to 15,000 blocks; must be within the accepted range of 12,960–25,920 blocks.
 - `fidelity_feerate`: Fee rate (in sats/vB) for the fidelity bond transaction. Defaults to 2.0; lower values are allowed, but anything below the relay minimum of 1.0 sats/vB is clamped to 1.0.
-- `connection_type`: Specifies the network mode; set to "TOR" in production for privacy, or "CLEARNET" during testing.
 - `base_fee`: A fixed fee charged by the Maker for providing its services (in satoshis).
 - `amount_relative_fee_pct`: A percentage fee based on the swap amount.
 - `time_relative_fee_pct`: A percentage fee based on the swap duration.
+- `required_confirms`: Number of confirmations required for funding transactions (default: 1).
 
-
+> **Note:**  
+> On the first run, if the default `network_port` or `rpc_port` is already in use, `makerd` automatically discovers a free port and persists it to `config.toml`.
 
 > **Important:**  
-> At the moment, OpenSwap operates only on the **TOR** network. The `connection_type` is hardcoded to `TOR`, and the app will only work with this network until multi-network support is added.
+> At the moment, OpenSwap operates only on the **TOR** network for peer-to-peer connections. There is no clearnet option; the app will only work over Tor until multi-network support is added.
 
 ### 2. **wallets Directory**
 
@@ -60,6 +76,10 @@ The default wallet directory is `$HOME/.openswap/maker/wallets`.
 ### 3. **debug.log**
 
 The log file for `makerd`, where debug information is stored for troubleshooting and monitoring.
+
+### 4. **rpc_cookie**
+
+A randomly generated authentication token written by `makerd` on startup and removed on shutdown. `maker-cli` reads this file from the maker data directory to authenticate its RPC requests, so it must be run on the same machine (and with read access to the data directory) as `makerd`.
 
 ---
 
@@ -106,56 +126,57 @@ This will display information about the `makerd` binary and its options.
 **Output:**
 
 ```bash
-openswap 0.1.2
-Developers at Citadel FOSS
 OpenSwap Maker Server
 
-The server requires a Bitcoin Core RPC connection running in Testnet4. It requires a starting
-balance, around 50,000 sats for Fidelity + Swap Liquidity (suggested 50,000 sats). So top up with at
-least 0.001 BTC to start all the node processes. Suggested [faucet
-here] http://xjw3jlepdy35ydwpjuptdbu3y74gyeagcjbuyq7xals2njjxrze6kxid.onion/
+The server requires a Bitcoin Core RPC connection running in Testnet4. It requires some starting balance, around 50,000 sats for Fidelity + Swap Liquidity (suggested 50,000 sats). So topup with at least 0.001 BTC to start all the node processses. Suggested [faucet here]<https://mempool.space/testnet4/faucet>
 
-All server processes will start after the fidelity bond transaction is confirmed. This may take some
-time. Approx: 10 mins. Once the bond is confirmed, the server starts listening for incoming swap
-requests. As it performs swaps for clients, it keeps earning fees.
+All server processes will start after the fidelity bond transaction is confirmed. This may take some time. Approx: 10 mins. Once the bond is confirmed, the server starts listening for incoming swap requests. As it performs swaps for clients, it keeps earning fees.
 
 The server is operated with the maker-cli app, for all basic wallet related operations.
 
-For more detailed usage information, please refer to the [Maker
-Doc] https://github.com/citadel-foss/openswap/blob/master/docs/makerd.md
+For more detailed usage information, please refer the [Maker Doc]<https://github.com/citadel-foss/openswap/blob/master/docs/makerd.md>
 
-This is early beta, and there are known and unknown bugs. Please report issues in the [Project Issue
-Board] https://github.com/citadel-foss/openswap/issues
+This is early beta, and there are known and unknown bugs. Please report issues in the [Project Issue Board]<https://github.com/citadel-foss/openswap/issues>
 
-USAGE:
-    makerd [OPTIONS]
+Usage: makerd [OPTIONS]
 
-OPTIONS:
-    -a, --USER:PASSWORD <USER:PASSWORD>
-            Bitcoin Core RPC authentication string (username, password)
-            
-            [default: user:password]
+Options:
+  -d, --data-directory <DATA_DIRECTORY>
+          Optional DNS data directory. Default value: "~/.openswap/maker"
 
-    -d, --data-directory <DATA_DIRECTORY>
-            Optional data directory. Default value: "~/.openswap/maker"
+  -r, --ADDRESS:PORT <ADDRESS:PORT>
+          Bitcoin Core RPC network address. Conflicts with `--electrum`
+          
+          [default: 127.0.0.1:38332]
 
-    -h, --help
-            Print help information
+  -z, --ZMQ <ZMQ>
+          Bitcoin Core ZMQ address:port value. Defaults to the RPC host on port 28332
 
-    -r, --ADDRESS:PORT <ADDRESS:PORT>
-            Bitcoin Core RPC network address
-            
-            [default: 127.0.0.1:38332]
+  -a, --USER:PASSWORD <USER:PASSWORD>
+          Bitcoin Core RPC authentication string (username, password). Conflicts with `--electrum`
+          
+          [default: user:password]
 
-    -t, --tor-auth <TOR_AUTH>
-            [default: ]
+      --electrum <ELECTRUM_URL>
+          Electrum server URL (e.g. `tcp://localhost:50001`). When set, the wallet is initialised against an Electrum backend instead of Bitcoin Core. Mutually exclusive with the Bitcoin Core flags (--rpc/--zmq/--auth)
 
-    -V, --version
-            Print version information
+      --electrum-tor
+          Route the Electrum backend through the Tor SOCKS proxy on `socks_port`. Works with an onion or a clearnet server; an onion URL needs it. Peer-to-peer Tor is unaffected either way
 
-    -w, --WALLET <WALLET>
-            Optional wallet name. If the wallet exists, load the wallet, else create a new wallet
-            with the given name. Default: maker-wallet
+  -t, --tor-auth <TOR_AUTH>
+          
+
+  -w, --WALLET <WALLET>
+          Optional wallet name. If the wallet exists, load the wallet, else create a new wallet with the given name. Default: maker
+
+  -p, --PASSWORD <PASSWORD>
+          Password for the encryption of the wallet. Required when creating a new wallet (wallet files are always encrypted) and to open an encrypted one. Prefer the OPENSWAP_WALLET_PASSWORD environment variable: a `-p` value is visible in the process list and shell history
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 This will give you detailed information about the options and arguments available for `Makerd`.
@@ -164,7 +185,15 @@ This will give you detailed information about the options and arguments availabl
 
 - The `-r` or `--ADDRESS:PORT` option specifies the Bitcoin Core RPC address and port. By default, this is set to **`127.0.0.1:38332`**.
 
+- The `-z` or `--ZMQ` option specifies the Bitcoin Core ZMQ address. If omitted, it defaults to the RPC host on port **`28332`**.
+
 - The `-a` or `--USER:PASSWORD` option specifies the Bitcoin Core RPC authentication. By default, this is set to **`user:password`**.
+
+- The `--electrum <ELECTRUM_URL>` option switches the wallet to an Electrum backend instead of Bitcoin Core (e.g. `tcp://localhost:50001`). It is mutually exclusive with `--rpc`, `--zmq`, and `--auth`. Add `--electrum-tor` to route the Electrum connection through the Tor SOCKS proxy (required for onion servers). Peer-to-peer Tor is unaffected either way.
+
+- The `-w` or `--WALLET` option selects the wallet file. The default wallet name is **`maker`**.
+
+- The `-p` or `--PASSWORD` option sets the wallet encryption passphrase. It is **required** when creating a new wallet and to open an encrypted one — wallet files are always encrypted (see [wallet security](./wallet-security.md)). Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable: a command-line value is visible in the process list and shell history.
 
 - #### If you're using the **default configuration**:
 
@@ -194,27 +223,26 @@ This will launch `makerd` and connect it to the Bitcoin RPC core running on its 
 - **Wallet Loading**: If an existing wallet file is found at `$HOME/.openswap/maker/wallets`, `makerd` will load it:
 
   ```bash
-  INFO openswap::wallet::api - Wallet file at "/path/to/maker-wallet" successfully loaded.
+  INFO openswap::wallet::api - Wallet file at "/path/to/maker" successfully loaded.
   ```
 
-- **New Wallet Creation**: If no wallet file is found, `makerd` will create a new wallet named `maker-wallet`. Wallet files are always encrypted, so a wallet passphrase must be supplied when creating (and later opening) the wallet. Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable over `-p`/`--PASSWORD` — a command-line value is visible in the process list and shell history:
+- **New Wallet Creation**: If no wallet file is found, `makerd` will create a new wallet named `maker`. Wallet files are always encrypted, so a wallet passphrase must be supplied when creating (and later opening) the wallet. Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable over `-p`/`--PASSWORD` — a command-line value is visible in the process list and shell history:
 
   ```bash
   $ OPENSWAP_WALLET_PASSWORD=my-wallet-passphrase ./makerd -a user:password -r 127.0.0.1:38332
   ```
 
+  On creation, the wallet's mnemonic seed phrase is displayed once on the terminal — back it up securely before continuing:
+
   ```bash
-  INFO openswap::wallet::api - Backup the Wallet Mnemonics.
-  ["harvest", "trust", "catalog", "degree", "oxygen", "business", "crawl", "enemy", "hamster", "music", "this", "idle"]
-  
-  INFO openswap::maker::api - New Wallet created at: "$HOME/.openswap/maker/wallets/maker-wallet".
+  INFO openswap::wallet::api - New Wallet created at : "$HOME/.openswap/maker/wallets/maker".
   ```
 
 - **Configuration File**: If no `config` file exists, `makerd` will create a default `config.toml` file at `$HOME/.openswap/maker/config.toml`:
 
    ```bash
-   WARN openswap::maker::config - Maker config file not found, creating default config file at path: /tmp/openswap/maker/config.toml
-   INFO openswap::maker::config - Successfully loaded config file from: $HOME/.openswap/maker/config.toml
+   WARN openswap::maker::api - Maker config file not found, creating default at: $HOME/.openswap/maker/config.toml
+   INFO openswap::maker::api - Loaded config file from: $HOME/.openswap/maker/config.toml
    ```
 
 - **Wallet Sync**: The wallet will sync to catch up with the latest updates:
@@ -224,68 +252,68 @@ This will launch `makerd` and connect it to the Bitcoin RPC core running on its 
   INFO openswap::wallet::rpc - Completed wallet sync and save
   ```
 
-- **TOR Initialization**: `makerd` will start the TOR process and listen for connections on a TOR address:
-
-  ```bash
-  INFO openswap::maker::server - [6102] Server is listening at 3xvc6tvf455afnogiwhzpztp7r5w43kq4r2yb5oootu7rog6k6rnq4id.onion:6102
-  ```
+- **TOR Initialization**: `makerd` will start the TOR process and listen for connections on a TOR address.
 
 - **Fidelity Bond Check**: `makerd` checks for existing fidelity bonds. 
 
   **If an existing fidelity bond is found**:
   ```bash
-  INFO openswap::wallet::fidelity - Fidelity Bond found | Index: 0 | Bond Value : 0.00043653 BTC
-  INFO openswap::maker::server - Highest bond at outpoint fc11a129...c:0 | Amount 5000000 sats | Remaining Timelock for expiry : 536 Blocks
+  INFO openswap::maker::api - Highest bond at outpoint fc11a129...c:0 | index 0 | Amount 10000 sats | Remaining Timelock: 536 Blocks | Bond Value: 1523 sats
   ```
 
-  **If no fidelity bonds are found**, it will create one using the fidelity amount and timelock from the configuration file. By default, the fidelity amount is `50,000 sats` and the timelock is `13104 blocks`:
+  **If no fidelity bonds are found**, it will create one using the fidelity amount and timelock from the configuration file. By default, the fidelity amount is `10,000 sats` and the timelock is `15,000 blocks`:
 
   ```bash
-  INFO openswap::maker::server - No active Fidelity Bonds found. Creating one.
-  INFO openswap::maker::server - Fidelity value chosen = 0.0005 BTC
-  INFO openswap::maker::server - Fidelity Tx fee = 1000 sats
+  INFO openswap::maker::api - No active Fidelity Bonds found. Creating one.
+  INFO openswap::maker::api - Fidelity value chosen = 10000 sats
+  INFO openswap::maker::api - Fidelity timelock 15000 blocks
   ```
 
-  > **Note**: Currently, the transaction fee for the fidelity bond is hardcoded at `1000 sats`. This approach of directly considering `fee` not `fee rate` will be improved in v0.1.1 milestones.
+  > **Note**: The fidelity bond transaction fee is calculated from the `fidelity_feerate` config value (default 2.0 sats/vB, clamped to the 1.0 sats/vB relay minimum), not a fixed amount.
 
-- **Funding Requirements**: If creating a new fidelity bond and the maker wallet is empty, you'll need to fund it with at least `0.00051000 BTC` to cover the fidelity amount and transaction fee. To fund the wallet, you can use [this faucet](http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/)(open in Tor browser).
+- **Funding Requirements**: If creating a new fidelity bond and the maker wallet is empty, you'll need to fund it — `makerd` will tell you exactly how much is missing and where to send it:
+
+  ```bash
+  WARN openswap::maker::api - Insufficient funds to create fidelity bond.
+  INFO openswap::maker::api - Send at least 0.00010500 BTC to "tb1p..."
+  INFO openswap::maker::api - Next sync in 10 secs
+  ```
+
+  To fund the wallet, you can use [this faucet](http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/)(open in Tor browser).
   We suggest taking `0.01 BTC` testcoins as the extra amount will be used in doing wallet related operations in [maker-cli demo](./maker-cli.md)
 
-- **Regular Wallet Sync**: The server will regularly sync the wallet every 10 seconds, increasing the interval in the pattern 10,20,30,40..., to detect any incoming funds.
+- **Regular Wallet Sync**: The server will regularly sync the wallet every 10 seconds, increasing the interval in the pattern 10,20,30..., to detect any incoming funds.
 
 - **Fidelity Transaction Creation**: Once the server detects sufficient funding (for new setups), it will automatically create and broadcast a fidelity transaction using the funding UTXOs:
 
   ```bash
-  INFO openswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 seen in mempool, waiting for confirmation.
+  INFO openswap::maker::api - [6102] Fidelity bond broadcast, waiting for confirmation: 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23
   ```
   
 - **Fidelity Transaction Confirmation**: Once the transaction is confirmed:
   
   ```bash
-  INFO openswap::wallet::fidelity - Fidelity Transaction 4593a892809621b64418d6bf9590c6536a1fa27f7a136d176ad302fb8ec3ce23 confirmed at blockheight: 229349
-  INFO openswap::maker::server - [6102] Successfully created fidelity bond
+  INFO openswap::maker::api - [6102] Successfully created fidelity bond
   ```
 
 
-- **Thread Spawning**: Several threads will be spawned to handle specific tasks:
+- **Thread Spawning**: Several threads will be spawned to handle specific tasks — a Nostr background task (to announce the fidelity bond), the RPC server, an idle-state checker, and a fidelity renewal loop:
 
   ```bash
-  INFO openswap::maker::server - [6102] Spawning contract-watcher thread
-  INFO openswap::maker::server - [6102] Spawning Client connection status checker thread
-  INFO openswap::maker::server - [6102] Spawning RPC server thread
+  INFO openswap::maker::server - [6102] Spawning nostr background task
   INFO openswap::maker::rpc::server - [6102] RPC socket binding successful at 127.0.0.1:6103
   ```
 
 - **Server Ready**: Finally, the `makerd` server is fully set up and ready to connect with other takers for coin swaps:
 
 ```bash
-INFO openswap::maker::server - [6102] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
+INFO openswap::maker::server - [6102] Server setup complete! Listening on port 6102
 ```
 
 The server will display information about swap liquidity and continue listening for requests:
 
 ```bash
-INFO openswap::maker::server - Swap Liquidity: 5001672 sats | Min: 10000 sats | Listening for requests.
+INFO openswap::maker::api - Swap Liquidity: 5001672 sats | Min: 10000 sats | Listening for requests.
 INFO openswap::maker::server - [6102] Bitcoin Network: regtest
 INFO openswap::maker::server - [6102] Spendable Wallet Balance: 0.05001672 BTC
 ```

--- a/docs/makerd.md
+++ b/docs/makerd.md
@@ -197,7 +197,11 @@ This will launch `makerd` and connect it to the Bitcoin RPC core running on its 
   INFO openswap::wallet::api - Wallet file at "/path/to/maker-wallet" successfully loaded.
   ```
 
-- **New Wallet Creation**: If no wallet file is found, `makerd` will create a new wallet named `maker-wallet`:
+- **New Wallet Creation**: If no wallet file is found, `makerd` will create a new wallet named `maker-wallet`. Wallet files are always encrypted, so a wallet passphrase must be supplied when creating (and later opening) the wallet. Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable over `-p`/`--PASSWORD` — a command-line value is visible in the process list and shell history:
+
+  ```bash
+  $ OPENSWAP_WALLET_PASSWORD=my-wallet-passphrase ./makerd -a user:password -r 127.0.0.1:38332
+  ```
 
   ```bash
   INFO openswap::wallet::api - Backup the Wallet Mnemonics.

--- a/docs/taker.md
+++ b/docs/taker.md
@@ -42,86 +42,78 @@ This will display a detailed guide about the app and its capabilities.
 #### **Output:**
 
 ```bash
-openswap 0.1.2
-Developers at Citadel FOSS
-A simple command line app to operate as a OpenSwap client.
+A simple command line app to operate as openswap client.
 
-The app works as a regular Bitcoin wallet with the added capability to perform openswaps. The app
-requires a running Bitcoin Core node with RPC access. It currently only runs on Testnet4. Suggested
-faucet for getting Signet coins (tor browser required): http://a4ovtjlwiclzy37bjaurcbb6wpl6dtckmlqwrywq7uoajeaz6kth4uyd.onion/
+The app works as a regular Bitcoin wallet with the added capability to perform openswaps. It can talk to either a Bitcoin Core node (over RPC + ZMQ — the default) or an Electrum-protocol server (via `--electrum`). Both paths support the full swap flow and the `restore` subcommand. It currently only runs on Testnet4. Suggested faucet for getting Signet coins (tor browser required): <http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/>
 
-For more detailed usage information, please refer:
-https://github.com/citadel-foss/openswap/blob/master/docs/taker.md
+For more detailed usage information, please refer: <https://github.com/citadel-foss/openswap/blob/master/docs/taker.md>
 
-This is early beta, and there are known and unknown bugs. Please report issues at:
-https://github.com/citadel-foss/openswap/issues
+This is early beta, and there are known and unknown bugs. Please report issues at: <https://github.com/citadel-foss/openswap/issues>
 
-USAGE:
-    taker [OPTIONS] <SUBCOMMAND>
+Usage: taker [OPTIONS] <COMMAND>
 
-OPTIONS:
-    -a, --USER:PASSWORD <USER:PASSWORD>
-            Bitcoin Core RPC authentication string. Ex: username:password
-            
-            [default: user:password]
+Commands:
+  list-utxo           Lists all utxos we know about along with their spend info. This is useful for debugging
+  list-utxo-regular   Lists all single signature wallet Utxos. These are all non-swap regular wallet utxos
+  list-utxo-swap      Lists all utxos received in incoming swaps
+  list-utxo-contract  Lists all utxos that we need to claim via timelock. If you see entries in this list, do a `taker recover` to claim them
+  get-balances        Get total wallet balances of different categories. regular: All single signature regular wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract: All live contract transaction balance locked in timelocks. If you see value in this field, you have unfinished or malfinished swaps. You can claim them back with the recover command. spendable: Spendable amount in wallet (regular + swap balance)
+  get-new-address     Returns a new address
+  send-to-address     Send to an external wallet address
+  fetch-offers        Update the offerbook with current market offers and display them
+  list-offers         List makers from the locally cached offerbook without triggering a network sync
+  poll-maker          Fetch an offer from a single maker address, verify the fidelity proof, and store the result in the offerbook. Adds the maker if absent
+  remove-maker        Remove a maker from the local offerbook by address
+  open-swap           Initiate the openswap process
+  recover             Recover from all failed swaps
+  backup              Backup the selected wallet.
+  restore             Restore a wallet from a backup file
+  verify-deniability  Verify the deniability proof for a specific swap
+  help                Print this message or the help of the given subcommand(s)
 
-    -d, --data-directory <DATA_DIRECTORY>
-            Optional data directory. Default value: "~/.openswap/taker"
+Options:
+  -d, --data-directory <DATA_DIRECTORY>
+          Optional data directory. Default value: "~/.openswap/taker"
 
-    -h, --help
-            Print help information
+  -r, --ADDRESS:PORT <ADDRESS:PORT>
+          Bitcoin Core RPC address:port value. Conflicts with `--electrum`
+          
+          [default: 127.0.0.1:38332]
 
-    -r, --ADDRESS:PORT <ADDRESS:PORT>
-            Bitcoin Core RPC address:port value
-            
-            [default: 127.0.0.1:38332]
+  -z, --ZMQ <ZMQ>
+          Bitcoin Core ZMQ address:port value. Defaults to the RPC host on port 28332
 
-    -t, --tor-auth <TOR_AUTH>
-            [default: ]
+  -a, --USER:PASSWORD <USER:PASSWORD>
+          Bitcoin Core RPC authentication string. Ex: username:password. Conflicts with `--electrum`
+          
+          [default: user:password]
 
-    -v, --verbosity <VERBOSITY>
-            Sets the verbosity level of debug.log file
-            
-            [default: info]
-            [possible values: off, error, warn, info, debug, trace]
+  -t, --tor-auth <TOR_AUTH>
+          
 
-    -V, --version
-            Print version information
+      --electrum <ELECTRUM_URL>
+          Electrum server URL (e.g. `tcp://localhost:50001`). When set, the wallet is initialised against an Electrum backend instead of Bitcoin Core. Mutually exclusive with the Bitcoin Core flags (--rpc/--zmq/--auth). Electrum servers do not serve full blocks, so chain-based fidelity-bond discovery is unavailable — maker discovery relies on nostr relays only
 
-    -w, --WALLET <WALLET>
-            Sets the taker wallet's name. If the wallet file already exists, it will load that
-            wallet. Default: taker-wallet
+      --electrum-tor
+          Route the Electrum backend through the Tor SOCKS proxy on `socks_port`. Works with an onion or a clearnet server; an onion URL needs it. Peer-to-peer Tor is unaffected either way
 
-SUBCOMMANDS:
-    openswap
-            Initiate the openswap process
-    fetch-offers
-            Update the offerbook with current market offers and display them
-    list-offers
-            List makers from the locally cached offerbook without requesting a fresh offer sync
-    get-balances
-            Get total wallet balances of different categories. regular: All single signature regular
-            wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract:
-            All live contract transaction balance locked in timelocks. If you see value in this
-            field, you have unfinished or malfinished swaps. You can claim them back with the
-            recover command. spendable: Spendable amount in wallet (regular + swap balance)
-    get-new-address
-            Returns a new address
-    help
-            Print this message or the help of the given subcommand(s)
-    list-utxo
-            Lists all utxos we know about along with their spend info. This is useful for debugging
-    list-utxo-contract
-            Lists all utxos that we need to claim via timelock. If you see entries in this list, do
-            a `taker recover` to claim them
-    list-utxo-regular
-            Lists all single signature wallet Utxos. These are all non-swap regular wallet utxos
-    list-utxo-swap
-            Lists all utxos received in incoming swaps
-    recover
-            Recover from all failed swaps
-    send-to-address
-            Send to an external wallet address
+  -w, --WALLET <WALLET>
+          Sets the taker wallet's name. If the wallet file already exists, it will load that wallet. Default: taker-wallet
+
+  -p, --PASSWORD <PASSWORD>
+          Password for the encryption of the wallet. Required when creating a new wallet (wallet files are always encrypted) and to open an encrypted one. Prefer the OPENSWAP_WALLET_PASSWORD environment variable: a `-p` value is visible in the process list and shell history
+
+  -v, --verbosity <VERBOSITY>
+          Sets the verbosity level of debug.log file
+          
+          [default: info]
+          [possible values: off, error, warn, info, debug, trace]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 ### Key Points About Command Arguments
@@ -130,7 +122,13 @@ SUBCOMMANDS:
 
 - The `-r` or `--ADDRESS:PORT` option specifies the Bitcoin Core RPC address and port. By default, this is set to `127.0.0.1:38332`.
 
+- The `-z` or `--ZMQ` option specifies the Bitcoin Core ZMQ address. If omitted, it defaults to the RPC host on port `28332`.
+
 - The `-a` or `--USER:PASSWORD` option specifies the Bitcoin Core RPC authentication. By default, this is set to **`user:password`**.
+
+- The `--electrum <ELECTRUM_URL>` option switches the wallet to an Electrum backend instead of Bitcoin Core (e.g. `tcp://localhost:50001`). It is mutually exclusive with `--rpc`, `--zmq`, and `--auth`. Add `--electrum-tor` to route the Electrum connection through the Tor SOCKS proxy (required for onion servers). Peer-to-peer Tor is unaffected either way.
+
+- The `-v` or `--verbosity` option sets the log level of the `debug.log` file (default: `info`).
 
 - #### If you're using the **default configuration**:
 
@@ -217,7 +215,7 @@ $ taker list-utxo
 }
 ```
 
-This lists all UTXOs we know about along with their spend info. Since the wallet is empty, no UTXOs are displayed.
+This lists all UTXOs the wallet knows about, along with their spend info — useful for debugging.
 
 ### List Regular UTXOs
 
@@ -259,7 +257,7 @@ $ taker list-utxo-swap
 }
 ```
 
-This lists all UTXOs received in incoming swaps. Since we haven't performed any openswaps yet, this list is empty.
+This lists all UTXOs received in incoming swaps. In this example the wallet holds one swept swap coin; on a fresh wallet that has never swapped, this list is empty.
 
 ### List Contract UTXOs
 
@@ -284,118 +282,168 @@ Now we are ready to initiate a openswap. We are first going to sync the offer bo
 $ taker fetch-offers
 ```
 
-**Output:**
+This blocks until the offerbook sync cycle completes (including Nostr-based maker discovery), then prints each discovered maker with its state, offer terms, and fidelity bond details, followed by a summary line:
 
-```json
-{
-  "base_fee": 500,
-  "amount_relative_fee_pct": 0.0025,
-  "time_relative_fee_pct": 0.0001,
-  "required_confirms": 1,
-  "minimum_locktime": 20,
-  "max_size": 49949540,
-  "min_size": 10000,
-  "bond_outpoint": "21e3902cc0a2b94602fa94a7d3664f1a4d861df84af5049a334d5ddf402ed7f5:0",
-  "bond_value": 904,
-  "bond_expiry": 28864,
-  "tor_address": "ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202"
-}
+```bash
+Waiting for offerbook synchronization to complete…
+Offerbook synchronized in 12.34s
+
+Discovered 2 makers
+
+
+    Maker
+    ─────
+    Address        : rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102
+    Protocol       : Legacy
+    State          : Good
+
+    Offer
+    ─────
+    Base Fee       : 500
+    Amount Fee %   : 0.0025
+    Time Fee %     : 0.0001
+
+    Limits
+    ──────
+    Min Size       : 10000
+    Max Size       : 49949540
+    Required Conf. : 1
+    Min Locktime   : 20
+
+    Fidelity Bond
+    ─────────────
+    Outpoint       : 21e3902cc0a2b94602fa94a7d3664f1a4d861df84af5049a334d5ddf402ed7f5:0
+    Value          : 904
+    Expiry         : 28864
+
+...
+
+Offerbook summary → good: 2, bad: 0, unresponsive: 0 (total: 2)
 ```
 
-This will fetch the list of available makers and display their offers.
+### List Cached Offers
+
+To list the makers already stored in the local offerbook without triggering a network sync:
+
+```bash
+$ taker list-offers
+```
+
+This prints the same per-maker display as `fetch-offers`, but reads only the locally cached offerbook.
+
+### Poll or Remove a Single Maker
+
+You can fetch and verify the offer of one specific maker (adding it to the offerbook if absent):
+
+```bash
+$ taker poll-maker --address <maker-onion-address:port>
+```
+
+And remove a maker from the local offerbook by address:
+
+```bash
+$ taker remove-maker --address <maker-onion-address:port>
+```
 
 ### Initiate a OpenSwap
 
 Now we can initiate a openswap with the makers:
 
 ```bash
-$ taker openswap
+$ taker open-swap
 ```
 
-This will initiate a openswap with the default parameters. The process typically takes several minutes to complete. You can monitor the swap progress by watching the debug log in a new terminal:
+This initiates a openswap with the default parameters (2 makers, 20,000 sats, legacy protocol). To see all available options, run:
+
+```bash
+$ taker open-swap --help
+```
+
+**Output:**
+
+```bash
+Initiate the openswap process
+
+Usage: taker open-swap [OPTIONS]
+
+Options:
+  -m, --makers <MAKERS>
+          Sets the Maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy. Adding more makers in the swap will incur more swap fees [default: 2]
+  -a, --amount <AMOUNT>
+          Sets the swap amount in sats [default: 20000]
+      --tx-count <TX_COUNT>
+          [default: 1]
+      --protocol <PROTOCOL>
+          Protocol version to use: "legacy" or "taproot" [default: legacy]
+      --maker-address <MAKER_ADDRESSES>
+          Manually specify maker addresses (host:port). Can be repeated. When set, these makers are used directly instead of auto-discovery
+      --auto-select
+          Automatically select UTXOs instead of interactive picker
+      --payment-address <PAYMENT_ADDRESS>
+          PaySwap: settle the swap to this third-party address. The swap amount then means the exact amount the receiver gets
+  -y, --yes
+          Skip the confirmation prompt and proceed immediately
+  -h, --help
+          Print help
+```
+
+By default, the command opens an interactive UTXO picker so you can choose which coins fund the swap; pass `--auto-select` to let the wallet pick them automatically.
+
+The swap runs in two phases. First it prepares the swap — discovering makers, negotiating with each hop, and computing the fees — then prints a summary and asks for confirmation:
+
+```bash
+========== Swap Summary ==========
+Swap ID:   c874d9f7ac7e6230
+Protocol:  Legacy
+Sending:   20000 sats
+
+  Hop 0: ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202 (Legacy)
+         Fees: base=500 sats, amt=0.0025%, time=0.000100%
+         Locktime: 48 blocks, Estimated fee: 550 sats
+  Hop 1: rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102 (Legacy)
+         Fees: base=500 sats, amt=0.0025%, time=0.000100%
+         Locktime: 24 blocks, Estimated fee: 530 sats
+
+Total estimated fee: 1080 sats
+Estimated receive:   18920 sats
+==================================
+
+Proceed with this swap? [y/N]
+```
+
+Confirm with `y` (or pass `-y`/`--yes` upfront) to execute the swap. With `--payment-address <addr>` (PaySwap), the summary instead shows the receiver, the exact amount the receiver gets, and the total openswap cost.
+
+The process typically takes several minutes to complete. You can monitor the swap progress by watching the debug log in a new terminal:
 
 ```bash
 tail -f ~/.openswap/taker/debug.log
 ```
 
 ```bash
-
-2025-09-03T18:58:34.830814322+05:30 INFO openswap::utill - ✅ Logger initialized successfully
-2025-09-03T18:58:34.831885420+05:30 INFO openswap::wallet::api - Wallet file at "/home/keraliss/.openswap/taker/wallets/taker-wallet" successfully loaded.
-2025-09-03T18:58:34.831932106+05:30 INFO openswap::taker::config - Successfully loaded config file from : /home/keraliss/.openswap/taker/config.toml
-2025-09-03T18:58:34.832064049+05:30 INFO openswap::utill - Tor is fully started and operational!
-2025-09-03T18:58:34.832636855+05:30 INFO openswap::taker::api - Succesfully loaded offerbook at : "/home/keraliss/.openswap/taker/offerbook.json"
-2025-09-03T18:58:34.832650756+05:30 INFO openswap::wallet::rpc - Initializing wallet sync and save
-2025-09-03T18:58:35.157963973+05:30 INFO openswap::wallet::rpc - Completed wallet sync and save
-2025-09-03T18:58:35.157987063+05:30 INFO openswap::taker::api - Using regular UTXOs for openswap
-2025-09-03T18:58:35.157991757+05:30 INFO openswap::taker::api - Syncing Offerbook
-2025-09-03T18:58:35.158000831+05:30 INFO openswap::taker::api - Fetching addresses from DNS: lp75qh3del4qot6fmkqq4taqm33pidvk63lncvhlwsllbwrl2f4g4qqd.onion:8080
-2025-09-03T18:58:44.794069324+05:30 INFO openswap::taker::routines - Downloading offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:44.794123815+05:30 INFO openswap::taker::routines - Downloading offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102
-2025-09-03T18:58:53.391435256+05:30 INFO openswap::taker::routines - Downloaded offer from : rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102 
-2025-09-03T18:58:53.641409491+05:30 INFO openswap::taker::routines - Downloaded offer from : ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202 
-2025-09-03T18:58:53.641555305+05:30 INFO openswap::taker::api - Found offer from rywnaguli5qwad2ayqyu3673acyyl5dw7bsjifhge4zohftfi76ybbid.onion:6102. Verifying Fidelity Proof
-2025-09-03T18:58:53.644582350+05:30 INFO openswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
-2025-09-03T18:58:53.644600038+05:30 INFO openswap::taker::api - Found offer from ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202. Verifying Fidelity Proof
-2025-09-03T18:58:53.645776479+05:30 INFO openswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
-2025-09-03T18:58:53.646061049+05:30 INFO openswap::taker::api - Found 5 suitable makers for this swap round
-2025-09-03T18:58:53.646074741+05:30 INFO openswap::taker::api - Initiating openswap with id : c874d9f7ac7e6230
-2025-09-03T18:58:53.646081183+05:30 INFO openswap::taker::api - Initializing First Hop.
-2025-09-03T18:58:53.646089505+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.700488732+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.702775316+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.706404936+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.706461956+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: 3233bcef16eb6c2179fda31d9229c6989111a75f297c9c49859320069cd460e6 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.706768325+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.708215981+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.708262825+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.756678424+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.758990905+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.762458743+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.762508683+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: db7afbbd4a7e7b0e1aa1b27b5f1deef509140413459b272c894a2ee8473eae44 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.762721044+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.763710980+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.763757893+05:30 INFO openswap::taker::api - Choosing next maker: 127.0.0.1:6102
-2025-09-03T18:58:53.813457799+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.815543924+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.819894556+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.820038208+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: a680b1d032a5fa5febd4f2c38743c9aa657783c2d1c713b5748ba6c57c6474d0 | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.820375931+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:53.821413777+05:30 ERROR openswap::taker::api - Failed to obtain sender's contract signatures from first_maker 127.0.0.1:6102: IO(Custom { kind: Other, error: "general SOCKS server failure" })
-2025-09-03T18:58:53.821551711+05:30 INFO openswap::taker::api - Choosing next maker: ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:53.872796787+05:30 INFO openswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 253000 sats, target+fee: 20324 sats)
-2025-09-03T18:58:53.874726933+05:30 INFO openswap::wallet::spend - Adding change output with 232560 sats (fee: 440 sats)
-2025-09-03T18:58:53.877062518+05:30 INFO openswap::wallet::spend - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.877090094+05:30 INFO openswap::wallet::funding - Created Funding tx, txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
-2025-09-03T18:58:53.877509748+05:30 INFO wallet - created funding txes random amounts
-2025-09-03T18:58:54.568365133+05:30 INFO openswap::taker::api - ===> ReqContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:58.263137675+05:30 INFO openswap::taker::api - <=== RespContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:58:58.263583864+05:30 INFO openswap::taker::api - Total Funding Txs Fees: 0.00000440 BTC
-2025-09-03T18:58:58.263606558+05:30 INFO openswap::taker::api - Transaction size: 220 vB (0.220 kvB)
-2025-09-03T18:58:58.291022378+05:30 INFO openswap::taker::api - Broadcasted Funding tx. txid: 5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c
-2025-09-03T18:58:58.291105164+05:30 INFO openswap::taker::api - Waiting for funding transaction confirmation. Txids : [5eacac48877057bdda3e34d1a7e5f93d4d594cde599be166e465b5464501c76c]
-2025-09-03T18:58:58.292556173+05:30 INFO openswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 0 secs
-2025-09-03T18:58:59.062221277+05:30 INFO openswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
-2025-09-03T18:59:29.063641719+05:30 INFO openswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 30 secs
-2025-09-03T18:59:29.683684462+05:30 INFO openswap::taker::api - ===> WaitingFundingConfirmation | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+INFO openswap::wallet::api - Wallet file at "/home/user/.openswap/taker/wallets/taker-wallet" successfully loaded.
+INFO openswap::taker::config - Successfully loaded config file from : /home/user/.openswap/taker/config.toml
+INFO openswap::utill - Tor is fully started and operational!
+INFO openswap::taker::api - Syncing Offerbook
+INFO openswap::taker::api - Found 5 suitable makers for this swap round
+INFO openswap::taker::api - Initiating openswap with id : c874d9f7ac7e6230
+INFO openswap::taker::api - Initializing First Hop.
+INFO openswap::taker::api - Choosing next maker: ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+INFO openswap::wallet::spend - Created Funding tx, txid: 5eacac48... | Size: 220 vB | Fee: 440 sats | Feerate: 2.00 sat/vB
+INFO openswap::taker::api - ===> ReqContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+INFO openswap::taker::api - <=== RespContractSigsForSender | ewaexd2es2uzr34wp26cj5zgph7bug7znmmxolvwzmoeedbiyfgz3wqd.onion:8202
+INFO openswap::taker::api - Broadcasted Funding tx. txid: 5eacac48...
+INFO openswap::taker::api - Waiting for funding transaction confirmation. Txids : [5eacac48...]
 
 .
 .
 .
-.
-.
 
-2025-09-03T19:55:19.045810783+05:30 INFO openswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:55:19.045831823+05:30 INFO openswap::wallet::api - Next sync in 130 secs
-2025-09-03T19:57:29.047058307+05:30 INFO openswap::wallet::api - Transaction confirmed at blockheight: 16032, txid : aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:57:29.047080134+05:30 INFO openswap::wallet::api - Sweep Transaction aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d confirmed at blockheight: 16032
-2025-09-03T19:57:29.047090987+05:30 INFO openswap::wallet::api - Successfully swept incoming swap coin, txid: aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d
-2025-09-03T19:57:29.047106047+05:30 INFO openswap::wallet::api - Successfully removed incoming swaps coins
-2025-09-03T19:57:29.047290187+05:30 INFO openswap::taker::api - Successfully swept 1 incoming swap coins: [aed232df3ce3523434fcd2a8aad7fad02fa858d4be29cf0e1c18dde4a3cefb9d]
-2025-09-03T19:57:29.047300886+05:30 INFO openswap::taker::api - Successfully Completed OpenSwap.
-2025-09-03T19:57:29.047307582+05:30 INFO openswap::taker::api - Shutting down taker.
-2025-09-03T19:57:29.047631218+05:30 INFO openswap::taker::api - offerbook data saved to disk.
-2025-09-03T19:57:29.047740527+05:30 INFO openswap::taker::api - Wallet data saved to disk.
+INFO openswap::wallet::api - Successfully swept incoming swap coin, txid: aed232df...
+INFO openswap::taker::api - Successfully swept 1 incoming swap coins: [aed232df...]
+INFO openswap::taker::api - Successfully Completed OpenSwap.
+INFO openswap::taker::api - Shutting down taker.
+INFO openswap::taker::api - offerbook data saved to disk.
+INFO openswap::taker::api - Wallet data saved to disk.
 ```
 
 ### Recovering Failed Swaps
@@ -414,7 +462,7 @@ $ taker list-utxo-contract
 If you see any UTXOs in the output, you can recover them using the `recover` command:
 
 ```bash
-$ taker  recover
+$ taker recover
 ```
 
 **Output:**
@@ -427,6 +475,38 @@ $ taker  recover
 
 This will attempt to recover all funds from failed swaps. In this case, since there are no unfinished transactions (both incoming and outgoing txids arrays are empty), the recovery process completes immediately with no funds to recover.
 
+### Backing Up the Wallet
+
+To back up the selected wallet (use `-w` to pick a non-default wallet), run:
+
+```bash
+$ taker backup
+```
+
+The backup is created in the current working directory as `<wallet_name>-backup.json`. Backups contain the master key and are always encrypted — you will be prompted interactively for a passphrase.
+
+### Restoring a Wallet
+
+To restore a wallet from a backup file:
+
+```bash
+$ taker restore --backup-file <backup-file>
+```
+
+If no `-w` wallet name is provided, the wallet is restored with its original name stored in the backup; otherwise it is restored under the given name.
+
+### Verifying a Deniability Proof
+
+After a completed swap, you can verify the deniability proof for a specific swap ID:
+
+```bash
+$ taker verify-deniability --swap-id <swap_id>
+
+Proof valid: swap participated in a completed openswap
+```
+
+If the proof is missing or doesn't check out, the command prints `Proof invalid or not found for this swap ID`.
+
 ## Data, Config and Wallets
 
 The taker stores all its data in a data directory. By default, the data directory is located at `$HOME/.openswap/taker`. You can change the data directory by passing the `--data-directory` option to the `taker` command.
@@ -436,6 +516,7 @@ The data directory contains the following files:
 1. `config.toml` - The configuration file for the taker.
 2. `debug.log` - The log file for the taker.
 3. `wallets` directory - Contains the wallet files for the taker.
+4. `offerbook.json` - The locally cached offerbook of known makers, updated by `fetch-offers` and `poll-maker`.
 
 **Default Taker Configuration (`~/.openswap/taker/config.toml`):**
 
@@ -443,13 +524,11 @@ The data directory contains the following files:
 control_port = 9051
 socks_port = 9050
 tor_auth_password = ""
-connection_type = "TOR"
 ```
  
 - `control_port`: The Tor Control Port. Check the [tor doc](tor.md) for more details.
 - `socks_port`: The Tor Socks Port. Check the [tor doc](tor.md) for more details.
 - `tor_auth_password`: Optional password for Tor control authentication; empty by default.
-- `connection_type`: The connection type to use for the directory server. Possible values are `CLEARNET` and `TOR`.
 
 ### Wallets
 

--- a/docs/taker.md
+++ b/docs/taker.md
@@ -126,6 +126,8 @@ SUBCOMMANDS:
 
 ### Key Points About Command Arguments
 
+- The `-p` or `--PASSWORD` option sets the wallet encryption passphrase. It is **required** when creating a new wallet and to open an encrypted one — wallet files are always encrypted (see [wallet security](./wallet-security.md)). Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable: a command-line value is visible in the process list and shell history.
+
 - The `-r` or `--ADDRESS:PORT` option specifies the Bitcoin Core RPC address and port. By default, this is set to `127.0.0.1:38332`.
 
 - The `-a` or `--USER:PASSWORD` option specifies the Bitcoin Core RPC authentication. By default, this is set to **`user:password`**.

--- a/docs/wallet-security.md
+++ b/docs/wallet-security.md
@@ -1,0 +1,131 @@
+# Wallet Key Security
+
+This document describes how openswap protects wallet keys — at rest and in
+memory — the exact threat model, and the known limitations. It reflects the
+design implemented in `src/security.rs` and `src/wallet/storage.rs`
+(`MasterKey`).
+
+## Design overview
+
+### At rest (always encrypted, no opt-out)
+
+- Wallet files are **always** encrypted. There is no cleartext-on-disk wallet
+  format: `WalletStore::write_to_disk` requires key material, and serializing
+  a plaintext master key is a hard error at the serde layer.
+- Encryption is AES-256-GCM. The key is derived from the wallet passphrase
+  with PBKDF2-HMAC-SHA256 (600,000 iterations, per-encryption 16-byte salt,
+  fresh 12-byte nonce per write), following the OWASP password-storage
+  guidance.
+- Wallet **backups** (`*.json`) contain the master key and are likewise always
+  encrypted; the taker CLI backup command always prompts for a passphrase.
+- Writes are atomic: the encrypted payload goes to a tempfile in the same
+  directory, is fsynced, and is renamed over the target — a crash mid-save
+  cannot truncate the only copy of the wallet. Tempfiles are created
+  mode `0600` on Unix.
+
+### The master key is individually sealed
+
+On top of whole-file encryption, the BIP32 master key (`MasterKey` in
+`src/wallet/storage.rs`) is stored as its own AES-256-GCM blob:
+
+- **On disk**, the sealed blob is what gets serialized, so the frequent
+  wallet-state saves (`save_to_disk` runs on every swap state transition)
+  never decrypt the master key.
+- **In memory**, the key stays sealed for the whole process lifetime and is
+  only decrypted inside `Wallet::with_master_key` / `with_account_key`
+  closures — i.e. for the duration of a single signature or derivation — then
+  the plaintext copy is erased.
+- Watch/sync code paths (`watch_wallet_scripts`, restore history probing,
+  prevout construction) derive account **xpubs** inside the key closure and
+  hold no secret material at all.
+
+### Passphrase hygiene
+
+- The passphrase is consumed at wallet load and zeroized; the long-lived
+  `Taker`/`MakerServer` configs hold `None` afterwards.
+- Every KDF boundary (`KeyMaterial::new_from_password`, `existing`,
+  `new_interactive`) zeroizes the passphrase string after derivation.
+- `KeyMaterial` (the derived key) is zeroized on drop and its `Debug` output
+  is redacted. `MasterKey`'s `Debug` is likewise redacted — before this
+  change, `{:?}` on a wallet printed the master xpriv to logs.
+- Prefer the `OPENSWAP_WALLET_PASSWORD` environment variable over
+  `-p`/`--PASSWORD`: a command-line value is visible in `ps` and shell
+  history.
+
+## Threat model
+
+### What this defends against
+
+- **Theft of the wallet file or backups** (disk, cloud sync, stolen server):
+  everything is AES-256-GCM ciphertext with a strong KDF.
+- **Passive memory disclosure**: core dumps, swap/page files, hibernation
+  images, cold-boot reads, crash reporters, accidental `Debug` logging. The
+  plaintext master key's in-memory exposure shrinks from the whole process
+  lifetime to milliseconds per signature.
+- **Accidental plaintext persistence**: the type system refuses to serialize
+  a plaintext master key, and there is no code path that writes an
+  unencrypted wallet file.
+
+### What it does **not** defend against
+
+- **A live attacker reading the process's memory.** A hot wallet must sign
+  autonomously, so the passphrase-derived `KeyMaterial` stays in memory and
+  can be used to unseal the master key. This is inherent to hot wallets;
+  real mitigation requires signer isolation (a separate signing process) or
+  a hardware signer, neither of which is implemented.
+- **Per-swap secrets are not sealed yet.** `IncomingSwapCoin` /
+  `OutgoingSwapCoin` hold `my_privkey`, `other_privkey` and `hash_preimage`
+  in plaintext in memory for the lifetime of an active swap (they *are*
+  encrypted at rest inside the wallet file). An in-memory reader during a
+  swap can steal in-flight swap funds, though not the HD wallet itself.
+  Sealing these is a planned follow-up.
+- **Erasure is best-effort, not guaranteed.** `Xpriv` is `Copy`, so earlier
+  copies may persist on the stack/in registers; `non_secure_erase` explicitly
+  permits the compiler to leave copies; a panic inside a key closure skips
+  the wipe; the extended key's `chain_code` is never erased (not
+  fund-critical: all wallet derivation below the master key is hardened).
+- **Passphrase theft** (keyloggers, phishing the prompt, reading the
+  environment of the process) is out of scope — an attacker with the
+  passphrase has the wallet.
+
+## Operational notes
+
+- **Mandatory passphrase**: `makerd`/`taker` require a wallet passphrase
+  (flag or `OPENSWAP_WALLET_PASSWORD`) both to create a new wallet and to
+  open an existing one. Running without one fails with a clear error.
+- **Legacy migration is one-way**: a pre-encryption wallet file is resealed
+  and rewritten encrypted on first load with a passphrase. Older openswap
+  binaries cannot read the migrated file. Back up before upgrading if you
+  may need to downgrade.
+- **Legacy plaintext backups** restore the same way: supply a passphrase and
+  the restored wallet is encrypted with it.
+- **The BIP39 mnemonic** is shown once at wallet creation and is the ultimate
+  backup — record it offline. It is kept in memory until the CLI displays it
+  (`take_new_mnemonic`) and is not zeroized.
+- **Test builds** (`cfg(test)` / the `integration-test` feature) reduce
+  PBKDF2 to 1 iteration for speed. Never use such a build with real funds.
+- **FFI**: `backup_wallet_gui_app` and `restore_wallet_gui_app` both require
+  a password; `is_wallet_encrypted` still detects legacy plaintext files.
+
+## File formats
+
+Current wallet file (CBOR):
+
+```
+EncryptedData {                       // outer: whole-store encryption
+    nonce, pbkdf2_salt,
+    encrypted_payload: WalletStore {
+        ...
+        master_key: EncryptedData {   // inner: individually sealed master key
+            nonce, pbkdf2_salt,
+            encrypted_payload: Xpriv
+        },
+        ...
+    }
+}
+```
+
+Legacy wallet file (pre-encryption): plaintext CBOR `WalletStore` with a
+plain `Xpriv` in `master_key`. Deserialization accepts both forms of the
+field (untagged); `Wallet::load` reseals and rewrites legacy files on first
+load.

--- a/examples/wallet_basic.rs
+++ b/examples/wallet_basic.rs
@@ -88,7 +88,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(wallet_path.parent().unwrap())?;
 
     let backend = AnyBlockchain::CoreRPC(CoreRPC::new(&rpc_config).unwrap());
-    let mut wallet = Wallet::init(&wallet_path, backend, None).unwrap();
+    // Wallet files are always encrypted; a passphrase is required.
+    let enc_material =
+        openswap::security::KeyMaterial::new_from_password(Some("example-password".to_string()))
+            .unwrap();
+    let mut wallet = Wallet::init(&wallet_path, backend, enc_material).unwrap();
 
     // Swap the two lines above for these to drive the same wallet through an electrs server instead of bitcoind RPC.
     //     use openswap::wallet::{Electrum, ElectrumConfig};
@@ -96,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //         url: "tcp://127.0.0.1:60401".to_string(),
     //     };
     //     let backend = AnyBlockchain::Electrum(Electrum::new(&electrum_config).unwrap());
-    //     let mut wallet = Wallet::init(&wallet_path, backend, None).unwrap();
+    //     let mut wallet = Wallet::init(&wallet_path, backend, enc_material).unwrap();
 
     println!("Wallet initialized successfully!");
 

--- a/src/bin/makerd.rs
+++ b/src/bin/makerd.rs
@@ -69,7 +69,11 @@ struct Cli {
     /// Optional wallet name. If the wallet exists, load the wallet, else create a new wallet with the given name. Default: maker
     #[clap(name = "WALLET", long, short = 'w')]
     pub(crate) wallet_name: Option<String>,
-    /// Optional Password for the encryption of the wallet.
+    /// Password for the encryption of the wallet. Required when creating a
+    /// new wallet (wallet files are always encrypted) and to open an
+    /// encrypted one. Prefer the OPENSWAP_WALLET_PASSWORD environment
+    /// variable: a `-p` value is visible in the process list and shell
+    /// history.
     #[clap(name = "PASSWORD", long, short = 'p')]
     pub password: Option<String>,
 }
@@ -94,7 +98,11 @@ fn main() -> Result<(), MakerError> {
     // operator's wallet and fidelity bond.
     let wallet_name = args.wallet_name.unwrap_or_else(|| "maker".to_string());
     config.wallet_name = wallet_name.clone();
-    config.password = args.password;
+    // CLI flag wins; otherwise fall back to the environment variable, which
+    // unlike `-p` does not expose the passphrase in the process list.
+    config.password = args
+        .password
+        .or_else(|| std::env::var("OPENSWAP_WALLET_PASSWORD").ok());
     if let Some(tor_auth) = args.tor_auth {
         config.tor_auth_password = tor_auth;
     }

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -76,7 +76,11 @@ struct Cli {
     #[clap(name = "WALLET", long, short = 'w')]
     pub wallet_name: Option<String>,
 
-    /// Optional Password for the encryption of the wallet.
+    /// Password for the encryption of the wallet. Required when creating a
+    /// new wallet (wallet files are always encrypted) and to open an
+    /// encrypted one. Prefer the OPENSWAP_WALLET_PASSWORD environment
+    /// variable: a `-p` value is visible in the process list and shell
+    /// history.
     #[clap(name = "PASSWORD", long, short = 'p')]
     pub password: Option<String>,
 
@@ -179,15 +183,12 @@ enum Commands {
     /// The backup will be created in the current working directory with the filename:
     /// `<wallet_name>-backup.json`.
     ///
-    /// Use the `-e, --encrypt` flag to encrypt the backup. If enabled, you will be prompted
-    /// interactively to enter a passphrase.
+    /// Backups contain the master key and are always encrypted; you will be
+    /// prompted interactively to enter a passphrase.
     ///
     ///
     #[clap(verbatim_doc_comment)]
-    Backup {
-        #[clap(long, short = 'e')]
-        encrypt: bool,
-    },
+    Backup,
 
     /// Restore a wallet from a backup file.
     ///
@@ -320,7 +321,7 @@ fn main() -> Result<(), TakerError> {
             args.command,
             Commands::Recover
                 | Commands::FetchOffers
-                | Commands::Backup { .. }
+                | Commands::Backup
                 | Commands::Restore { .. }
                 | Commands::OpenSwap { .. }
         ),
@@ -380,7 +381,12 @@ fn main() -> Result<(), TakerError> {
         tor_auth_password: args.tor_auth.clone().or_else(|| {
             (!file_config.tor_auth_password.is_empty()).then_some(file_config.tor_auth_password)
         }),
-        password: args.password.clone(),
+        // CLI flag wins; otherwise fall back to the environment variable,
+        // which unlike `-p` does not expose the passphrase in the process list.
+        password: args
+            .password
+            .clone()
+            .or_else(|| std::env::var("OPENSWAP_WALLET_PASSWORD").ok()),
         wallet_name: wallet_name.clone(),
         ..TakerInitConfig::default()
     }
@@ -654,9 +660,9 @@ fn main() -> Result<(), TakerError> {
         Commands::Recover => {
             taker.recover_active_swap()?;
         }
-        Commands::Backup { encrypt } => {
+        Commands::Backup => {
             let wallet = lock_debug!(taker.get_wallet().read()).unwrap();
-            Wallet::backup_interactive(&wallet, *encrypt);
+            Wallet::backup_interactive(&wallet);
         }
         Commands::Restore { .. } => {
             // Handled above before taker init

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -580,7 +580,10 @@ impl MakerServer {
         if let AnyBlockchain::CoreRPC(core) = &blockchain {
             core.check_node_requirements().map_err(MakerError::Wallet)?;
         }
-        let mut wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.clone())?;
+        // Take the passphrase out of the config: the wallet keeps the derived
+        // key material, so the cleartext passphrase must not linger in the
+        // long-lived server config.
+        let mut wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.take())?;
         let data_dir = config.data_dir.clone();
         log::info!("Sync at:----MakerServer init----");
         wallet.sync_and_save(&shutdown)?;

--- a/src/security.rs
+++ b/src/security.rs
@@ -14,6 +14,7 @@ use bip39::rand::random;
 use pbkdf2::pbkdf2_hmac_array;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::Sha256;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::utill;
 use std::{fs, path::Path};
@@ -134,7 +135,7 @@ pub struct SerdeCbor;
 impl SerdeFormat for SerdeCbor {
     type Error = serde_cbor::Error;
     fn from_slice<T: DeserializeOwned>(input: &[u8]) -> Result<T, Self::Error> {
-        utill::deserialize_from_cbor::<T>(input.to_vec())
+        utill::deserialize_from_cbor::<T>(input)
     }
 }
 /// A 16-byte (128-bit) salt used with PBKDF2 to derive encryption keys.
@@ -168,7 +169,9 @@ const PBKDF2_ITERATIONS: u32 = 1;
 const PBKDF2_ITERATIONS: u32 = 600_000;
 
 /// Holds derived cryptographic key material used for encrypting and decrypting wallet data.
-#[derive(Debug, Clone)]
+///
+/// Zeroized on drop; `Debug` is redacted so the key never reaches logs.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct KeyMaterial {
     /// A 256-bit key derived from the user’s passphrase via PBKDF2.
     /// This key is used with AES-GCM for encryption/decryption.
@@ -179,17 +182,26 @@ pub struct KeyMaterial {
     /// Key derivation salt, randomly generated to ensure unique keys per password.
     pub pbkdf2_salt: PBKDF2Salt,
 }
+
+/// Redacted: key material must never reach logs.
+impl std::fmt::Debug for KeyMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("KeyMaterial(<redacted>)")
+    }
+}
+
 impl KeyMaterial {
     /// Creates new key material from a password, with a freshly random generated nonce and salt.
+    ///
+    /// The passphrase string is zeroized after key derivation.
     pub fn new_from_password(enc_password: Option<String>) -> Option<Self> {
-        enc_password.map(|pwd| {
+        enc_password.map(|mut pwd| {
             let pbkdf2_salt = random::<PBKDF2Salt>();
+            let key =
+                pbkdf2_hmac_array::<Sha256, 32>(pwd.as_bytes(), &pbkdf2_salt, PBKDF2_ITERATIONS);
+            pwd.zeroize();
             KeyMaterial {
-                key: pbkdf2_hmac_array::<Sha256, 32>(
-                    pwd.as_bytes(),
-                    &pbkdf2_salt,
-                    PBKDF2_ITERATIONS,
-                ),
+                key,
                 nonce: Aes256Gcm::generate_nonce(&mut OsRng).into(),
                 pbkdf2_salt,
             }
@@ -197,27 +209,43 @@ impl KeyMaterial {
     }
     /// Prompts the user interactively for a new encryption passphrase.
     ///
-    /// If the user enters an empty string, returns `None`, indicating no encryption.
-    /// Otherwise, returns `Some(KeyMaterial)` with a newly generated nonce and salt.
+    /// If the user enters an empty string, returns `None`; callers decide
+    /// whether that is acceptable (wallet and backup encryption require a
+    /// non-empty passphrase).
     pub fn new_interactive(prompt: Option<String>) -> Result<Option<Self>, SecurityError> {
-        let enc_password =
-            utill::prompt_password(prompt.unwrap_or(
-                "Enter new encryption passphrase (empty for no encryption): ".to_string(),
-            ))?;
+        let enc_password = utill::prompt_password(
+            prompt.unwrap_or("Enter new encryption passphrase: ".to_string()),
+        )?;
 
         if enc_password.is_empty() {
             Ok(None)
         } else {
             let pbkdf2_salt = random::<PBKDF2Salt>();
+            let mut enc_password = enc_password;
+            let key = pbkdf2_hmac_array::<Sha256, 32>(
+                enc_password.as_bytes(),
+                &pbkdf2_salt,
+                PBKDF2_ITERATIONS,
+            );
+            enc_password.zeroize();
             Ok(Some(KeyMaterial {
-                key: pbkdf2_hmac_array::<Sha256, 32>(
-                    enc_password.as_bytes(),
-                    &pbkdf2_salt,
-                    PBKDF2_ITERATIONS,
-                ),
+                key,
                 nonce: Aes256Gcm::generate_nonce(&mut OsRng).into(),
                 pbkdf2_salt,
             }))
+        }
+    }
+
+    /// Creates ephemeral key material with a random key, nonce, and salt.
+    ///
+    /// The key is never persisted, so anything sealed with it is
+    /// unrecoverable once the process exits. Only used by tests — wallets
+    /// always seal with passphrase-derived material.
+    pub fn new_ephemeral() -> Self {
+        KeyMaterial {
+            key: random::<EncryptionKey>(),
+            nonce: Aes256Gcm::generate_nonce(&mut OsRng).into(),
+            pbkdf2_salt: random::<PBKDF2Salt>(),
         }
     }
 
@@ -225,13 +253,13 @@ impl KeyMaterial {
     ///
     /// This is used when decrypting existing wallet data, where the nonce
     /// and the salt have already been read from disk and are available.
-    pub fn existing(password: String, nonce: EncryptionNonce, pbkdf2_salt: PBKDF2Salt) -> Self {
+    /// The passphrase string is zeroized after key derivation.
+    pub fn existing(mut password: String, nonce: EncryptionNonce, pbkdf2_salt: PBKDF2Salt) -> Self {
+        let key =
+            pbkdf2_hmac_array::<Sha256, 32>(password.as_bytes(), &pbkdf2_salt, PBKDF2_ITERATIONS);
+        password.zeroize();
         KeyMaterial {
-            key: pbkdf2_hmac_array::<Sha256, 32>(
-                password.as_bytes(),
-                &pbkdf2_salt,
-                PBKDF2_ITERATIONS,
-            ),
+            key,
             nonce,
             pbkdf2_salt,
         }
@@ -250,7 +278,7 @@ impl KeyMaterial {
 /// refers to the same value as the nonce. They are conceptually the same in this context.
 ///
 /// This wrapper itself is then serialized to CBOR and written to disk.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct EncryptedData {
     /// Nonce used for AES-GCM encryption (must match during decryption).
     nonce: EncryptionNonce,
@@ -277,8 +305,9 @@ pub fn encrypt_struct<T: Serialize>(
     plain_struct: T,
     enc_material: &KeyMaterial,
 ) -> Result<EncryptedData, EncryptError> {
-    // Serialize wallet data to bytes.
-    let packed_store = serde_cbor::ser::to_vec(&plain_struct)?;
+    // Serialize wallet data to bytes. `Zeroizing` wipes the plaintext buffer
+    // on drop so no serialized copy of the secret survives in freed heap.
+    let packed_store = Zeroizing::new(serde_cbor::ser::to_vec(&plain_struct)?);
 
     // QA: AES-GCM nonce reuse across wallet saves or backup restoration leaks
     // relationships between plaintexts encrypted under the same key.
@@ -321,13 +350,17 @@ pub fn decrypt_struct<T: DeserializeOwned>(
     let cipher = Aes256Gcm::new(&key);
     let nonce = aes_gcm::Nonce::from(nonce_vec);
 
-    // Decrypt the inner CBOR bytes.
-    let plaintext_cbor = cipher
-        .decrypt(&nonce, encrypted_struct.encrypted_payload.as_ref())
-        .map_err(|_| SecurityError::Decryption)?;
+    // Decrypt the inner CBOR bytes. `Zeroizing` wipes the plaintext buffer on
+    // drop so no serialized copy of the secret survives in freed heap.
+    let plaintext_cbor = Zeroizing::new(
+        cipher
+            .decrypt(&nonce, encrypted_struct.encrypted_payload.as_ref())
+            .map_err(|_| SecurityError::Decryption)?,
+    );
 
-    // Deserialize the inner CBOR into the original type
-    Ok(utill::deserialize_from_cbor::<T>(plaintext_cbor)?)
+    // Deserialize the inner CBOR into the original type (borrows the
+    // `Zeroizing` buffer, so no un-wiped copy is made).
+    Ok(utill::deserialize_from_cbor::<T>(&plaintext_cbor)?)
 }
 /// Loads a sensitive struct from a file, supporting both encrypted and plaintext formats.
 ///

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -563,7 +563,7 @@ impl Taker {
     }
 
     /// Initialize a new taker. The backend is resolved from `config` via [`TakerInitConfig::backend`].
-    pub fn init(config: TakerInitConfig) -> Result<Self, TakerError> {
+    pub fn init(mut config: TakerInitConfig) -> Result<Self, TakerError> {
         // Init the Wallet
         let wallet_name = config.wallet_name.clone();
 
@@ -586,7 +586,10 @@ impl Taker {
         if let AnyBlockchain::CoreRPC(core) = &blockchain {
             core.check_node_requirements()?;
         }
-        let wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.clone())?;
+        // Take the passphrase out of the config: the wallet keeps the derived
+        // key material, so the cleartext passphrase must not linger in the
+        // long-lived server config.
+        let wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.take())?;
 
         // Init Watch Service
         let (watch_service, registry, initial_sync_complete) =

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -960,20 +960,24 @@ pub(crate) fn get_tor_hostname(
 }
 
 /// Deserialize any generic type from a CBOR file. The type should impl [serde::de::Deserialize].
-pub fn deserialize_from_cbor<T>(mut reader: Vec<u8>) -> Result<T, serde_cbor::Error>
+pub fn deserialize_from_cbor<T>(reader: &[u8]) -> Result<T, serde_cbor::Error>
 where
     T: serde::de::DeserializeOwned,
 {
-    match serde_cbor::from_slice::<T>(&reader) {
+    match serde_cbor::from_slice::<T>(reader) {
         Ok(store) => Ok(store),
         Err(e) => {
             let err_string = format!("{e:?}");
             if err_string.contains("code: TrailingData") {
                 // Defensive error handling - monitor logs to confirm wallet files stay clean.
                 log::info!("Wallet file has trailing data, trying to restore");
+                let mut end = reader.len();
                 loop {
-                    reader.pop();
-                    match serde_cbor::from_slice::<T>(&reader) {
+                    if end == 0 {
+                        break Err(e);
+                    }
+                    end -= 1;
+                    match serde_cbor::from_slice::<T>(&reader[..end]) {
                         Ok(store) => break Ok(store),
                         Err(_) => continue,
                     }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -14,7 +14,7 @@ use std::{
 
 use std::collections::{HashMap, HashSet};
 
-use crate::security::KeyMaterial;
+use crate::security::{KeyMaterial, SecurityError};
 
 use bip39::Mnemonic;
 #[cfg(not(feature = "integration-test"))]
@@ -25,7 +25,7 @@ use bitcoin::{
     block::Header,
     key::TapTweak,
     secp256k1,
-    secp256k1::{Keypair, Secp256k1, SecretKey},
+    secp256k1::{Keypair, Secp256k1, SecretKey, XOnlyPublicKey},
     sighash::{EcdsaSighashType, Prevouts, SighashCache, TapSighashType},
     Address, Amount, Network, OutPoint, PublicKey, Script, ScriptBuf, Transaction, TxOut, Txid,
     Weight,
@@ -34,6 +34,7 @@ use bitcoind::bitcoincore_rpc::bitcoincore_rpc_json::{ListUnspentResultEntry, Sc
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::Path;
+use zeroize::Zeroize;
 
 use crate::{
     lock_debug,
@@ -103,10 +104,11 @@ pub struct Wallet {
     pub(crate) blockchain: AnyBlockchain,
     pub(crate) wallet_file_path: PathBuf,
     pub(crate) store: WalletStore,
-    /// Optional encryption material derived from the user’s passphrase.
-    /// If present, wallet data will be encrypted/decrypted using AES-GCM.
-    /// The original passphrase is never stored—only the derived key is kept in memory.
-    pub(crate) store_enc_material: Option<KeyMaterial>,
+    /// Encryption material derived from the user’s passphrase. Wallet files
+    /// are always encrypted; this key encrypts the store on disk and seals
+    /// the master key in memory. The original passphrase is never stored —
+    /// only the derived key is kept in memory.
+    pub(crate) store_enc_material: KeyMaterial,
     /// Transient: seed phrase of a wallet created by
     /// [`Wallet::init`]. Read once via [`Wallet::take_new_mnemonic`].
     pub(super) new_mnemonic: Option<SecretMnemonic>,
@@ -153,7 +155,11 @@ impl PartialEq for Wallet {
         //self.store == other.store
         //avoided filename
         self.store.network == other.store.network &&
-        self.store.master_key == other.store.master_key &&
+        // Compare master keys by plaintext (each unsealed with its own
+        // passphrase), not by sealed bytes, so wallets sealed under
+        // different passphrases/nonces still compare equal.
+        self.store.master_key.plaintext_with(&self.store_enc_material) ==
+        other.store.master_key.plaintext_with(&other.store_enc_material) &&
         self.store.external_index == other.store.external_index &&
         self.store.internal_index == other.store.internal_index &&
         self.store.offer_maxsize == other.store.offer_maxsize &&
@@ -405,7 +411,7 @@ impl Wallet {
     pub fn init(
         path: &Path,
         blockchain: AnyBlockchain,
-        store_enc_material: Option<KeyMaterial>,
+        store_enc_material: KeyMaterial,
     ) -> Result<Self, WalletError> {
         let network = blockchain.get_blockchain_info()?.chain;
 
@@ -423,6 +429,8 @@ impl Wallet {
             .to_string();
 
         let wallet_birthday = blockchain.get_block_count()?;
+        // WalletStore::init seals the master key before the first write, so
+        // the plaintext key never reaches disk.
         let store = WalletStore::init(
             file_name,
             path,
@@ -481,14 +489,57 @@ impl Wallet {
 
     /// Load wallet data from file and connect to a blockchain backend.
     /// In case of core rpc, core wallet name, and wallet_id field in the file should match.
-    /// If encryption material is provided, decrypt the wallet store using it.
+    ///
+    /// Wallet files are always encrypted. A legacy unencrypted file is
+    /// migrated on load: it is resealed under the supplied passphrase and
+    /// rewritten encrypted. Loading a legacy file without a passphrase, or
+    /// creating/loading without one where encryption is impossible, fails.
     pub(crate) fn load(
         path: &Path,
         blockchain: AnyBlockchain,
         password: Option<String>,
     ) -> Result<Self, WalletError> {
-        let (store, store_enc_material) =
-            WalletStore::read_from_disk(path, password.unwrap_or_default())?;
+        let password = password.filter(|p| !p.is_empty());
+
+        let migration_material = |store: WalletStore,
+                                  password: Option<String>|
+         -> Result<(WalletStore, KeyMaterial), WalletError> {
+            let password = password.ok_or_else(|| {
+                WalletError::General(format!(
+                    "wallet file {path:?} is unencrypted (legacy format); \
+                     provide the wallet passphrase to migrate it to encrypted storage"
+                ))
+            })?;
+            let material = KeyMaterial::new_from_password(Some(password))
+                .expect("a non-empty passphrase always yields key material");
+            Ok((store, material))
+        };
+
+        let (store, store_enc_material, migrated) =
+            match WalletStore::read_from_disk(path, password.clone().unwrap_or_default()) {
+                Ok((store, Some(material))) => (store, material, false),
+                // Legacy plaintext file, no passphrase supplied.
+                Ok((store, None)) => {
+                    let (store, material) = migration_material(store, password.clone())?;
+                    (store, material, true)
+                }
+                // Passphrase supplied for a legacy plaintext file: read it as
+                // plaintext, then migrate.
+                Err(WalletError::Security(SecurityError::Format(msg)))
+                    if password.is_some() && msg.contains("expected encrypted file") =>
+                {
+                    let (store, None) = WalletStore::read_from_disk(path, String::new())? else {
+                        unreachable!("a plaintext wallet file yields no encryption material")
+                    };
+                    let (store, material) = migration_material(store, password.clone())?;
+                    (store, material, true)
+                }
+                Err(e) => return Err(e),
+            };
+        // Wipe the cleartext passphrase; only the derived key material is kept.
+        if let Some(mut p) = password {
+            p.zeroize();
+        }
 
         if let AnyBlockchain::CoreRPC(core) = &blockchain {
             if core.wallet_name() != store.file_name {
@@ -517,7 +568,7 @@ impl Wallet {
             store.incoming_swapcoins.len(),
             store.outgoing_swapcoins.len()
         );
-        Ok(Self {
+        let mut wallet = Self {
             blockchain,
             wallet_file_path: path.to_path_buf(),
             store,
@@ -525,14 +576,21 @@ impl Wallet {
             new_mnemonic: None,
             locked_utxos: HashSet::new(),
             restore_scan: false,
-        })
+        };
+        wallet.seal_master_key()?;
+        if migrated {
+            // Persist the migration immediately: resealed master key and an
+            // encrypted file. Never leave the legacy plaintext file around.
+            wallet.save_to_disk()?;
+            log::info!("Migrated legacy plaintext wallet {path:?} to encrypted storage");
+        }
+        Ok(wallet)
     }
 
     /// Loads an existing wallet from the given path or initializes a new one if none exists.
     ///
-    /// Prompts the user for an encryption passphrase (unless running tests),
-    /// derives encryption key material if a passphrase is provided,
-    /// and either loads or creates the wallet accordingly.
+    /// Wallet files are always encrypted, so a passphrase is required both to
+    /// open an existing wallet and to create a new one.
     pub(crate) fn load_or_init(
         path: &Path,
         blockchain: AnyBlockchain,
@@ -545,8 +603,15 @@ impl Wallet {
             wallet
         } else {
             // wallet doesn't exists at the given path, create a new one
-
-            let store_enc_material = KeyMaterial::new_from_password(password);
+            let Some(password) = password.filter(|p| !p.is_empty()) else {
+                return Err(WalletError::General(
+                    "a passphrase is required to create a wallet; \
+                     cleartext wallet files are not supported"
+                        .to_string(),
+                ));
+            };
+            let store_enc_material = KeyMaterial::new_from_password(Some(password))
+                .expect("a non-empty passphrase always yields key material");
 
             let wallet = Wallet::init(path, blockchain, store_enc_material)?;
 
@@ -561,6 +626,49 @@ impl Wallet {
     pub(crate) fn save_to_disk(&self) -> Result<(), WalletError> {
         self.store
             .write_to_disk(&self.wallet_file_path, &self.store_enc_material)
+    }
+
+    /// Seals the master key in memory under the wallet's encryption material
+    /// and erases the plaintext copy. Called once at wallet construction
+    /// (load/restore; `WalletStore::init` seals before its first write);
+    /// afterwards the plaintext key only exists transiently inside
+    /// [`Wallet::with_master_key`].
+    pub(crate) fn seal_master_key(&mut self) -> Result<(), WalletError> {
+        self.store.master_key.seal(&self.store_enc_material)
+    }
+
+    /// Runs `f` with the plaintext master key, unsealing the in-memory key
+    /// first and erasing the plaintext copy afterwards. The plaintext key
+    /// must not escape the closure; derive whatever is needed inside it.
+    pub(crate) fn with_master_key<T>(
+        &self,
+        f: impl FnOnce(&Xpriv) -> Result<T, WalletError>,
+    ) -> Result<T, WalletError> {
+        self.store
+            .master_key
+            .with_unlocked(&self.store_enc_material, f)
+    }
+
+    /// Runs `f` with the account-level Xpriv for `address_type`
+    /// (`m/purpose'/coin_type'/0'`), erasing the account key afterwards.
+    /// Prefer this over [`Wallet::with_master_key`] whenever an account key
+    /// suffices — it shortens the master key's exposure and wipes the
+    /// derived key too.
+    pub(crate) fn with_account_key<T>(
+        &self,
+        address_type: AddressType,
+        f: impl FnOnce(&Xpriv) -> Result<T, WalletError>,
+    ) -> Result<T, WalletError> {
+        let secp = crate::utill::global_secp();
+        self.with_master_key(|master_key| {
+            let mut account = master_key.derive_priv(
+                secp,
+                &Self::get_derivation_path(address_type, self.store.network),
+            )?;
+            let result = f(&account);
+            account.private_key.non_secure_erase();
+            result
+        })
     }
 
     /// Adds a incoming swap coin to the wallet.
@@ -1294,11 +1402,8 @@ impl Wallet {
         address_type: AddressType,
     ) -> Result<HashMap<KeychainKind, String>, WalletError> {
         let secp = Secp256k1::new();
-        let derivation_path = Self::get_derivation_path(address_type, self.store.network);
-        let wallet_xpub = Xpub::from_priv(
-            &secp,
-            &self.store.master_key.derive_priv(&secp, &derivation_path)?,
-        );
+        let wallet_xpub =
+            self.with_account_key(address_type, |account| Ok(Xpub::from_priv(&secp, account)))?;
 
         // Get descriptors for external and internal keychain. Other chains are not supported yet.
         [KeychainKind::External, KeychainKind::Internal]
@@ -1369,7 +1474,9 @@ impl Wallet {
     /// Core wallet label is the master Xpub(crate) fingerint.
     pub(crate) fn get_core_wallet_label(&self) -> String {
         let secp = Secp256k1::new();
-        let m_xpub = Xpub::from_priv(&secp, &self.store.master_key);
+        let m_xpub = self
+            .with_master_key(|master_key| Ok(Xpub::from_priv(&secp, master_key)))
+            .expect("in-memory master key unsealing failed");
         m_xpub.fingerprint().to_string()
     }
 
@@ -1533,9 +1640,10 @@ impl Wallet {
                 AddressType::P2WPKH
             };
             let secp = crate::utill::global_secp();
-            let derivation_path = Self::get_derivation_path(address_type, self.store.network);
-            let master_private_key = self.store.master_key.derive_priv(secp, &derivation_path)?;
-            if hd.fingerprint == master_private_key.fingerprint(secp).to_string() {
+            let account_fingerprint = self.with_account_key(address_type, |account| {
+                Ok(account.fingerprint(secp).to_string())
+            })?;
+            if hd.fingerprint == account_fingerprint {
                 return Ok(Some(UTXOSpendInfo::SeedCoin {
                     path: format!("m/{}/{}", hd.keychain_idx, hd.index),
                     input_value: utxo.amount,
@@ -1588,10 +1696,10 @@ impl Wallet {
                 };
 
                 let secp = Secp256k1::new();
-                let derivation_path = Self::get_derivation_path(address_type, self.store.network);
-                let master_private_key =
-                    self.store.master_key.derive_priv(&secp, &derivation_path)?;
-                if fingerprint == master_private_key.fingerprint(&secp).to_string() {
+                let account_fingerprint = self.with_account_key(address_type, |account| {
+                    Ok(account.fingerprint(&secp).to_string())
+                })?;
+                if fingerprint == account_fingerprint {
                     return Ok(Some(UTXOSpendInfo::SeedCoin {
                         path: format!("m/{addr_type}/{index}"),
                         input_value: utxo.amount,
@@ -1825,12 +1933,14 @@ impl Wallet {
             let secp = crate::utill::global_secp();
             let mut accounts = Vec::with_capacity(2);
             for address_type in [AddressType::P2WPKH, AddressType::P2TR] {
+                // Public derivation suffices for history probing, so only the
+                // account xpub leaves the key closure — no secret material is
+                // held for the duration of the scan.
                 accounts.push((
                     address_type,
-                    self.store.master_key.derive_priv(
-                        secp,
-                        &Self::get_derivation_path(address_type, self.store.network),
-                    )?,
+                    self.with_account_key(address_type, |account| {
+                        Ok(Xpub::from_priv(secp, account))
+                    })?,
                 ));
             }
 
@@ -1943,8 +2053,11 @@ impl Wallet {
     pub(crate) fn derive_tor_key(&self) -> [u8; 64] {
         // Hash the 32-byte secp256k1 private key bytes RFC 8032 per 5.1.5,
         // then clamp into a valid Ed25519 expanded key.
-        let mut tor_key =
-            *sha512::Hash::hash(&self.store.master_key.private_key.secret_bytes()).as_byte_array();
+        let mut tor_key = self
+            .with_master_key(|mk| {
+                Ok(*sha512::Hash::hash(&mk.private_key.secret_bytes()).as_byte_array())
+            })
+            .expect("in-memory master key unsealing failed");
         tor_key[0] &= 248;
         tor_key[31] &= 127;
         tor_key[31] |= 64;
@@ -1956,20 +2069,18 @@ impl Wallet {
         &self,
     ) -> Result<(SecretKey, PublicKey, ChainCode), WalletError> {
         let secp = Secp256k1::new();
-        let Xpriv {
-            private_key,
-            chain_code,
-            ..
-        } = self
-            .store
-            .master_key
-            .derive_priv(&secp, &[ChildNumber::from_hardened_idx(175)?])?;
-
-        let public_key = PublicKey {
-            compressed: true,
-            inner: private_key.public_key(&secp),
-        };
-        Ok((private_key, public_key, chain_code))
+        self.with_master_key(|mk| {
+            let mut child = mk.derive_priv(&secp, &[ChildNumber::from_hardened_idx(175)?])?;
+            let public_key = PublicKey {
+                compressed: true,
+                inner: child.private_key.public_key(&secp),
+            };
+            // The returned SecretKey is caller-owned by design; erase the
+            // intermediate extended key it was copied out of.
+            let result = (child.private_key, public_key, child.chain_code);
+            child.private_key.non_secure_erase();
+            Ok(result)
+        })
     }
 
     /// Refreshes the UTXO cache by adding only new UTXOs while preserving existing ones.
@@ -2073,29 +2184,29 @@ impl Wallet {
                         address_type,
                         ..
                     } => {
-                        let base_derivation =
-                            Self::get_derivation_path(*address_type, self.store.network);
-                        let master_private_key = self
-                            .store
-                            .master_key
-                            .derive_priv(&secp, &base_derivation)
+                        // Prevouts only need the script_pubkey: derive it
+                        // from the account xpub so no secret material is
+                        // involved in this pass at all.
+                        let account_xpub = self
+                            .with_account_key(*address_type, |account| {
+                                Ok(Xpub::from_priv(&secp, account))
+                            })
                             .unwrap();
-                        let privkey = master_private_key
-                            .derive_priv(&secp, &DerivationPath::from_str(path).unwrap())
+                        let child_pubkey = account_xpub
+                            .derive_pub(&secp, &DerivationPath::from_str(path).unwrap())
                             .unwrap()
-                            .private_key;
+                            .public_key;
 
                         let script_pubkey = match address_type {
                             AddressType::P2WPKH => {
                                 let pubkey = PublicKey {
                                     compressed: true,
-                                    inner: privkey.public_key(&secp),
+                                    inner: child_pubkey,
                                 };
                                 ScriptBuf::new_p2wpkh(&pubkey.wpubkey_hash().unwrap())
                             }
                             AddressType::P2TR => {
-                                let keypair = Keypair::from_secret_key(&secp, &privkey);
-                                let (x_only_pubkey, _) = keypair.x_only_public_key();
+                                let x_only_pubkey = XOnlyPublicKey::from(child_pubkey);
                                 ScriptBuf::new_p2tr(&secp, x_only_pubkey, None)
                             }
                         };
@@ -2162,13 +2273,11 @@ impl Wallet {
                     address_type,
                     ..
                 } => {
-                    let base_derivation =
-                        Self::get_derivation_path(address_type, self.store.network);
-                    let master_private_key =
-                        self.store.master_key.derive_priv(&secp, &base_derivation)?;
-                    let privkey = master_private_key
-                        .derive_priv(&secp, &DerivationPath::from_str(&path)?)?
-                        .private_key;
+                    let mut privkey = self.with_account_key(address_type, |account| {
+                        Ok(account
+                            .derive_priv(&secp, &DerivationPath::from_str(&path)?)?
+                            .private_key)
+                    })?;
 
                     match address_type {
                         AddressType::P2WPKH => {
@@ -2196,7 +2305,7 @@ impl Wallet {
                             input.witness.push(pubkey.to_bytes());
                         }
                         AddressType::P2TR => {
-                            let keypair = Keypair::from_secret_key(&secp, &privkey);
+                            let mut keypair = Keypair::from_secret_key(&secp, &privkey);
 
                             // Calculate taproot key-spend sighash using all prevouts
                             let sighash = SighashCache::new(&tx_clone)
@@ -2211,8 +2320,10 @@ impl Wallet {
                             let signature = secp.sign_schnorr(&msg, &tweaked_keypair.to_keypair());
 
                             input.witness.push(signature.as_ref());
+                            keypair.non_secure_erase();
                         }
                     }
+                    privkey.non_secure_erase();
                 }
                 UTXOSpendInfo::TimelockContract {
                     swapcoin_multisig_redeemscript,
@@ -3274,15 +3385,17 @@ fn utxo_matches_tx(tx: &Transaction, utxo: &ListUnspentResultEntry) -> bool {
 }
 
 /// scriptPubKey at `(keychain, index)` under an already-derived account key.
-/// Taking the account keeps the expensive hardened derivation out of index loops.
+/// Taking the account keeps the expensive hardened derivation out of index
+/// loops, and using the account *xpub* means watch/probe paths never hold
+/// any secret material.
 fn derive_child_script(
-    account: &Xpriv,
+    account: &Xpub,
     address_type: AddressType,
     keychain: KeychainKind,
     index: u32,
 ) -> Result<ScriptBuf, WalletError> {
     let secp = crate::utill::global_secp();
-    let child = account.derive_priv(
+    let child = account.derive_pub(
         secp,
         &DerivationPath::from(vec![
             ChildNumber::from_normal_idx(keychain.index_num())?,
@@ -3293,7 +3406,7 @@ fn derive_child_script(
         AddressType::P2WPKH => {
             let pk = PublicKey {
                 compressed: true,
-                inner: child.private_key.public_key(secp),
+                inner: child.public_key,
             };
             ScriptBuf::new_p2wpkh(
                 &pk.wpubkey_hash()
@@ -3301,8 +3414,7 @@ fn derive_child_script(
             )
         }
         AddressType::P2TR => {
-            let keypair = Keypair::from_secret_key(secp, &child.private_key);
-            let (xonly, _parity) = keypair.x_only_public_key();
+            let xonly = XOnlyPublicKey::from(child.public_key);
             ScriptBuf::new_p2tr(secp, xonly, None)
         }
     })
@@ -3320,13 +3432,13 @@ impl Wallet {
 
         // Add the descriptor utxos to the watch list.
         for address_type in [AddressType::P2WPKH, AddressType::P2TR] {
-            // Derive the account-level Xpriv once per address_type; every
-            // (keychain, index) below it is then a cheap child derive.
-            let account = self.store.master_key.derive_priv(
-                secp,
-                &Self::get_derivation_path(address_type, self.store.network),
-            )?;
-            let fingerprint = account.fingerprint(secp).to_string();
+            // Watching only needs public derivation: take the account xpub
+            // out of the key closure and hold no secret material for the
+            // duration of the watch loop. Every (keychain, index) below it is
+            // then a cheap public child derive.
+            let account =
+                self.with_account_key(address_type, |account| Ok(Xpub::from_priv(secp, account)))?;
+            let fingerprint = account.fingerprint().to_string();
             let is_taproot = matches!(address_type, AddressType::P2TR);
             for keychain in [KeychainKind::External, KeychainKind::Internal] {
                 for index in 0..=self.max_watch_index(keychain)? {
@@ -3757,13 +3869,15 @@ mod prevout_contract_tests {
 
     fn test_wallet(path: &Path) -> Wallet {
         let master_key = Xpriv::new_master(bitcoin::Network::Regtest, &[42; 32]).unwrap();
+        let enc_material =
+            KeyMaterial::new_from_password(Some("test-password".to_string())).unwrap();
         let store = WalletStore::init(
             "prevout-contract-test".to_string(),
             path,
             bitcoin::Network::Regtest,
             master_key,
             None,
-            &None,
+            &enc_material,
         )
         .unwrap();
 
@@ -3774,7 +3888,7 @@ mod prevout_contract_tests {
             blockchain,
             wallet_file_path: path.to_path_buf(),
             store,
-            store_enc_material: None,
+            store_enc_material: enc_material,
             new_mnemonic: None,
             locked_utxos: HashSet::new(),
             restore_scan: false,
@@ -3867,7 +3981,8 @@ mod prevout_contract_tests {
             .prevout_to_contract_map
             .contains_key(&new_prevout));
 
-        let (reloaded_store, _) = WalletStore::read_from_disk(&wallet_path, String::new()).unwrap();
+        let (reloaded_store, _) =
+            WalletStore::read_from_disk(&wallet_path, "test-password".to_string()).unwrap();
         assert_eq!(
             reloaded_store.prevout_to_contract_map.get(&prevout),
             Some(&approved_contract)
@@ -3958,25 +4073,28 @@ mod restore_history_probe_tests {
         url
     }
 
-    fn account_for(address_type: AddressType) -> Xpriv {
+    fn account_for(address_type: AddressType) -> Xpub {
+        let secp = crate::utill::global_secp();
         let master = Xpriv::new_master(bitcoin::Network::Regtest, &MASTER_SEED).unwrap();
-        master
+        let account = master
             .derive_priv(
-                crate::utill::global_secp(),
+                secp,
                 &Wallet::get_derivation_path(address_type, bitcoin::Network::Regtest),
             )
-            .unwrap()
+            .unwrap();
+        Xpub::from_priv(secp, &account)
     }
 
     fn stub_wallet(path: &Path, url: String) -> Wallet {
         let master_key = Xpriv::new_master(bitcoin::Network::Regtest, &MASTER_SEED).unwrap();
+        let enc_material = KeyMaterial::new_ephemeral();
         let store = WalletStore::init(
             "restore-probe-test".to_string(),
             path,
             bitcoin::Network::Regtest,
             master_key,
             None,
-            &None,
+            &enc_material,
         )
         .unwrap();
         let electrum = Electrum::new(&crate::wallet::ElectrumConfig {
@@ -3989,7 +4107,7 @@ mod restore_history_probe_tests {
             blockchain: AnyBlockchain::Electrum(electrum),
             wallet_file_path: path.to_path_buf(),
             store,
-            store_enc_material: None,
+            store_enc_material: enc_material,
             new_mnemonic: None,
             locked_utxos: HashSet::new(),
             restore_scan: true,

--- a/src/wallet/backup.rs
+++ b/src/wallet/backup.rs
@@ -36,7 +36,9 @@ impl From<&Wallet> for WalletBackup {
     fn from(wallet: &Wallet) -> Self {
         WalletBackup {
             network: (wallet.store.network),
-            master_key: (wallet.store.master_key),
+            master_key: wallet
+                .with_master_key(|master_key| Ok(*master_key))
+                .expect("in-memory master key unsealing failed"),
             wallet_birthday: (wallet.store.wallet_birthday),
             file_name: (wallet.store.file_name.clone()),
         }
@@ -45,19 +47,10 @@ impl From<&Wallet> for WalletBackup {
 impl Wallet {
     /// Creates a backup of the wallet and writes it to the given path.
     ///
-    /// The backup is saved as a `.json` file. If encryption material is provided,
-    /// the backup content is encrypted before being written.
-    ///
-    /// # Behavior
-    ///
-    /// - If encryption is used, the backup content is encrypted and serialized.
-    /// - If not, a warning is printed, and the backup is stored unencrypted.
-    /// - The final backup file will have a `.json` extension.
-    pub fn backup(
-        &self,
-        path: &Path,
-        backup_enc_material: Option<KeyMaterial>,
-    ) -> Result<(), WalletError> {
+    /// The backup is saved as a `.json` file, encrypted with the provided
+    /// key material. Backups are always encrypted: they contain the master
+    /// key, so a cleartext-on-disk form is not supported by design.
+    pub fn backup(&self, path: &Path, backup_enc_material: KeyMaterial) -> Result<(), WalletError> {
         let mut backup_path = path.join("");
         backup_path.set_extension("json");
 
@@ -65,18 +58,9 @@ impl Wallet {
 
         let backup = WalletBackup::from(self);
 
-        let backup_file_content = match backup_enc_material {
-            Some(key_material) => {
-                let encrypted = encrypt_struct(backup, &key_material).map_err(|e| {
-                    WalletError::General(format!("wallet backup encryption failed: {e:?}"))
-                })?;
-                serde_json::to_string_pretty(&encrypted)?
-            }
-            None => {
-                log::info!("Warning! The wallet backup file will be saved unencrypted!");
-                serde_json::to_string_pretty(&backup)?
-            }
-        };
+        let encrypted = encrypt_struct(backup, &backup_enc_material)
+            .map_err(|e| WalletError::General(format!("wallet backup encryption failed: {e:?}")))?;
+        let backup_file_content = serde_json::to_string_pretty(&encrypted)?;
         let mut file = fs::File::create(backup_path)?;
         file.write_all(backup_file_content.as_bytes())?;
 
@@ -101,7 +85,7 @@ impl Wallet {
         wallet_backup: &WalletBackup,
         wallet_path: &Path,
         backend_config: &BackendConfig,
-        restored_enc_material: Option<KeyMaterial>,
+        restored_enc_material: KeyMaterial,
     ) -> Result<Wallet, WalletError> {
         if wallet_path.exists() {
             return Err(WalletError::General(format!(
@@ -158,6 +142,7 @@ impl Wallet {
             // Flag to use the RESTORE_ADDRESS_GAP instead of normal gap while restoring.
             restore_scan: true,
         };
+        tmp_wallet.seal_master_key()?;
         tmp_wallet.sync_and_save(&crate::utill::NO_SHUTDOWN)?;
         tmp_wallet.restore_scan = false;
 
@@ -179,7 +164,7 @@ impl Wallet {
         wallet_path: &Path,
         backend_config: &BackendConfig,
         wallet_birthday: Option<u64>,
-        restored_enc_material: Option<KeyMaterial>,
+        restored_enc_material: KeyMaterial,
     ) -> Result<Wallet, WalletError> {
         let network = AnyBlockchain::from_config(backend_config)?
             .get_blockchain_info()?
@@ -255,9 +240,16 @@ impl Wallet {
                 }
             };
         let restore_enc_material = match KeyMaterial::new_interactive(Some(
-            "Enter restored walled encryption passphrase(empty for no encryption): ".to_string(),
+            "Enter restored wallet encryption passphrase: ".to_string(),
         )) {
-            Ok(material) => material,
+            Ok(Some(material)) => material,
+            Ok(None) => {
+                log::error!(
+                    "Wallet restore failed: a passphrase is required; \
+                     cleartext wallet files are not supported"
+                );
+                return;
+            }
             Err(err) => {
                 log::error!("Encryption passphrase prompt failed: {err}");
                 return;
@@ -273,18 +265,18 @@ impl Wallet {
             println!("Wallet restore succeeded!");
         }
     }
-    /// Interactively creates a wallet backup, optionally encrypted.
+    /// Interactively creates a wallet backup.
     ///
     /// This is a user-friendly version of the [`Wallet::backup`] method, which:
     /// - Uses the current working directory as the backup location.
-    /// - Prompts the user to input encryption material (if `encrypt` is `true`).
+    /// - Prompts the user for the encryption passphrase (backups contain the
+    ///   master key, so they are always encrypted).
     ///
     /// # Behavior
     ///
-    /// - Prompts for encryption key if `encrypt == true`.
     /// - Names the backup file as `{wallet_name}-backup.json`.
     /// - Writes the backup to the current working directory.
-    pub fn backup_interactive(wallet: &Self, encrypt: bool) {
+    pub fn backup_interactive(wallet: &Self) {
         log::info!("Initiating wallet backup!");
         let backup_name = format!("{}-backup", wallet.get_name());
         log::info!(
@@ -301,16 +293,19 @@ impl Wallet {
             }
         };
 
-        let backup_enc_material = if encrypt {
-            match KeyMaterial::new_interactive(None) {
-                Ok(material) => material,
-                Err(err) => {
-                    log::error!("Encryption passphrase prompt failed: {err}");
-                    return;
-                }
+        let backup_enc_material = match KeyMaterial::new_interactive(None) {
+            Ok(Some(material)) => material,
+            Ok(None) => {
+                log::error!(
+                    "Wallet backup failed: a passphrase is required; \
+                     cleartext backups are not supported"
+                );
+                return;
             }
-        } else {
-            None
+            Err(err) => {
+                log::error!("Encryption passphrase prompt failed: {err}");
+                return;
+            }
         };
 
         let backup_path = working_directory.join(backup_name);

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -4,7 +4,7 @@
 //! for exposing swap functionality and reporting to other languages.
 
 use crate::{
-    security::{load_sensitive_struct, KeyMaterial, SerdeJson},
+    security::{load_sensitive_struct, KeyMaterial, SecurityError, SerdeJson},
     utill::{get_taker_dir, parse_checked_address, MIN_FEE_RATE},
     wallet::{infer_address_type, AddressType, Destination, Wallet, WalletBackup, WalletError},
 };
@@ -18,11 +18,11 @@ pub use super::report::{
     MakerFeeInfo, MakerReport, RecoveryReport, SwapRole, SwapStatus, TakerReport,
 };
 
-/// Restores a wallet from an encrypted or unencrypted JSON backup file for GUI/FFI applications.
+/// Restores a wallet from a JSON backup file for GUI/FFI applications.
 ///
 /// This is a non-interactive restore method designed for programmatic use via FFI bindings.
 /// Unlike `restore_wallet`, this function accepts a path to a JSON backup file and handles both
-/// encrypted and unencrypted backups using [`load_sensitive_struct`].
+/// encrypted and legacy plaintext backups using [`load_sensitive_struct`].
 ///
 /// # Behavior
 ///
@@ -35,9 +35,10 @@ pub use super::report::{
 ///
 /// - `data_dir`: Target directory, defaults to `~/.openswap/taker`
 /// - `wallet_file_name`: Restored wallet filename, defaults to name from backup if empty
-/// - `backup_file_path`: Path to the JSON file containing the wallet backup (encrypted or plain)
-/// - `password`: Required if the backup is encrypted. Supplying a non-empty password
-///   also requires the backup file itself to be encrypted; plaintext is rejected.
+/// - `backup_file_path`: Path to the JSON file containing the wallet backup (encrypted,
+///   or a legacy plaintext backup, which is migrated)
+/// - `password`: Required. Decrypts an encrypted backup; for a legacy plaintext
+///   backup it becomes the passphrase of the restored (always encrypted) wallet.
 pub fn restore_wallet_gui_app(
     data_dir: Option<PathBuf>,
     wallet_file_name: Option<String>,
@@ -45,11 +46,37 @@ pub fn restore_wallet_gui_app(
     backup_file_path: PathBuf,
     password: Option<String>,
 ) {
+    let password = password.filter(|p| !p.is_empty());
+    let Some(password) = password else {
+        log::error!(
+            "Wallet restore failed: a passphrase is required; \
+             cleartext wallet files are not supported"
+        );
+        return;
+    };
     let (backup, encryption_material) = match load_sensitive_struct::<WalletBackup, SerdeJson>(
         &backup_file_path,
-        Some(password.unwrap_or_default()),
+        Some(password.clone()),
     ) {
-        Ok(backup) => backup,
+        Ok((backup, Some(material))) => (backup, material),
+        Ok((_, None)) => {
+            unreachable!("a supplied passphrase either decrypts or errors")
+        }
+        // A passphrase was supplied for a legacy plaintext backup: read it
+        // as plaintext and encrypt the restored wallet with that passphrase.
+        Err(SecurityError::Format(msg)) if msg.contains("expected encrypted file") => {
+            match load_sensitive_struct::<WalletBackup, SerdeJson>(&backup_file_path, None) {
+                Ok((backup, _)) => {
+                    let material = KeyMaterial::new_from_password(Some(password))
+                        .expect("a non-empty passphrase always yields key material");
+                    (backup, material)
+                }
+                Err(err) => {
+                    log::error!("Wallet backup load failed: {err}");
+                    return;
+                }
+            }
+        }
         Err(err) => {
             log::error!("Wallet backup load failed: {err}");
             return;
@@ -78,36 +105,36 @@ pub fn restore_wallet_gui_app(
 }
 
 impl Wallet {
-    /// Creates a wallet backup for GUI/FFI applications with optional encryption.
+    /// Creates a wallet backup for GUI/FFI applications.
     ///
-    /// This is a ffi-only wrapper around [`Wallet::backup`] that handles encryption
-    /// material generation internally based on whether a password is provided.
-    ///
-    /// # Behavior
-    ///
-    /// - If `password` is `Some(pwd)` and not empty: Creates encrypted backup using the password
-    /// - If `password` is `None` or empty string: Creates unencrypted backup (logs warning)
-    /// - The backup is written as a `.json` file at the specified path
+    /// This is a ffi-only wrapper around [`Wallet::backup`] that derives the
+    /// encryption material from the provided password. Backups contain the
+    /// master key and are always encrypted; a missing or empty password is
+    /// an error.
     ///
     /// # Parameters
     ///
     /// - `destination_path`: Destination file path for the backup (`.json`)
-    /// - `password`: Optional password for encryption. Use `None` or empty string for plaintext backup
+    /// - `password`: Required password used to encrypt the backup
     ///
     /// # Example
     ///
     /// ```ignore
-    /// // Encrypted backup
-    /// wallet.backup_gui_app("/path/to/backup".to_string(), Some("my_password".to_string()))?;
-    ///
-    /// // Unencrypted backup
-    /// wallet.backup_gui_app("/path/to/backup".to_string(), None)?;
+    /// wallet.backup_wallet_gui_app("/path/to/backup".to_string(), Some("my_password".to_string()))?;
     pub fn backup_wallet_gui_app(
         &self,
         destination_path: String,
         password: Option<String>,
     ) -> Result<(), WalletError> {
-        let km = KeyMaterial::new_from_password(password);
+        let Some(password) = password.filter(|p| !p.is_empty()) else {
+            return Err(WalletError::General(
+                "a passphrase is required for wallet backups; \
+                 cleartext backups are not supported"
+                    .to_string(),
+            ));
+        };
+        let km = KeyMaterial::new_from_password(Some(password))
+            .expect("a non-empty passphrase always yields key material");
         let backup_path = Path::new(&destination_path);
         self.backup(backup_path, km)?;
 

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -404,11 +404,11 @@ impl Wallet {
 
         let child_derivation_path = derivation_path.child(ChildNumber::Normal { index });
 
-        Ok(self
-            .store
-            .master_key
-            .derive_priv(&secp, &child_derivation_path)?
-            .to_keypair(&secp))
+        self.with_master_key(|mk| {
+            Ok(mk
+                .derive_priv(&secp, &child_derivation_path)?
+                .to_keypair(&secp))
+        })
     }
 
     /// Derives the fidelity redeemscript from bond values at a given index.

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -1,9 +1,15 @@
 //! The Wallet Storage Interface.
 //!
-//! Wallet data is currently written in unencrypted CBOR files which are not directly human readable.
+//! Wallet data is written to disk as AES-256-GCM-encrypted CBOR; there is no
+//! cleartext-on-disk wallet format by design (legacy cleartext files are
+//! still readable, for one-time migration by `Wallet::load`). The master key
+//! is additionally sealed individually, see [`MasterKey`].
 
 use crate::{
-    security::{encrypt_struct, load_sensitive_struct, KeyMaterial, SerdeCbor},
+    security::{
+        decrypt_struct, encrypt_struct, load_sensitive_struct, EncryptedData, KeyMaterial,
+        SerdeCbor,
+    },
     wallet::UTXOSpendInfo,
 };
 
@@ -13,7 +19,7 @@ use bitcoin::{bip32::Xpriv, Network, OutPoint, ScriptBuf};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
-    fs::{self, File},
+    fs::File,
     io::BufWriter,
     path::Path,
 };
@@ -32,6 +38,135 @@ pub enum AddressType {
     P2TR,
 }
 
+/// The wallet's BIP32 master key.
+///
+/// The key is kept *sealed* — AES-256-GCM-encrypted under the wallet's
+/// passphrase-derived key — both in memory and on disk (the sealed blob is
+/// what gets serialized; there is no cleartext-on-disk form by design). It
+/// is only decrypted transiently when a signature or key derivation
+/// requires it, which shrinks the window in which the plaintext key is
+/// exposed to memory-scraping malware from the whole process lifetime to
+/// the duration of a single signing operation.
+///
+/// Note: the sealing key itself must remain in memory for a hot wallet to
+/// sign autonomously, so this defends against passive memory disclosure
+/// (core dumps, swap, cold reads), not against a live attacker reading the
+/// process's memory. Erasure is best-effort (`Xpriv` is `Copy`; a panic
+/// inside the closure skips the wipe; the chain code is never erased).
+/// See `docs/wallet-security.md` for the full threat model.
+pub(crate) enum MasterKey {
+    /// Plaintext key. Transient: only present while a legacy (pre-encryption)
+    /// wallet file is being migrated and resealed, or in tests. Must never
+    /// reach disk — see [`MasterKey`]'s `Serialize` impl.
+    Plaintext(Xpriv),
+    /// Sealed (encrypted) key blob. This is the only serializable state.
+    Sealed(EncryptedData),
+}
+
+impl MasterKey {
+    /// Seals a plaintext key in place, erasing the plaintext copy. No-op if
+    /// the key is already sealed.
+    pub(crate) fn seal(&mut self, key: &KeyMaterial) -> Result<(), WalletError> {
+        if let Self::Plaintext(xpriv) = self {
+            let data = encrypt_struct(xpriv, key)
+                .map_err(|e| WalletError::General(format!("master key sealing failed: {e:?}")))?;
+            let mut old = std::mem::replace(self, Self::Sealed(data));
+            if let Self::Plaintext(old_xpriv) = &mut old {
+                old_xpriv.private_key.non_secure_erase();
+            }
+        }
+        Ok(())
+    }
+
+    /// Unseals the key (if sealed), runs `f` with the plaintext, then erases
+    /// the plaintext copy. The plaintext key must not escape the closure;
+    /// derive whatever is needed inside it.
+    pub(crate) fn with_unlocked<T>(
+        &self,
+        key: &KeyMaterial,
+        f: impl FnOnce(&Xpriv) -> Result<T, WalletError>,
+    ) -> Result<T, WalletError> {
+        match self {
+            Self::Plaintext(xpriv) => f(xpriv),
+            Self::Sealed(data) => {
+                let mut xpriv: Xpriv = decrypt_struct(data.clone(), key)?;
+                let result = f(&xpriv);
+                xpriv.private_key.non_secure_erase();
+                result
+            }
+        }
+    }
+
+    /// Returns the plaintext key, unsealing first if necessary.
+    ///
+    /// Only used where the surrounding interface cannot propagate errors
+    /// (`PartialEq`); prefer [`MasterKey::with_unlocked`].
+    pub(crate) fn plaintext_with(&self, key: &KeyMaterial) -> Option<Xpriv> {
+        match self {
+            Self::Plaintext(xpriv) => Some(*xpriv),
+            Self::Sealed(data) => decrypt_struct(data.clone(), key).ok(),
+        }
+    }
+}
+
+/// Byte-wise equality of the stored representation: two loads of the same
+/// wallet file compare equal. To compare master keys across different
+/// passphrases or sealings, decrypt both via [`MasterKey::plaintext_with`]
+/// (as `Wallet`'s `PartialEq` does).
+impl PartialEq for MasterKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Plaintext(a), Self::Plaintext(b)) => a == b,
+            (Self::Sealed(a), Self::Sealed(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+/// Redacted: never print key material, sealed or not.
+impl std::fmt::Debug for MasterKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plaintext(_) => f.write_str("MasterKey(<plaintext>)"),
+            Self::Sealed(_) => f.write_str("MasterKey(<sealed>)"),
+        }
+    }
+}
+
+/// Only the sealed blob is serializable: a plaintext master key must never
+/// be written to disk, so attempting to serialize one is a hard error.
+/// Serializing the sealed form never decrypts anything, which keeps
+/// plaintext out of the (frequent) wallet-state save path entirely.
+impl Serialize for MasterKey {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Sealed(data) => data.serialize(serializer),
+            Self::Plaintext(_) => Err(serde::ser::Error::custom(
+                "plaintext master key must never be serialized",
+            )),
+        }
+    }
+}
+
+/// On-disk representation: new wallet files store the sealed blob; legacy
+/// files store a plain [`Xpriv`], which deserializes into the transient
+/// [`MasterKey::Plaintext`] state for migration (`Wallet::load` reseals and
+/// rewrites the file encrypted right after loading).
+impl<'de> Deserialize<'de> for MasterKey {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum MasterKeyWire {
+            Sealed(EncryptedData),
+            Legacy(Xpriv),
+        }
+        Ok(match MasterKeyWire::deserialize(deserializer)? {
+            MasterKeyWire::Sealed(data) => Self::Sealed(data),
+            MasterKeyWire::Legacy(xpriv) => Self::Plaintext(xpriv),
+        })
+    }
+}
+
 /// Represents the internal data store for a Bitcoin wallet.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct WalletStore {
@@ -39,8 +174,9 @@ pub(crate) struct WalletStore {
     pub(crate) file_name: String,
     /// Network the wallet operates on.
     pub(crate) network: Network,
-    /// The master key for the wallet.
-    pub(super) master_key: Xpriv,
+    /// The master key for the wallet. Sealed (encrypted) in memory; only
+    /// unsealed transiently for signing, see [`MasterKey`].
+    pub(super) master_key: MasterKey,
     /// The external index for the wallet.
     pub(super) external_index: u32,
     /// The internal index for the wallet.
@@ -72,18 +208,21 @@ pub(crate) struct WalletStore {
 
 impl WalletStore {
     /// Initialize a store at a path (if path already exists, it will overwrite it).
+    ///
+    /// The master key is sealed with `store_enc_material` before the first
+    /// write, so the plaintext key never reaches disk.
     pub(crate) fn init(
         file_name: String,
         path: &Path,
         network: Network,
         master_key: Xpriv,
         wallet_birthday: Option<u64>,
-        store_enc_material: &Option<KeyMaterial>,
+        store_enc_material: &KeyMaterial,
     ) -> Result<Self, WalletError> {
-        let store = Self {
+        let mut store = Self {
             file_name,
             network,
-            master_key,
+            master_key: MasterKey::Plaintext(master_key),
             external_index: 0,
             internal_index: 0,
             offer_maxsize: 0,
@@ -97,6 +236,7 @@ impl WalletStore {
             wallet_birthday,
             utxo_cache: HashMap::new(),
         };
+        store.master_key.seal(store_enc_material)?;
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -111,38 +251,29 @@ impl WalletStore {
     }
 
     /// Load existing file, updates it, writes it back (errors if path doesn't exist).
+    ///
+    /// The wallet file is always encrypted: there is no cleartext-on-disk
+    /// form by design. The write is atomic — a tempfile in the same
+    /// directory, fsynced and renamed over the target — so a crash mid-save
+    /// cannot truncate the only copy of the wallet.
     pub(crate) fn write_to_disk(
         &self,
         path: &Path,
-        store_enc_material: &Option<KeyMaterial>,
+        store_enc_material: &KeyMaterial,
     ) -> Result<(), WalletError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        let wallet_file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)?;
-        let writer = BufWriter::new(wallet_file);
+        let encrypted = encrypt_struct(self, store_enc_material)
+            .map_err(|e| WalletError::General(format!("wallet store encryption failed: {e:?}")))?;
 
-        match store_enc_material {
-            Some(material) => {
-                // Encryption branch: encrypt the serialized wallet before writing.
-
-                let encrypted = encrypt_struct(self, material).map_err(|e| {
-                    WalletError::General(format!("wallet store encryption failed: {e:?}"))
-                })?;
-
-                // Write encrypted wallet data to disk.
-                serde_cbor::to_writer(writer, &encrypted)?;
-            }
-            None => {
-                // No encryption: serialize and write the wallet directly.
-                serde_cbor::to_writer(writer, &self)?;
-            }
-        }
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        serde_cbor::to_writer(BufWriter::new(&mut tmp), &encrypted)?;
+        tmp.as_file().sync_all()?;
+        tmp.persist(path)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         Ok(())
     }
 
@@ -173,6 +304,8 @@ mod tests {
             let seed: [u8; 16] = thread_rng().gen();
             Xpriv::new_master(Network::Bitcoin, &seed).unwrap()
         };
+        let password = "wallet password".to_string();
+        let encryption_material = KeyMaterial::new_from_password(Some(password.clone())).unwrap();
 
         let original_wallet_store = WalletStore::init(
             "test_wallet".to_string(),
@@ -180,42 +313,88 @@ mod tests {
             Network::Bitcoin,
             master_key,
             None,
-            &None,
+            &encryption_material,
         )
         .unwrap();
 
         original_wallet_store
-            .write_to_disk(&file_path, &None)
+            .write_to_disk(&file_path, &encryption_material)
             .unwrap();
 
-        let (read_wallet, _nonce) = WalletStore::read_from_disk(&file_path, String::new()).unwrap();
+        let (read_wallet, material) = WalletStore::read_from_disk(&file_path, password).unwrap();
+        assert!(material.is_some());
         assert_eq!(original_wallet_store, read_wallet);
     }
 
     #[test]
-    fn rejects_plaintext_wallet_when_password_is_supplied() {
-        let temp_dir = tempdir().unwrap();
-        let file_path = temp_dir.path().join("test_wallet.cbor");
+    fn sealed_master_key_roundtrips() {
         let seed: [u8; 16] = thread_rng().gen();
-        let master_key = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+        let xpriv = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+        let material = KeyMaterial::new_ephemeral();
 
-        WalletStore::init(
-            "test_wallet".to_string(),
+        let mut key = MasterKey::Plaintext(xpriv);
+        key.seal(&material).unwrap();
+        assert!(matches!(key, MasterKey::Sealed(_)));
+
+        // Unsealing yields the original key.
+        let unsealed = key.with_unlocked(&material, |k| Ok(*k)).unwrap();
+        assert_eq!(unsealed, xpriv);
+
+        // The sealed blob survives a serde roundtrip and still unseals.
+        let bytes = serde_cbor::to_vec(&key).unwrap();
+        let read_back: MasterKey = serde_cbor::from_slice(&bytes).unwrap();
+        assert_eq!(key, read_back);
+        assert_eq!(
+            read_back.with_unlocked(&material, |k| Ok(*k)).unwrap(),
+            xpriv
+        );
+
+        // A legacy plaintext representation still deserializes (into the
+        // transient migration state)...
+        let legacy: MasterKey =
+            serde_cbor::from_slice(&serde_cbor::to_vec(&xpriv).unwrap()).unwrap();
+        assert_eq!(legacy, MasterKey::Plaintext(xpriv));
+
+        // ...but serializing a plaintext key is a hard error: cleartext must
+        // never reach disk.
+        assert!(serde_cbor::to_vec(&legacy).is_err());
+
+        // Debug output never contains key material.
+        assert_eq!(format!("{key:?}"), "MasterKey(<sealed>)");
+        assert_eq!(format!("{legacy:?}"), "MasterKey(<plaintext>)");
+    }
+
+    #[test]
+    fn sealed_master_key_survives_encrypted_store_roundtrip() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("sealed_wallet.cbor");
+        let seed: [u8; 16] = thread_rng().gen();
+        let xpriv = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+        let password = "wallet password".to_string();
+        let encryption_material = KeyMaterial::new_from_password(Some(password.clone())).unwrap();
+
+        // init seals the master key before the first write.
+        let store = WalletStore::init(
+            "sealed_wallet".to_string(),
             &file_path,
             Network::Bitcoin,
-            master_key,
+            xpriv,
             None,
-            &None,
+            &encryption_material,
         )
         .unwrap();
+        assert!(matches!(store.master_key, MasterKey::Sealed(_)));
+        store
+            .write_to_disk(&file_path, &encryption_material)
+            .unwrap();
 
-        let load_result = WalletStore::read_from_disk(&file_path, "wallet password".to_string());
-        let error = load_result.expect_err("a password must require an encrypted wallet file");
-        assert!(
-            error.to_string().contains("expected encrypted file"),
-            "unexpected error: {}",
-            error
-        );
+        let (read_store, _) = WalletStore::read_from_disk(&file_path, password).unwrap();
+        assert_eq!(store, read_store);
+        let unsealed = read_store
+            .master_key
+            .with_unlocked(&encryption_material, |k| Ok(*k))
+            .unwrap();
+        assert_eq!(unsealed, xpriv);
     }
 
     #[test]
@@ -225,7 +404,7 @@ mod tests {
         let seed: [u8; 16] = thread_rng().gen();
         let master_key = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
         let password = "wallet password".to_string();
-        let encryption_material = KeyMaterial::new_from_password(Some(password.clone()));
+        let encryption_material = KeyMaterial::new_from_password(Some(password.clone())).unwrap();
 
         let original_wallet_store = WalletStore::init(
             "test_wallet".to_string(),

--- a/tests/integration/taker_cli.rs
+++ b/tests/integration/taker_cli.rs
@@ -66,6 +66,10 @@ impl TakerCli {
         args.push("--WALLET");
         args.push("test_wallet");
 
+        // Wallet files are always encrypted; a passphrase is required.
+        args.push("--PASSWORD");
+        args.push("integration-test");
+
         args.push("--ZMQ");
         args.push(&self.zmq_addr);
 

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -730,6 +730,9 @@ impl TestFramework {
                         .with_backend(backend)
                         .with_nostr_relays(vec![nostr_relay_url.clone()]);
                     config.wallet_name = taker_id;
+                    // Wallet files are always encrypted; tests use a fixed
+                    // passphrase (PBKDF2 rounds are 1 under `integration-test`).
+                    config.password = Some("integration-test".to_string());
                     let mut taker = Taker::init(config).unwrap();
                     taker.behavior = behavior;
                     taker
@@ -768,6 +771,9 @@ impl TestFramework {
                         fidelity_timelock: 950,     // ~950 blocks for test
                         network: bitcoin::Network::Regtest,
                         nostr_relays: vec![nostr_relay_url.clone()],
+                        // Wallet files are always encrypted; tests use a fixed
+                        // passphrase (PBKDF2 rounds are 1 under `integration-test`).
+                        password: Some("integration-test".to_string()),
                         ..MakerServerConfig::default()
                     }
                     .with_backend(backend);
@@ -848,6 +854,9 @@ impl TestFramework {
             .with_backend(backend)
             .with_nostr_relays(vec![self.nostr_relay_url.clone()]);
         config.wallet_name = taker_id;
+        // Must match the passphrase set in `TestFramework::init`, or the
+        // re-init cannot decrypt the wallet.
+        config.password = Some("integration-test".to_string());
         config
     }
 

--- a/tests/integration/wallet_backup.rs
+++ b/tests/integration/wallet_backup.rs
@@ -82,8 +82,8 @@ fn send_and_mine(
 }
 
 #[test]
-fn plainwallet_plainbackup_plainrestore() {
-    info!("Running Test: Creating Wallet file, backing it up, then receive a payment, and restore backup");
+fn legacy_plain_backup_restores_into_encrypted_wallet() {
+    info!("Running Test: legacy plaintext backup restores into an encrypted wallet");
 
     let (
         original_wallet,
@@ -92,33 +92,42 @@ fn plainwallet_plainbackup_plainrestore() {
         mut bitcoind,
         restored_wallet_file,
         root_dir,
-    ) = setup("plain_wallet_plainbackup_plain_restore".to_string());
+    ) = setup("legacy_plain_backup_restore".to_string());
+
+    let km = KeyMaterial::new_from_password(Some("integration-test".to_string())).unwrap();
 
     let mut wallet = Wallet::init(
         &original_wallet,
         AnyBlockchain::CoreRPC(CoreRPC::new(&rpc_config).unwrap()),
-        None,
+        km,
     )
     .unwrap();
 
     let addr = wallet.get_next_external_address(AddressType::P2TR).unwrap();
     send_and_mine(&mut bitcoind, &addr, 0.05, 1).unwrap();
 
-    let _ = wallet.backup(&wallet_backup_file, None);
+    // Simulate a legacy plaintext backup file; backups are always encrypted now.
+    let backup_json = serde_json::to_string_pretty(&WalletBackup::from(&wallet)).unwrap();
+    fs::write(&wallet_backup_file, backup_json).unwrap();
 
     let addr = wallet.get_next_external_address(AddressType::P2TR).unwrap();
     send_and_mine(&mut bitcoind, &addr, 0.05, 1).unwrap();
 
     wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
-    let (backup, _) =
+    let (backup, material) =
         load_sensitive_struct::<WalletBackup, SerdeJson>(&wallet_backup_file, None).unwrap();
+    assert!(material.is_none(), "legacy backup must be plaintext");
 
+    // Restore under a *different* passphrase: the restored wallet is encrypted
+    // with it, and wallet equality compares the underlying master keys.
+    let restore_km =
+        KeyMaterial::new_from_password(Some("restored-wallet-password".to_string())).unwrap();
     let restored_wallet = Wallet::restore(
         &backup,
         &restored_wallet_file,
         &BackendConfig::CoreRpc(rpc_config.clone()),
-        None,
+        restore_km,
     )
     .unwrap();
 
@@ -129,7 +138,7 @@ fn plainwallet_plainbackup_plainrestore() {
 
     cleanup(&mut bitcoind, &root_dir);
 
-    info!("🎉 Wallet Backup and Restore after tx test ran successfully!");
+    info!("🎉 Legacy plaintext backup migration test ran successfully!");
 }
 
 #[test]
@@ -143,7 +152,7 @@ fn encwallet_encbackup_encrestore() {
         root_dir,
     ) = setup("encwallet_encbackup_encrestore".to_string());
 
-    let km = KeyMaterial::new_from_password(Some("integration-test".to_string()));
+    let km = KeyMaterial::new_from_password(Some("integration-test".to_string())).unwrap();
 
     let mut wallet = Wallet::init(
         &original_wallet,
@@ -231,15 +240,19 @@ fn setup_electrum(test_name: &str) -> ElectrumSetup {
 }
 
 #[test]
-fn plainwallet_plainbackup_plainrestore_electrum() {
-    info!("Running Test: Electrum-backed Wallet backup-restore");
+fn legacy_plain_backup_restores_into_encrypted_wallet_electrum() {
+    info!(
+        "Running Test: Electrum-backed legacy plaintext backup restores into an encrypted wallet"
+    );
 
-    let mut s = setup_electrum("plain_wallet_plainbackup_plain_restore_electrum");
+    let mut s = setup_electrum("legacy_plain_backup_restore_electrum");
+
+    let km = KeyMaterial::new_from_password(Some("integration-test".to_string())).unwrap();
 
     let mut wallet = Wallet::init(
         &s.original_wallet,
         AnyBlockchain::Electrum(Electrum::new(&s.electrum_cfg).unwrap()),
-        None,
+        km,
     )
     .unwrap();
 
@@ -247,7 +260,9 @@ fn plainwallet_plainbackup_plainrestore_electrum() {
     send_and_mine(&mut s.bitcoind, &addr, 0.05, 1).unwrap();
     wait_for_electrs_tip(&s.bitcoind, &s.electrsd, &s.electrum_cfg);
 
-    wallet.backup(&s.backup_file, None).unwrap();
+    // Simulate a legacy plaintext backup file; backups are always encrypted now.
+    let backup_json = serde_json::to_string_pretty(&WalletBackup::from(&wallet)).unwrap();
+    fs::write(&s.backup_file, backup_json).unwrap();
 
     let addr = wallet.get_next_external_address(AddressType::P2TR).unwrap();
     send_and_mine(&mut s.bitcoind, &addr, 0.05, 1).unwrap();
@@ -255,14 +270,19 @@ fn plainwallet_plainbackup_plainrestore_electrum() {
 
     wallet.sync_and_save(&openswap::utill::NO_SHUTDOWN).unwrap();
 
-    let (backup, _) =
+    let (backup, material) =
         load_sensitive_struct::<WalletBackup, SerdeJson>(&s.backup_file, None).unwrap();
+    assert!(material.is_none(), "legacy backup must be plaintext");
 
+    // Restore under a *different* passphrase: the restored wallet is encrypted
+    // with it, and wallet equality compares the underlying master keys.
+    let restore_km =
+        KeyMaterial::new_from_password(Some("restored-wallet-password".to_string())).unwrap();
     let restored_wallet = Wallet::restore(
         &backup,
         &s.restored_wallet,
         &BackendConfig::Electrum(s.electrum_cfg.clone()),
-        None,
+        restore_km,
     )
     .unwrap();
 
@@ -272,14 +292,14 @@ fn plainwallet_plainbackup_plainrestore_electrum() {
     drop(s.electrsd);
     cleanup(&mut s.bitcoind, &s.root_dir);
 
-    info!("🎉 Electrum wallet backup-restore test ran successfully!");
+    info!("🎉 Electrum legacy plaintext backup migration test ran successfully!");
 }
 
 #[test]
 fn encwallet_encbackup_encrestore_electrum() {
     let mut s = setup_electrum("encwallet_encbackup_encrestore_electrum");
 
-    let km = KeyMaterial::new_from_password(Some("integration-test".to_string()));
+    let km = KeyMaterial::new_from_password(Some("integration-test".to_string())).unwrap();
 
     let mut wallet = Wallet::init(
         &s.original_wallet,


### PR DESCRIPTION
## Summary

Updates the three CLI app docs (`docs/makerd.md`, `docs/maker-cli.md`, `docs/taker.md`) to match the current binaries (v0.2.2). All `--help` outputs were captured verbatim from freshly built binaries.

### makerd.md
- Replaced the `--help` output with the actual clap v4 output; documented new flags: `-z/--ZMQ`, `--electrum`, `--electrum-tor`, `-p/--PASSWORD`
- Corrected the default wallet name (`maker`, not `maker-wallet`)
- Updated default `config.toml`: removed obsolete `connection_type`, added `required_confirms`, updated fidelity defaults (`fidelity_amount` 10,000 sats, `fidelity_timelock` 15,000 blocks with the valid 12,960–25,920 range)
- Removed the stale "fidelity fee hardcoded at 1000 sats" note (fee now derives from `fidelity_feerate`)
- Documented `rpc_cookie` authentication and first-run port auto-discovery; refreshed startup/shutdown log examples

### maker-cli.md
- Replaced `--help` output; documented `-d/--data-directory` (used to read the RPC auth cookie) and the new `verify-deniability` subcommand
- `send-to-address` now takes `--feerate` (sats/vByte, default 2) instead of `--fee`, and returns a txid
- Updated `show-fidelity` JSON shape and made the tutorial balances internally consistent with the 10,000-sat default bond

### taker.md
- Replaced `--help` output; documented `-z/--ZMQ`, `--electrum`/`--electrum-tor`, `-p/--PASSWORD`
- The swap subcommand is `open-swap` (clap kebab-case); documented all its options (`--makers`, `--amount`, `--tx-count`, `--protocol legacy|taproot`, `--maker-address`, `--auto-select`, `--payment-address` PaySwap, `-y/--yes`) and the new prepare → summary → confirmation flow
- Updated `fetch-offers`/`list-offers` to the human-readable offer display; added `poll-maker`, `remove-maker`, `backup`, `restore`, `verify-deniability` sections
- Removed `connection_type` from the taker `config.toml`; added `offerbook.json` to the data-directory listing; trimmed the 90-line log dump to a short representative excerpt

## Note on base

This branch is stacked on `feat/encrypted-master-key-memory` (commit 6aa104b), because some documented behavior (`OPENSWAP_WALLET_PASSWORD`, mandatory wallet encryption) only exists there. This PR therefore includes that commit as well; merge the feature branch first, or review both together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wallets and backups are now encrypted by default, with required passphrases.
  - Legacy plaintext wallets and backups are migrated to encrypted formats.
  - Added secure wallet backup, restore, and deniability verification workflows.
  - Wallet passwords can be supplied through `OPENSWAP_WALLET_PASSWORD`.

- **Bug Fixes**
  - Improved protection of passwords, keys, and sensitive data in memory.
  - Wallet files are written atomically and reject unsupported cleartext formats.

- **Documentation**
  - Updated Maker, Taker, and wallet security documentation to reflect current commands, options, encryption behavior, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->