### PR TITLE
fix_ci

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Clippy (main codebase with all features)
         run: cargo +stable clippy --all-features --lib --bins --tests -- -D warnings
 
+      - name: Build examples
+        run: cargo +stable build --examples
+
       - name: Clippy (examples with default features only)
         run: cargo +stable clippy --examples -- -D warnings
 


### PR DESCRIPTION
## Summary
Adds example compilation to the lint CI workflow so example targets are built and linted alongside the main code. This prevents example regressions from being missed by CI.

## Related Issue
#1002 

## Testing
cargo +stable build --examples

## Checklist
- [*] Tests were added or updated where needed
- [*] Formatting and lints pass
- [ ] Documentation was updated where needed
- [ ] Security or protocol impact is explained above, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow to build Rust examples with the stable toolchain before running Clippy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->